### PR TITLE
store: add sqlite pool and initial migration for nullifier table

### DIFF
--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -18,11 +18,15 @@ doctest = false
 [dependencies]
 anyhow = { version = "1.0" }
 clap = { version = "4.3" , features = ["derive"] }
+deadpool-sqlite = { version = "0.5", features = ["rt_tokio_1"]}
 directories = { version = "5.0" }
 figment = { version = "0.10", features = ["toml", "env"] }
+miden-crypto = { version = "0.6.0" }
 miden-node-proto = { path = "../proto" }
 miden-node-utils = { path = "../utils" }
+once_cell = { version = "1.18.0" }
 prost = { version = "0.11" }
+rusqlite_migration = { version = "1.0" }
 serde = { version = "1.0" , features = ["derive"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
 toml = { version = "0.7" }

--- a/store/src/cli/cli.rs
+++ b/store/src/cli/cli.rs
@@ -9,6 +9,9 @@ pub struct Cli {
     #[arg(short, long, value_name = "FILE", default_value = config::CONFIG_FILENAME)]
     pub config: Option<PathBuf>,
 
+    #[arg(short, long, value_name = "SQLITE_FILE")]
+    pub sqlite: Option<PathBuf>,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/store/src/config.rs
+++ b/store/src/config.rs
@@ -1,4 +1,6 @@
+use once_cell::sync::Lazy;
 use std::fmt::Display;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -7,6 +9,14 @@ pub const HOST: &str = "localhost";
 pub const PORT: u16 = 28943;
 pub const ENV_PREFIX: &str = "MIDEN_STORE";
 pub const CONFIG_FILENAME: &str = "miden-store.toml";
+pub const STORE_FILENAME: &str = "miden-store.sqlite3";
+
+pub static DEFAULT_STORE_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    directories::ProjectDirs::from("", "Polygon", "Miden")
+        .map(|d| d.data_local_dir().join(STORE_FILENAME))
+        // fallback to current dir
+        .unwrap_or(PathBuf::new())
+});
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Endpoint {
@@ -16,10 +26,12 @@ pub struct Endpoint {
     pub port: u16,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct StoreConfig {
     /// Main endpoint of the server.
     pub endpoint: Endpoint,
+    /// SQLite database file
+    pub sqlite: PathBuf,
 }
 
 impl Default for Endpoint {
@@ -34,6 +46,15 @@ impl Default for Endpoint {
 impl Display for Endpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Endpoint::default(),
+            sqlite: DEFAULT_STORE_PATH.clone(),
+        }
     }
 }
 

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -1,0 +1,64 @@
+use crate::{config::StoreConfig, migrations, types::BlockNumber};
+use anyhow::anyhow;
+use deadpool_sqlite::{rusqlite::types::ValueRef, Config as SqliteConfig, Pool, Runtime};
+use miden_crypto::{
+    hash::rpo::RpoDigest,
+    utils::{Deserializable, SliceReader},
+};
+use std::fs::create_dir_all;
+use tracing::info;
+
+pub struct Db {
+    pool: Pool,
+}
+
+impl Db {
+    /// Open a connection to the DB and apply any pending migrations.
+    pub async fn get_conn(config: StoreConfig) -> Result<Self, anyhow::Error> {
+        if let Some(p) = config.sqlite.parent() {
+            create_dir_all(p)?;
+        }
+
+        let pool = SqliteConfig::new(config.sqlite.clone()).create_pool(Runtime::Tokio1)?;
+
+        let conn = pool.get().await?;
+
+        info!(
+            sqlite = format!("{}", config.sqlite.display()),
+            "Connected to the DB",
+        );
+
+        conn.interact(|conn| migrations::MIGRATIONS.to_latest(conn))
+            .await
+            .map_err(|_| anyhow!("Migration task failed with a panic"))??;
+
+        Ok(Db { pool })
+    }
+
+    pub async fn get_nullifiers(&mut self) -> Result<Vec<(RpoDigest, BlockNumber)>, anyhow::Error> {
+        self.pool
+            .get()
+            .await?
+            .interact(|conn| {
+                let mut stmt = conn.prepare("SELECT nullifier, block_number FROM nullifiers;")?;
+                let mut rows = stmt.query([])?;
+                let mut result = vec![];
+                while let Some(row) = rows.next()? {
+                    let nullifier = match row.get_ref_unwrap(0) {
+                        ValueRef::Blob(data) => {
+                            let mut reader = SliceReader::new(data);
+                            RpoDigest::read_from(&mut reader)
+                                .map_err(|_| anyhow!("Decoding nullifier from DB failed"))?
+                        }
+                        _ => unreachable!(),
+                    };
+                    let block_number = row.get(1)?;
+                    result.push((nullifier, block_number));
+                }
+
+                Ok(result)
+            })
+            .await
+            .map_err(|_| anyhow!("Get nullifiers task failed with a panic"))?
+    }
+}

--- a/store/src/migrations.rs
+++ b/store/src/migrations.rs
@@ -1,0 +1,13 @@
+use once_cell::sync::Lazy;
+use rusqlite_migration::{Migrations, M};
+
+pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
+    Migrations::new(vec![M::up(
+        "CREATE TABLE nullifiers (id INTEGER PRIMARY KEY, nullifier BLOB, block_number INTEGER);",
+    )])
+});
+
+#[test]
+fn migrations_test() {
+    assert!(MIGRATIONS.validate().is_ok());
+}

--- a/store/src/server/api.rs
+++ b/store/src/server/api.rs
@@ -1,39 +1,65 @@
-use std::net::ToSocketAddrs;
-use tracing::info;
-use anyhow::Result;
-
 use crate::config::StoreConfig;
-use tonic::{transport::Server, Response, Status, Streaming};
-
+use crate::db::Db;
+use anyhow::Result;
+use miden_crypto::{merkle::TieredSmt, Felt, FieldElement};
 use miden_node_proto::store;
+use std::net::ToSocketAddrs;
+use tokio::time::Instant;
+use tonic::{transport::Server, Response, Status, Streaming};
+use tracing::{info, instrument};
 
-#[derive(Default)]
-pub struct DBApi {}
+pub struct StoreApi {
+    db: Db,
+    nullifier_tree: TieredSmt,
+}
 
 #[tonic::async_trait]
-impl store::api_server::Api for DBApi {
+impl store::api_server::Api for StoreApi {
     type CheckNullifiersStream = Streaming<store::CheckNullifiersResponse>;
 
     async fn check_nullifiers(
         &self,
         _request: tonic::Request<Streaming<store::CheckNullifiersRequest>>,
-    ) -> Result<Response<Self::CheckNullifiersStream>, Status>
-    {
+    ) -> Result<Response<Self::CheckNullifiersStream>, Status> {
         todo!()
     }
 }
 
-pub async fn serve(config: StoreConfig) -> Result<()> {
+#[instrument(skip(db))]
+async fn load_nullifier_tree(db: &mut Db) -> Result<TieredSmt> {
+    let nullifiers = db.get_nullifiers().await?;
+    let len = nullifiers.len();
+    let leaves = nullifiers.into_iter().map(|(nullifier, block)| {
+        (
+            nullifier,
+            [Felt::new(block), Felt::ZERO, Felt::ZERO, Felt::ZERO],
+        )
+    });
+
+    let now = Instant::now();
+    let nullifier_tree = TieredSmt::with_leaves(leaves)?;
+    let elapsed = now.elapsed().as_secs();
+
+    info!(
+        num_of_leaves = len,
+        tree_construction = elapsed,
+        "Loaded nullifier tree"
+    );
+    Ok(nullifier_tree)
+}
+
+pub async fn serve(config: StoreConfig, mut db: Db) -> Result<()> {
     let host_port = (config.endpoint.host.as_ref(), config.endpoint.port);
     let addrs: Vec<_> = host_port.to_socket_addrs()?.collect();
+
+    let nullifier_tree = load_nullifier_tree(&mut db).await?;
+    let db = store::api_server::ApiServer::new(StoreApi { db, nullifier_tree });
 
     info!(
         host = config.endpoint.host,
         port = config.endpoint.port,
         "Server initialized",
     );
-
-    let db = store::api_server::ApiServer::new(DBApi::default());
     Server::builder().add_service(db).serve(addrs[0]).await?;
 
     Ok(())

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -1,0 +1,1 @@
+pub type BlockNumber = u64;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-figment = { version = "0.10", features = ["toml", "env"] }
+anyhow = { version = "1.0" }
 directories = { version = "5.0" }
+figment = { version = "0.10", features = ["toml", "env"] }
+serde = { version = "1.0" , features = ["derive"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" , features = ["fmt"] }
-anyhow = { version = "1.0" }
-serde = { version = "1.0" , features = ["derive"] }


### PR DESCRIPTION
A few important notes:

- Error handling:
  - The code is using `anyhow` as the top-level error. This is because the error messages produced by that library are more informative than the default `main() -> std::Result<>`
  - However, `anyhow` requires the wrapped errors to implement `std::error::Error`. Which is an issue in our code and third party libraries
  - Also, `anyhow` requires the `Sync` and `Send` marker traits, which was an issue with `deadpool`
  - To circumvent the above for the time being, errors are translated using the `anyhow!` macro. In addition to that, I think we should implement `std::error::Error` on all of our error types.
- This PR introduces an async trait to abstract interactions with the underlying database. This is because eventually we may want to move away form sqlite to something else, and it is best to reduce the surface area for such a change.
  - The code uses an async trait, even though that is not natively supported. This change uses the same `async_trait` that is used by `tonic`
  - The choice of an async trait instead of a normal trait was done because it is the most general of the two, and this allows for the use of both types of databases in the future with minimal changes.
- this adds migrations to the sqlite, the migrations are statics using `once_cell` instead of `lazy_init` or `std::once_cell`. I'm using `once_cell` because that doesn't rely on a macro and results in better errro messages. I'm not using the `std` version because the `once_cell` has simpler code with the lazy callback.
- next steps:
  - the streaming code to read the nullifier data is a bit complicated, to handle connection dropping, so that would probably be best implemented on a separate PR
  - I'm planning on adding some CLI utilities to wrap the sqlite database and the gRPC clients, to make it somewhat easy to test from the command line