### PR TITLE
store: fix binary name

### DIFF
--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.67"
 
 [[bin]]
-name = "miden-store"
+name = "miden-node-store"
 path = "src/main.rs"
 bench = false
 doctest = false


### PR DESCRIPTION
As the PR title says, the name should have been `miden-node-store` and not `miden-store` to match the packages name.