### PR TITLE
store: fetch block header by number endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ members = [
     "utils",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false, features = ["std"] }
+miden_objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main", default-features = false }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,15 +11,15 @@ rust-version = "1.67"
 
 [dependencies]
 hex = { version = "0.4" }
-miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
-prost = { version = "0.11" }
-tonic = { version = "0.9" }
+miden-crypto = { workspace = true }
+prost = { version = "0.12" }
+tonic = { version = "0.10" }
 
 [dev-dependencies]
 proptest = { version = "1.2" }
 
 [build-dependencies]
 miette = { version = "5.9", features = ["fancy"] }
-prost = { version = "0.11" }
-protox = { version = "0.4" }
-tonic-build = { version = "0.9" }
+prost = { version = "0.12" }
+protox = { version = "0.5" }
+tonic-build = { version = "0.10" }

--- a/proto/proto/block_header.proto
+++ b/proto/proto/block_header.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+package block_header;
+
+import "digest.proto";
+
+message BlockHeader {
+    /// the hash of the previous blocks header.
+    digest.Digest prev_hash = 1;
+    /// a unique sequential number of the current block.
+    uint32 block_num = 2;
+    /// a commitment to an MMR of the entire chain where each block is a leaf.
+    digest.Digest chain_root = 3;
+    /// a commitment to account database.
+    digest.Digest account_root = 4;
+    /// a commitment to the nullifier database.
+    digest.Digest nullifier_root = 5;
+    /// a commitment to all notes created in the current block.
+    digest.Digest note_root = 6;
+    /// a commitment to a set of transaction batches executed as a part of this block.
+    digest.Digest batch_root = 7;
+    /// a hash of a STARK proof attesting to the correct state transition.
+    digest.Digest proof_hash = 8;
+    /// specifies the version of the protocol.
+    uint32 version = 9;
+    /// the time when the block was created.
+    uint64 timestamp = 10;
+}

--- a/proto/proto/rpc.proto
+++ b/proto/proto/rpc.proto
@@ -2,6 +2,7 @@
 syntax = "proto3";
 package rpc;
 
+import "block_header.proto";
 import "digest.proto";
 import "tsmt.proto";
 
@@ -15,6 +16,18 @@ message CheckNullifiersResponse {
     repeated tsmt.NullifierProof proofs = 1;
 }
 
+message FetchBlockHeaderByNumberRequest {
+    // The block number of the target block.
+    //
+    // If not provided, means latest know block.
+    optional uint64 block_num = 1;
+}
+
+message FetchBlockHeaderByNumberResponse {
+    block_header.BlockHeader block_header = 1;
+}
+
 service Api {
     rpc CheckNullifiers(CheckNullifiersRequest) returns (CheckNullifiersResponse) {}
+    rpc FetchBlockHeaderByNumber(FetchBlockHeaderByNumberRequest) returns (FetchBlockHeaderByNumberResponse) {}
 }

--- a/proto/proto/store.proto
+++ b/proto/proto/store.proto
@@ -4,6 +4,7 @@
 syntax = "proto3";
 package store;
 
+import "block_header.proto";
 import "digest.proto";
 import "tsmt.proto";
 
@@ -17,6 +18,18 @@ message CheckNullifiersResponse {
     repeated tsmt.NullifierProof proofs = 1;
 }
 
+message FetchBlockHeaderByNumberRequest {
+    // The block number of the target block.
+    //
+    // If not provided, means latest know block.
+    optional uint64 block_num = 1;
+}
+
+message FetchBlockHeaderByNumberResponse {
+    block_header.BlockHeader block_header = 1;
+}
+
 service Api {
     rpc CheckNullifiers(CheckNullifiersRequest) returns (CheckNullifiersResponse) {}
+    rpc FetchBlockHeaderByNumber(FetchBlockHeaderByNumberRequest) returns (FetchBlockHeaderByNumberResponse) {}
 }

--- a/proto/src/generated/block_header.rs
+++ b/proto/src/generated/block_header.rs
@@ -1,0 +1,35 @@
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockHeader {
+    /// / the hash of the previous blocks header.
+    #[prost(message, optional, tag = "1")]
+    pub prev_hash: ::core::option::Option<super::digest::Digest>,
+    /// / a unique sequential number of the current block.
+    #[prost(uint32, tag = "2")]
+    pub block_num: u32,
+    /// / a commitment to an MMR of the entire chain where each block is a leaf.
+    #[prost(message, optional, tag = "3")]
+    pub chain_root: ::core::option::Option<super::digest::Digest>,
+    /// / a commitment to account database.
+    #[prost(message, optional, tag = "4")]
+    pub account_root: ::core::option::Option<super::digest::Digest>,
+    /// / a commitment to the nullifier database.
+    #[prost(message, optional, tag = "5")]
+    pub nullifier_root: ::core::option::Option<super::digest::Digest>,
+    /// / a commitment to all notes created in the current block.
+    #[prost(message, optional, tag = "6")]
+    pub note_root: ::core::option::Option<super::digest::Digest>,
+    /// / a commitment to a set of transaction batches executed as a part of this block.
+    #[prost(message, optional, tag = "7")]
+    pub batch_root: ::core::option::Option<super::digest::Digest>,
+    /// / a hash of a STARK proof attesting to the correct state transition.
+    #[prost(message, optional, tag = "8")]
+    pub proof_hash: ::core::option::Option<super::digest::Digest>,
+    /// / specifies the version of the protocol.
+    #[prost(uint32, tag = "9")]
+    pub version: u32,
+    /// / the time when the block was created.
+    #[prost(uint64, tag = "10")]
+    pub timestamp: u64,
+}

--- a/proto/src/generated/mod.rs
+++ b/proto/src/generated/mod.rs
@@ -1,3 +1,4 @@
+pub mod block_header;
 pub mod digest;
 pub mod rpc;
 pub mod store;

--- a/proto/src/generated/rpc.rs
+++ b/proto/src/generated/rpc.rs
@@ -14,6 +14,23 @@ pub struct CheckNullifiersResponse {
     #[prost(message, repeated, tag = "1")]
     pub proofs: ::prost::alloc::vec::Vec<super::tsmt::NullifierProof>,
 }
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchBlockHeaderByNumberRequest {
+    /// The block number of the target block.
+    ///
+    /// If not provided, means latest know block.
+    #[prost(uint64, optional, tag = "1")]
+    pub block_num: ::core::option::Option<u64>,
+}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchBlockHeaderByNumberResponse {
+    #[prost(message, optional, tag = "1")]
+    pub block_header: ::core::option::Option<super::block_header::BlockHeader>,
+}
 /// Generated client implementations.
 pub mod api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -121,6 +138,31 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "CheckNullifiers"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn fetch_block_header_by_number(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FetchBlockHeaderByNumberRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FetchBlockHeaderByNumberResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rpc.Api/FetchBlockHeaderByNumber",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rpc.Api", "FetchBlockHeaderByNumber"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -135,6 +177,13 @@ pub mod api_server {
             request: tonic::Request<super::CheckNullifiersRequest>,
         ) -> std::result::Result<
             tonic::Response<super::CheckNullifiersResponse>,
+            tonic::Status,
+        >;
+        async fn fetch_block_header_by_number(
+            &self,
+            request: tonic::Request<super::FetchBlockHeaderByNumberRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FetchBlockHeaderByNumberResponse>,
             tonic::Status,
         >;
     }
@@ -235,7 +284,7 @@ pub mod api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).check_nullifiers(request).await
+                                <T as Api>::check_nullifiers(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -248,6 +297,55 @@ pub mod api_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = CheckNullifiersSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rpc.Api/FetchBlockHeaderByNumber" => {
+                    #[allow(non_camel_case_types)]
+                    struct FetchBlockHeaderByNumberSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<super::FetchBlockHeaderByNumberRequest>
+                    for FetchBlockHeaderByNumberSvc<T> {
+                        type Response = super::FetchBlockHeaderByNumberResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::FetchBlockHeaderByNumberRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::fetch_block_header_by_number(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FetchBlockHeaderByNumberSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/generated/store.rs
+++ b/proto/src/generated/store.rs
@@ -14,6 +14,23 @@ pub struct CheckNullifiersResponse {
     #[prost(message, repeated, tag = "1")]
     pub proofs: ::prost::alloc::vec::Vec<super::tsmt::NullifierProof>,
 }
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchBlockHeaderByNumberRequest {
+    /// The block number of the target block.
+    ///
+    /// If not provided, means latest know block.
+    #[prost(uint64, optional, tag = "1")]
+    pub block_num: ::core::option::Option<u64>,
+}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchBlockHeaderByNumberResponse {
+    #[prost(message, optional, tag = "1")]
+    pub block_header: ::core::option::Option<super::block_header::BlockHeader>,
+}
 /// Generated client implementations.
 pub mod api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -123,6 +140,31 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("store.Api", "CheckNullifiers"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn fetch_block_header_by_number(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FetchBlockHeaderByNumberRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FetchBlockHeaderByNumberResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/FetchBlockHeaderByNumber",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("store.Api", "FetchBlockHeaderByNumber"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -137,6 +179,13 @@ pub mod api_server {
             request: tonic::Request<super::CheckNullifiersRequest>,
         ) -> std::result::Result<
             tonic::Response<super::CheckNullifiersResponse>,
+            tonic::Status,
+        >;
+        async fn fetch_block_header_by_number(
+            &self,
+            request: tonic::Request<super::FetchBlockHeaderByNumberRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FetchBlockHeaderByNumberResponse>,
             tonic::Status,
         >;
     }
@@ -237,7 +286,7 @@ pub mod api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).check_nullifiers(request).await
+                                <T as Api>::check_nullifiers(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -250,6 +299,55 @@ pub mod api_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = CheckNullifiersSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/store.Api/FetchBlockHeaderByNumber" => {
+                    #[allow(non_camel_case_types)]
+                    struct FetchBlockHeaderByNumberSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<super::FetchBlockHeaderByNumberRequest>
+                    for FetchBlockHeaderByNumberSvc<T> {
+                        type Response = super::FetchBlockHeaderByNumberResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::FetchBlockHeaderByNumberRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::fetch_block_header_by_number(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FetchBlockHeaderByNumberSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -5,6 +5,7 @@ pub mod hex;
 
 // RE-EXPORTS
 // ------------------------------------------------------------------------------------------------
+pub use generated::block_header;
 pub use generated::digest;
 pub use generated::rpc;
 pub use generated::store;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -15,20 +15,20 @@ clap = { version = "4.3" , features = ["derive"] }
 directories = { version = "5.0" }
 figment = { version = "0.10", features = ["toml", "env"] }
 hex = { version = "0.4" }
-miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
+miden-crypto = { workspace = true }
 miden-node-proto = { path = "../proto" }
 miden-node-store = { path = "../store" }
 miden-node-utils = { path = "../utils" }
-prost = { version = "0.11" }
+prost = { version = "0.12" }
 serde = { version = "1.0" , features = ["derive"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
-toml = { version = "0.7" }
-tonic = { version = "0.9" }
+toml = { version = "0.8" }
+tonic = { version = "0.10" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" , features = ["fmt"] }
 
 [build-dependencies]
 miette = { version = "5.9", features = ["fancy"] }
-prost = { version = "0.11" }
-protox = { version = "0.4" }
-tonic-build = { version = "0.9" }
+prost = { version = "0.12" }
+protox = { version = "0.5" }
+tonic-build = { version = "0.10" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -18,24 +18,25 @@ doctest = false
 [dependencies]
 anyhow = { version = "1.0" }
 clap = { version = "4.3" , features = ["derive"] }
-deadpool-sqlite = { version = "0.5", features = ["rt_tokio_1"]}
+deadpool-sqlite = { version = "0.6", features = ["rt_tokio_1"]}
 directories = { version = "5.0" }
 figment = { version = "0.10", features = ["toml", "env"] }
-miden-crypto = { git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
+miden-crypto = { workspace = true }
 miden-node-proto = { path = "../proto" }
 miden-node-utils = { path = "../utils" }
+miden_objects = { workspace = true }
 once_cell = { version = "1.18.0" }
-prost = { version = "0.11" }
+prost = { version = "0.12" }
 rusqlite_migration = { version = "1.0" }
 serde = { version = "1.0" , features = ["derive"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
-toml = { version = "0.7" }
-tonic = { version = "0.9" }
+toml = { version = "0.8" }
+tonic = { version = "0.10" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" , features = ["fmt"] }
 
 [build-dependencies]
 miette = { version = "5.9", features = ["fancy"] }
-prost = { version = "0.11" }
-protox = { version = "0.4" }
-tonic-build = { version = "0.9" }
+prost = { version = "0.12" }
+protox = { version = "0.5" }
+tonic-build = { version = "0.10" }

--- a/store/src/migrations.rs
+++ b/store/src/migrations.rs
@@ -3,7 +3,29 @@ use rusqlite_migration::{Migrations, M};
 
 pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
     Migrations::new(vec![M::up(
-        "CREATE TABLE nullifiers (id INTEGER PRIMARY KEY, nullifier BLOB, block_number INTEGER);",
+        "
+        CREATE TABLE
+            block_header
+        (
+            block_num INTEGER NOT NULL,
+            block_header BLOB NOT NULL,
+
+            PRIMARY KEY (block_num),
+            CONSTRAINT block_header_block_num_positive CHECK (block_num >= 0)
+        ) STRICT, WITHOUT ROWID;
+
+        CREATE TABLE
+            nullifiers
+        (
+            nullifier BLOB NOT NULL,
+            block_number INTEGER NOT NULL,
+
+            PRIMARY KEY (nullifier),
+            CONSTRAINT nullifiers_nullifier_valid_digest CHECK (length(nullifier) = 32),
+            CONSTRAINT nullifiers_block_number_positive CHECK (block_number >= 0),
+            FOREIGN KEY (block_number) REFERENCES block_header (block_num)
+        ) STRICT, WITHOUT ROWID;
+        ",
     )])
 });
 


### PR DESCRIPTION
issue: #20

Adds protobuf message to retrieve a block header by number.

Assumptions:
- A user learns about a block's hash by fetching the block header. So it doesn't make sense to have a fetch block header by block hash.
- A user is not really interested in the changes in the block header, but in the state represented by it. So it doesn't make sense to support fetch for a range of block numbers.
    - Instead we should have endpoints that return the historical for on-chain accounts' storage items. This will perform better since it scales by the number of changes to the smart contract, and not by the number of blocks.
- A user doesn't want to download the complete state that is commited to by a block. So it doesn't make sense to reply with data beyond the block header
    - Instead we should have additional endpoints to perform partial state download. Ideally these endpoints would also support `block_number`s as a request parameter so the user only needs to perform a single round trip.
    - This is not talking about other nodes in the network.