### PR TITLE
Implement transaction queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "proto",
     "rpc",
     "store",
+    "tx_pipeline",
     "utils",
 ]
 resolver = "2"

--- a/tx_pipeline/Cargo.toml
+++ b/tx_pipeline/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "miden-tx-pipeline"
+version = "0.1.0"
+authors = ["miden contributors"]
+readme = "README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/miden-node"
+keywords = ["miden", "node", "program", "store"]
+edition = "2021"
+rust-version = "1.67"
+
+[dev-dependencies]
+miden-air = { package = "miden-air", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main", default-features = false }
+winterfell = "0.6"
+
+[dependencies]
+async-trait = "0.1"
+miden_objects = { workspace = true }
+tokio = { version = "1.29", features = ["rt-multi-thread", "macros", "time"] }

--- a/tx_pipeline/Cargo.toml
+++ b/tx_pipeline/Cargo.toml
@@ -17,5 +17,9 @@ winterfell = "0.6"
 [dependencies]
 async-trait = "0.1"
 miden_objects = { workspace = true }
-tokio = { version = "1.29", features = ["rt-multi-thread", "macros", "time"] }
-concurrent-queue = "2.3"
+tokio = { version = "1.29", features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }

--- a/tx_pipeline/Cargo.toml
+++ b/tx_pipeline/Cargo.toml
@@ -18,3 +18,4 @@ winterfell = "0.6"
 async-trait = "0.1"
 miden_objects = { workspace = true }
 tokio = { version = "1.29", features = ["rt-multi-thread", "macros", "time"] }
+concurrent-queue = "2.3"

--- a/tx_pipeline/src/lib.rs
+++ b/tx_pipeline/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+pub mod test_utils;

--- a/tx_pipeline/src/lib.rs
+++ b/tx_pipeline/src/lib.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
 pub mod test_utils;
+
+pub mod tasks;

--- a/tx_pipeline/src/tasks/mod.rs
+++ b/tx_pipeline/src/tasks/mod.rs
@@ -1,0 +1,1 @@
+pub mod txqueue;

--- a/tx_pipeline/src/tasks/txqueue/mod.rs
+++ b/tx_pipeline/src/tasks/txqueue/mod.rs
@@ -27,14 +27,19 @@ pub trait TxQueueHandleOut {
     ) -> Result<(), Self::ProduceBatchError>;
 }
 
+pub struct TxQueueOptions {
+    pub batch_size: usize,
+}
+
 pub async fn tx_queue<HandleIn, HandleOut>(
     handle_in: HandleIn,
     handle_out: HandleOut,
+    options: TxQueueOptions,
 ) where
     HandleIn: TxQueueHandleIn,
     HandleOut: TxQueueHandleOut,
 {
-    let mut queue_task = TxQueue::new(handle_in, handle_out);
+    let mut queue_task = TxQueue::new(handle_in, handle_out, options);
     queue_task.run().await
 }
 
@@ -46,6 +51,7 @@ where
     queue: ConcurrentQueue<Arc<ProvenTransaction>>,
     handle_in: HandleIn,
     handle_out: HandleOut,
+    options: TxQueueOptions,
 }
 
 impl<HandleIn, HandleOut> TxQueue<HandleIn, HandleOut>
@@ -56,11 +62,13 @@ where
     pub fn new(
         handle_in: HandleIn,
         handle_out: HandleOut,
+        options: TxQueueOptions,
     ) -> Self {
         Self {
             queue: ConcurrentQueue::unbounded(),
             handle_in,
             handle_out,
+            options,
         }
     }
 

--- a/tx_pipeline/src/tasks/txqueue/mod.rs
+++ b/tx_pipeline/src/tasks/txqueue/mod.rs
@@ -1,0 +1,70 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use async_trait::async_trait;
+use concurrent_queue::ConcurrentQueue;
+use miden_objects::transaction::ProvenTransaction;
+
+#[async_trait]
+pub trait TxQueueHandleIn {
+    type ReadTxError;
+
+    async fn read_transaction(&mut self) -> Result<ProvenTransaction, Self::ReadTxError>;
+}
+
+#[async_trait]
+pub trait TxQueueHandleOut {
+    type VerifyTxError;
+    type ProduceBatchError;
+
+    async fn verify_transaction(
+        &self,
+        tx: Arc<ProvenTransaction>,
+    ) -> Result<(), Self::VerifyTxError>;
+
+    async fn produce_batch(
+        &self,
+        txs: Vec<ProvenTransaction>,
+    ) -> Result<(), Self::ProduceBatchError>;
+}
+
+pub async fn tx_queue<HandleIn, HandleOut>(
+    handle_in: HandleIn,
+    handle_out: HandleOut,
+) where
+    HandleIn: TxQueueHandleIn,
+    HandleOut: TxQueueHandleOut,
+{
+    let mut queue_task = TxQueue::new(handle_in, handle_out);
+    queue_task.run().await
+}
+
+struct TxQueue<HandleIn, HandleOut>
+where
+    HandleIn: TxQueueHandleIn,
+    HandleOut: TxQueueHandleOut,
+{
+    queue: ConcurrentQueue<Arc<ProvenTransaction>>,
+    handle_in: HandleIn,
+    handle_out: HandleOut,
+}
+
+impl<HandleIn, HandleOut> TxQueue<HandleIn, HandleOut>
+where
+    HandleIn: TxQueueHandleIn,
+    HandleOut: TxQueueHandleOut,
+{
+    pub fn new(
+        handle_in: HandleIn,
+        handle_out: HandleOut,
+    ) -> Self {
+        Self {
+            queue: ConcurrentQueue::unbounded(),
+            handle_in,
+            handle_out,
+        }
+    }
+
+    pub async fn run(&mut self) {
+        todo!()
+    }
+}

--- a/tx_pipeline/src/test_utils/mod.rs
+++ b/tx_pipeline/src/test_utils/mod.rs
@@ -1,0 +1,136 @@
+///! FibSmall taken from the `fib_small` example in `winterfell`
+use winterfell::{
+    crypto::{hashers::Blake3_192, DefaultRandomCoin},
+    math::fields::f64::BaseElement,
+    math::FieldElement,
+    Air, AirContext, Assertion, EvaluationFrame, FieldExtension, ProofOptions, Prover, StarkProof,
+    Trace, TraceInfo, TraceTable, TransitionConstraintDegree,
+};
+
+const TRACE_WIDTH: usize = 2;
+
+pub fn are_equal<E: FieldElement>(
+    a: E,
+    b: E,
+) -> E {
+    a - b
+}
+
+pub struct FibSmall {
+    context: AirContext<BaseElement>,
+    result: BaseElement,
+}
+
+impl Air for FibSmall {
+    type BaseField = BaseElement;
+    type PublicInputs = BaseElement;
+
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    fn new(
+        trace_info: TraceInfo,
+        pub_inputs: Self::BaseField,
+        options: ProofOptions,
+    ) -> Self {
+        let degrees = vec![TransitionConstraintDegree::new(1), TransitionConstraintDegree::new(1)];
+        assert_eq!(TRACE_WIDTH, trace_info.width());
+        FibSmall {
+            context: AirContext::new(trace_info, degrees, 3, options),
+            result: pub_inputs,
+        }
+    }
+
+    fn context(&self) -> &AirContext<Self::BaseField> {
+        &self.context
+    }
+
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
+        &self,
+        frame: &EvaluationFrame<E>,
+        _periodic_values: &[E],
+        result: &mut [E],
+    ) {
+        let current = frame.current();
+        let next = frame.next();
+        // expected state width is 2 field elements
+        debug_assert_eq!(TRACE_WIDTH, current.len());
+        debug_assert_eq!(TRACE_WIDTH, next.len());
+
+        // constraints of Fibonacci sequence (2 terms per step):
+        // s_{0, i+1} = s_{0, i} + s_{1, i}
+        // s_{1, i+1} = s_{1, i} + s_{0, i+1}
+        result[0] = are_equal(next[0], current[0] + current[1]);
+        result[1] = are_equal(next[1], current[1] + next[0]);
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
+        // a valid Fibonacci sequence should start with two ones and terminate with
+        // the expected result
+        let last_step = self.trace_length() - 1;
+        vec![
+            Assertion::single(0, 0, Self::BaseField::ONE),
+            Assertion::single(1, 0, Self::BaseField::ONE),
+            Assertion::single(1, last_step, self.result),
+        ]
+    }
+}
+
+pub struct DummyProver {
+    options: ProofOptions,
+}
+
+impl DummyProver {
+    pub fn new() -> Self {
+        Self {
+            options: ProofOptions::new(1, 2, 1, FieldExtension::None, 2, 127),
+        }
+    }
+
+    /// Builds an execution trace for computing a Fibonacci sequence of the specified length such
+    /// that each row advances the sequence by 2 terms.
+    pub fn build_trace(
+        &self,
+        sequence_length: usize,
+    ) -> TraceTable<BaseElement> {
+        assert!(sequence_length.is_power_of_two(), "sequence length must be a power of 2");
+
+        let mut trace = TraceTable::new(TRACE_WIDTH, sequence_length / 2);
+        trace.fill(
+            |state| {
+                state[0] = BaseElement::ONE;
+                state[1] = BaseElement::ONE;
+            },
+            |_, state| {
+                state[0] += state[1];
+                state[1] += state[0];
+            },
+        );
+
+        trace
+    }
+}
+
+impl Prover for DummyProver {
+    type BaseField = BaseElement;
+    type Air = FibSmall;
+    type Trace = TraceTable<BaseElement>;
+    type HashFn = Blake3_192<BaseElement>;
+    type RandomCoin = DefaultRandomCoin<Self::HashFn>;
+
+    fn get_pub_inputs(
+        &self,
+        trace: &Self::Trace,
+    ) -> BaseElement {
+        let last_step = trace.length() - 1;
+        trace.get(1, last_step)
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}
+
+pub fn dummy_stark_proof() -> StarkProof {
+    let prover = DummyProver::new();
+    prover.prove(prover.build_trace(16)).unwrap()
+}


### PR DESCRIPTION
Closes: #40

Builds on #39.

Left to do:
+ [ ] clean up code (and adhere to coding guidelines)
+ [ ] write tests
+ [ ] document current transaction queue requirements
+ [ ] write docstrings