### PR TITLE
Fix race

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,4 +1,4 @@
-mod conversion;
+pub mod conversion;
 pub mod error;
 mod generated;
 pub mod hex;

--- a/store/src/db/mod.rs
+++ b/store/src/db/mod.rs
@@ -109,11 +109,11 @@ impl Db {
         block_num: BlockNumber,
         account_ids: &[AccountId],
         note_tag_prefixes: &[u32],
-        nullifiers_prefix: &[u32],
+        nullifier_prefixes: &[u32],
     ) -> Result<StateSyncUpdate, anyhow::Error> {
         let account_ids = account_ids.to_vec();
         let note_tag_prefixes = note_tag_prefixes.to_vec();
-        let nullifiers_prefix = nullifiers_prefix.to_vec();
+        let nullifier_prefixes = nullifier_prefixes.to_vec();
 
         self.pool
             .get()
@@ -124,7 +124,7 @@ impl Db {
                     block_num,
                     &account_ids,
                     &note_tag_prefixes,
-                    &nullifiers_prefix,
+                    &nullifier_prefixes,
                 )
             })
             .await

--- a/store/src/db/mod.rs
+++ b/store/src/db/mod.rs
@@ -5,22 +5,18 @@ use crate::{
 };
 use anyhow::anyhow;
 use deadpool_sqlite::{Config as SqliteConfig, Pool, Runtime};
-use miden_crypto::{
-    hash::rpo::RpoDigest,
-    utils::{Deserializable, SliceReader},
-};
+use miden_crypto::hash::rpo::RpoDigest;
 use miden_node_proto::{
-    account_id,
     block_header::BlockHeader,
     digest::Digest,
-    merkle::MerklePath,
     note::Note,
     responses::{AccountHashUpdate, NullifierUpdate},
 };
-use prost::Message;
-use rusqlite::{params, types::Value, vtab::array};
-use std::{fs::create_dir_all, rc::Rc};
+use rusqlite::vtab::array;
+use std::fs::create_dir_all;
 use tracing::info;
+
+mod sql;
 
 #[cfg(test)]
 mod tests;
@@ -63,125 +59,14 @@ impl Db {
         Ok(Db { pool })
     }
 
-    /// Inserts a new nullifier to the DB.
-    ///
-    /// This method may be called multiple times with the same nullifier.
-    #[cfg(test)]
-    pub async fn add_nullifier(
-        &self,
-        nullifier: RpoDigest,
-        block_number: BlockNumber,
-    ) -> Result<usize, anyhow::Error> {
-        use miden_crypto::StarkField;
-
-        let num_rows = self
-            .pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let mut stmt = conn
-                    .prepare("INSERT INTO nullifiers (nullifier, nullifier_prefix, block_number) VALUES (?1, ?2, ?3);")?;
-                stmt.execute(params![nullifier.as_bytes(), u64_to_prefix(nullifier[0].as_int()), block_number])
-            })
-            .await
-            .map_err(|_| anyhow!("Add nullifier task failed with a panic"))??;
-
-        Ok(num_rows)
-    }
-
     /// Loads all the nullifiers from the DB.
     pub async fn get_nullifiers(&self) -> Result<Vec<(RpoDigest, BlockNumber)>, anyhow::Error> {
         self.pool
             .get()
             .await?
-            .interact(|conn| {
-                let mut stmt = conn.prepare("SELECT nullifier, block_number FROM nullifiers;")?;
-                let mut rows = stmt.query([])?;
-                let mut result = vec![];
-                while let Some(row) = rows.next()? {
-                    let nullifier_data = row.get_ref(0)?.as_blob()?;
-                    let nullifier = decode_rpo_digest(nullifier_data)?;
-                    let block_number = row.get(1)?;
-                    result.push((nullifier, block_number));
-                }
-
-                Ok(result)
-            })
+            .interact(sql::get_nullifiers)
             .await
             .map_err(|_| anyhow!("Get nullifiers task failed with a panic"))?
-    }
-
-    /// Returns nullifiers created in the `(block_start, block_end]` range which also match the
-    /// `nullifiers` filter.
-    ///
-    /// Each value of the `nullifiers` is only the 16 most significat bits of the nullifier of
-    /// interest to the client. This hides the details of the specific nullifier being requested.
-    pub async fn get_nullifiers_by_block_range(
-        &self,
-        block_start: BlockNumber,
-        block_end: BlockNumber,
-        nullifiers: &[u32],
-    ) -> Result<Vec<NullifierUpdate>, anyhow::Error> {
-        let nullifiers: Vec<_> = nullifiers.iter().copied().map(u32_to_value).collect();
-
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let mut stmt = conn.prepare(
-                    "
-                        SELECT
-                            nullifier,
-                            block_number
-                        FROM
-                            nullifiers
-                        WHERE
-                            block_number > ?1 AND
-                            block_number <= ?2 AND
-                            nullifier_prefix IN rarray(?3)
-                    ",
-                )?;
-
-                let mut rows = stmt.query(params![block_start, block_end, Rc::new(nullifiers)])?;
-
-                let mut result = Vec::new();
-                while let Some(row) = rows.next()? {
-                    let nullifier_data = row.get_ref(0)?.as_blob()?;
-                    let nullifier: Digest = decode_rpo_digest(nullifier_data)?.into();
-                    let block_num = row.get(1)?;
-
-                    result.push(NullifierUpdate {
-                        nullifier: Some(nullifier),
-                        block_num,
-                    });
-                }
-
-                Ok(result)
-            })
-            .await
-            .map_err(|_| anyhow!("Get nullifiers by block number task failed with a panic"))?
-    }
-
-    /// Save a [BlockHeader] to the DB.
-    #[cfg(test)]
-    pub async fn add_block_header(
-        &self,
-        block_header: BlockHeader,
-    ) -> Result<usize, anyhow::Error> {
-        let num_rows = self
-            .pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let mut stmt = conn.prepare(
-                    "INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);",
-                )?;
-                stmt.execute(params![block_header.block_num, block_header.encode_to_vec()])
-            })
-            .await
-            .map_err(|_| anyhow!("Add block header task failed with a panic"))??;
-
-        Ok(num_rows)
     }
 
     /// Search for a [BlockHeader] from the DB by its `block_num`.
@@ -194,27 +79,7 @@ impl Db {
         self.pool
             .get()
             .await?
-            .interact(move |conn| {
-                let mut stmt;
-                let mut rows = match block_number {
-                    Some(block_number) => {
-                        stmt = conn.prepare("SELECT block_header FROM block_headers WHERE block_num = ?1")?;
-                        stmt.query([block_number])?
-                    },
-                    None => {
-                        stmt = conn.prepare("SELECT block_header FROM block_headers ORDER BY block_num DESC LIMIT 1")?;
-                        stmt.query([])?
-                    },
-                };
-
-                match rows.next()? {
-                    Some(row) =>  {
-                        let data = row.get_ref(0)?.as_blob()?;
-                        Ok(Some(BlockHeader::decode(data)?))
-                    },
-                    None => Ok(None),
-                }
-            })
+            .interact(move |conn| sql::get_block_header(conn, block_number))
             .await
             .map_err(|_| anyhow!("Get block header task failed with a panic"))?
     }
@@ -224,240 +89,9 @@ impl Db {
         self.pool
             .get()
             .await?
-            .interact(|conn| {
-                let mut stmt = conn.prepare("SELECT block_header FROM block_headers;")?;
-                let mut rows = stmt.query([])?;
-                let mut result = vec![];
-                while let Some(row) = rows.next()? {
-                    let block_header_data = row.get_ref(0)?.as_blob()?;
-                    let block_header = BlockHeader::decode(block_header_data)?;
-                    result.push(block_header);
-                }
-
-                Ok(result)
-            })
+            .interact(sql::get_block_headers)
             .await
             .map_err(|_| anyhow!("Get block headers task failed with a panic"))?
-    }
-
-    /// Save a [Note] to the DB.
-    #[cfg(test)]
-    pub async fn add_note(
-        &self,
-        note: Note,
-    ) -> Result<usize, anyhow::Error> {
-        let num_rows = self
-            .pool
-            .get()
-            .await?
-            .interact(move |conn| -> Result<_, anyhow::Error> {
-                use miden_node_store::errors::DbError;
-
-                let mut stmt = conn.prepare(
-                    "
-                    INSERT INTO
-                    notes
-                    (
-                        block_num,
-                        note_index,
-                        note_hash,
-                        sender,
-                        tag,
-                        num_assets,
-                        merkle_path
-                    )
-                    VALUES
-                    (
-                        ?1, ?2, ?3, ?4, ?5, ?6, ?7
-                    );",
-                )?;
-                let res = stmt.execute(params![
-                    note.block_num,
-                    note.note_index,
-                    note.note_hash.ok_or(DbError::NoteMissingHash)?.encode_to_vec(),
-                    note.sender,
-                    note.tag,
-                    note.num_assets,
-                    note.merkle_path.ok_or(DbError::NoteMissingMerklePath)?.encode_to_vec(),
-                ])?;
-                Ok(res)
-            })
-            .await
-            .map_err(|_| anyhow!("Add note task failed with a panic"))??;
-
-        Ok(num_rows)
-    }
-
-    /// Return notes matching the tag and account_ids search criteria.
-    ///
-    /// # Returns
-    ///
-    /// - Empty vector if no tag created after `block_num` match `tags` or `account_ids`.
-    /// - Otherwise, notes which the 16 high bits match `tags`, or the `sender` is one of the
-    ///   `account_ids`.
-    ///
-    /// # Note
-    ///
-    /// This method returns notes from a single block. To fetch all notes up to the chain tip,
-    /// multiple requests are necessary.
-    pub async fn get_notes_since_block_by_tag_and_sender(
-        &self,
-        tags: &[u32],
-        account_ids: &[u64],
-        block_num: BlockNumber,
-    ) -> Result<Vec<Note>, anyhow::Error> {
-        let tags: Vec<Value> = tags.iter().copied().map(u32_to_value).collect();
-        let account_ids = account_ids
-            .iter()
-            .copied()
-            .map(u64_to_value)
-            .collect::<Result<Vec<Value>, anyhow::Error>>()?;
-
-        let notes = self
-            .pool
-            .get()
-            .await?
-            .interact(move |conn| -> Result<_, anyhow::Error> {
-                let mut stmt = conn.prepare(
-                    "
-                    SELECT
-                        block_num,
-                        note_index,
-                        note_hash,
-                        sender,
-                        tag,
-                        num_assets,
-                        merkle_path
-                    FROM
-                        notes
-                    WHERE
-                        -- find the next block which contains at least one note with a matching tag
-                        block_num = (
-                            SELECT
-                                block_num
-                            FROM
-                                notes
-                            WHERE
-                                ((tag >> 48) IN rarray(?1) OR sender IN rarray(?2)) AND
-                                block_num > ?3
-                            ORDER BY
-                                block_num ASC
-                            LIMIT
-                                1
-                        ) AND
-                        -- load notes that matches any of tags
-                        (tag >> 48) IN rarray(?1);
-                ",
-                )?;
-                let mut rows =
-                    stmt.query(params![Rc::new(tags), Rc::new(account_ids), block_num])?;
-
-                let mut res = Vec::new();
-                while let Some(row) = rows.next()? {
-                    let block_num = row.get(0)?;
-                    let note_index = row.get(1)?;
-                    let note_hash_data = row.get_ref(2)?.as_blob()?;
-                    let note_hash = Some(decode_protobuf_digest(note_hash_data)?);
-                    let sender = row.get(3)?;
-                    let tag = row.get(4)?;
-                    let num_assets = row.get(5)?;
-                    let merkle_path_data = row.get_ref(6)?.as_blob()?;
-                    let merkle_path = Some(MerklePath::decode(merkle_path_data)?);
-
-                    let note = Note {
-                        block_num,
-                        note_index,
-                        note_hash,
-                        sender,
-                        tag,
-                        num_assets,
-                        merkle_path,
-                    };
-                    res.push(note);
-                }
-                Ok(res)
-            })
-            .await
-            .map_err(|_| anyhow!("Get notes since block by tag task failed with a panic"))??;
-
-        Ok(notes)
-    }
-
-    /// Inserts or updates an account's hash in the DB.
-    #[cfg(test)]
-    pub async fn update_account_hash(
-        &self,
-        account_id: AccountId,
-        account_hash: Digest,
-        block_num: BlockNumber,
-    ) -> Result<usize, anyhow::Error> {
-        let num_rows = self
-            .pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let mut stmt = conn.prepare(
-                    "INSERT OR REPLACE INTO accounts (account_id, account_hash, block_num) VALUES (?1, ?2, ?3);",
-                )?;
-                stmt.execute(params![account_id, account_hash.encode_to_vec(), block_num])
-            })
-            .await
-            .map_err(|_| anyhow!("Update account hash task failed with a panic"))??;
-
-        Ok(num_rows)
-    }
-
-    // Returns the account hash of the ones that have changed in the range `(block_start, block_end]`.
-    pub async fn get_account_hash_by_block_range(
-        &self,
-        block_start: BlockNumber,
-        block_end: BlockNumber,
-        account_ids: &[AccountId],
-    ) -> Result<Vec<AccountHashUpdate>, anyhow::Error> {
-        let account_ids = account_ids
-            .iter()
-            .copied()
-            .map(u64_to_value)
-            .collect::<Result<Vec<Value>, anyhow::Error>>()?;
-
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let mut stmt = conn.prepare(
-                    "
-                        SELECT
-                            account_id, account_hash, block_num
-                        FROM
-                            accounts
-                        WHERE
-                            block_num > ?1 AND
-                            block_num <= ?2 AND
-                            account_id IN rarray(?3)
-                    ",
-                )?;
-
-                let mut rows = stmt.query(params![block_start, block_end, Rc::new(account_ids)])?;
-
-                let mut result = Vec::new();
-                while let Some(row) = rows.next()? {
-                    let account_id_data: u64 = row.get(0)?;
-                    let account_id: account_id::AccountId = account_id_data.into();
-                    let account_hash_data = row.get_ref(1)?.as_blob()?;
-                    let account_hash = Digest::decode(account_hash_data)?;
-                    let block_num = row.get(2)?;
-
-                    result.push(AccountHashUpdate {
-                        account_id: Some(account_id),
-                        account_hash: Some(account_hash),
-                        block_num,
-                    });
-                }
-
-                Ok(result)
-            })
-            .await
-            .map_err(|_| anyhow!("Get account hash by block number task failed with a panic"))?
     }
 
     /// Loads all the account hashes from the DB.
@@ -465,21 +99,7 @@ impl Db {
         self.pool
             .get()
             .await?
-            .interact(move |conn| {
-                let mut stmt = conn.prepare("SELECT account_id, account_hash FROM accounts")?;
-                let mut rows = stmt.query([])?;
-
-                let mut result = Vec::new();
-                while let Some(row) = rows.next()? {
-                    let account_id: u64 = row.get(0)?;
-                    let account_hash_data = row.get_ref(1)?.as_blob()?;
-                    let account_hash = Digest::decode(account_hash_data)?;
-
-                    result.push((account_id, account_hash));
-                }
-
-                Ok(result)
-            })
+            .interact(sql::get_account_hashes)
             .await
             .map_err(|_| anyhow!("Get account hashes task failed with a panic"))?
     }
@@ -487,80 +107,27 @@ impl Db {
     pub async fn get_state_sync(
         &self,
         block_num: BlockNumber,
-        account_ids: &[u64],
+        account_ids: &[AccountId],
         note_tag_prefixes: &[u32],
         nullifiers_prefix: &[u32],
     ) -> Result<StateSyncUpdate, anyhow::Error> {
-        let notes = self
-            .get_notes_since_block_by_tag_and_sender(note_tag_prefixes, account_ids, block_num)
-            .await?;
+        let account_ids = account_ids.to_vec();
+        let note_tag_prefixes = note_tag_prefixes.to_vec();
+        let nullifiers_prefix = nullifiers_prefix.to_vec();
 
-        let (block_header, chain_tip) = if !notes.is_empty() {
-            let block_header = self
-                .get_block_header(Some(notes[0].block_num))
-                .await?
-                .ok_or(anyhow!("Block db is empty"))?;
-            let tip = self.get_block_header(None).await?.ok_or(anyhow!("Block db is empty"))?;
-
-            (block_header, tip.block_num)
-        } else {
-            let block_header =
-                self.get_block_header(None).await?.ok_or(anyhow!("Block db is empty"))?;
-
-            let block_num = block_header.block_num;
-            (block_header, block_num)
-        };
-
-        let account_updates = self
-            .get_account_hash_by_block_range(block_num, block_header.block_num, account_ids)
-            .await?;
-
-        let nullifiers = self
-            .get_nullifiers_by_block_range(block_num, block_header.block_num, nullifiers_prefix)
-            .await?;
-
-        Ok(StateSyncUpdate {
-            notes,
-            block_header,
-            chain_tip,
-            account_updates,
-            nullifiers,
-        })
+        self.pool
+            .get()
+            .await?
+            .interact(move |conn| {
+                sql::get_state_sync(
+                    conn,
+                    block_num,
+                    &account_ids,
+                    &note_tag_prefixes,
+                    &nullifiers_prefix,
+                )
+            })
+            .await
+            .map_err(|_| anyhow!("Get account hashes task failed with a panic"))?
     }
-}
-
-// UTILITIES
-// ================================================================================================
-
-/// Decodes a blob from the database into a [RpoDigest].
-fn decode_rpo_digest(data: &[u8]) -> Result<RpoDigest, anyhow::Error> {
-    let mut reader = SliceReader::new(data);
-    RpoDigest::read_from(&mut reader).map_err(|_| anyhow!("Decoding nullifier from DB failed"))
-}
-
-/// Decodes a blob from the database into a [Digest].
-fn decode_protobuf_digest(data: &[u8]) -> Result<Digest, anyhow::Error> {
-    Ok(Digest::decode(data)?)
-}
-
-/// Converts a `u64` into a [Value].
-///
-/// Sqlite uses `i64` as its internal representation format.
-fn u64_to_value(v: u64) -> Result<Value, anyhow::Error> {
-    let v: i64 = v.try_into()?;
-    Ok(Value::Integer(v))
-}
-
-/// Converts a `u32` into a [Value].
-///
-/// Sqlite uses `i64` as its internal representation format.
-fn u32_to_value(v: u32) -> Value {
-    let v: i64 = v.into();
-    Value::Integer(v)
-}
-
-/// Returns the high bits of the `u64` value used during searches.
-#[cfg(test)]
-fn u64_to_prefix(v: u64) -> u32 {
-    (v >> 48) as u32
 }

--- a/store/src/db/sql.rs
+++ b/store/src/db/sql.rs
@@ -1,0 +1,426 @@
+//! Wrapper functions for SQL statements.
+use super::StateSyncUpdate;
+use crate::types::{AccountId, BlockNumber};
+use anyhow::anyhow;
+use miden_crypto::{
+    hash::rpo::RpoDigest,
+    utils::{Deserializable, SliceReader},
+};
+use miden_node_proto::{
+    account_id,
+    block_header::BlockHeader,
+    digest::Digest,
+    merkle::MerklePath,
+    note::Note,
+    responses::{AccountHashUpdate, NullifierUpdate},
+};
+use prost::Message;
+use rusqlite::{params, types::Value, Connection};
+use std::rc::Rc;
+
+#[cfg(test)]
+pub fn add_nullifier(
+    conn: &mut Connection,
+    nullifier: RpoDigest,
+    block_number: BlockNumber,
+) -> anyhow::Result<usize> {
+    use miden_crypto::StarkField;
+
+    let mut stmt = conn.prepare(
+        "INSERT INTO nullifiers (nullifier, nullifier_prefix, block_number) VALUES (?1, ?2, ?3);",
+    )?;
+
+    Ok(stmt.execute(params![
+        nullifier.as_bytes(),
+        u64_to_prefix(nullifier[0].as_int()),
+        block_number
+    ])?)
+}
+
+pub fn get_nullifiers(
+    conn: &mut Connection
+) -> Result<Vec<(RpoDigest, BlockNumber)>, anyhow::Error> {
+    let mut stmt = conn.prepare("SELECT nullifier, block_number FROM nullifiers;")?;
+    let mut rows = stmt.query([])?;
+    let mut result = vec![];
+    while let Some(row) = rows.next()? {
+        let nullifier_data = row.get_ref(0)?.as_blob()?;
+        let nullifier = decode_rpo_digest(nullifier_data)?;
+        let block_number = row.get(1)?;
+        result.push((nullifier, block_number));
+    }
+
+    Ok(result)
+}
+
+/// Returns nullifiers created in the `(block_start, block_end]` range which also match the
+/// `nullifiers` filter.
+///
+/// Each value of the `nullifiers` is only the 16 most significat bits of the nullifier of
+/// interest to the client. This hides the details of the specific nullifier being requested.
+pub fn get_nullifiers_by_block_range(
+    conn: &mut Connection,
+    block_start: BlockNumber,
+    block_end: BlockNumber,
+    nullifiers: &[u32],
+) -> Result<Vec<NullifierUpdate>, anyhow::Error> {
+    let nullifiers: Vec<Value> = nullifiers.iter().copied().map(u32_to_value).collect();
+
+    let mut stmt = conn.prepare(
+        "
+        SELECT
+            nullifier,
+            block_number
+        FROM
+            nullifiers
+        WHERE
+            block_number > ?1 AND
+            block_number <= ?2 AND
+            nullifier_prefix IN rarray(?3)
+    ",
+    )?;
+
+    let mut rows = stmt.query(params![block_start, block_end, Rc::new(nullifiers)])?;
+
+    let mut result = Vec::new();
+    while let Some(row) = rows.next()? {
+        let nullifier_data = row.get_ref(0)?.as_blob()?;
+        let nullifier: Digest = decode_rpo_digest(nullifier_data)?.into();
+        let block_num = row.get(1)?;
+
+        result.push(NullifierUpdate {
+            nullifier: Some(nullifier),
+            block_num,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Save a [BlockHeader] to the DB.
+#[cfg(test)]
+pub fn add_block_header(
+    conn: &mut Connection,
+    block_header: BlockHeader,
+) -> Result<usize, anyhow::Error> {
+    let mut stmt =
+        conn.prepare("INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);")?;
+    Ok(stmt.execute(params![block_header.block_num, block_header.encode_to_vec()])?)
+}
+
+/// Search for a [BlockHeader] from the DB by its `block_num`.
+///
+/// When `block_number` is [None], the latest block header is returned.
+pub fn get_block_header(
+    conn: &mut Connection,
+    block_number: Option<BlockNumber>,
+) -> Result<Option<BlockHeader>, anyhow::Error> {
+    let mut stmt;
+    let mut rows = match block_number {
+        Some(block_number) => {
+            stmt = conn.prepare("SELECT block_header FROM block_headers WHERE block_num = ?1")?;
+            stmt.query([block_number])?
+        },
+        None => {
+            stmt = conn.prepare(
+                "SELECT block_header FROM block_headers ORDER BY block_num DESC LIMIT 1",
+            )?;
+            stmt.query([])?
+        },
+    };
+
+    match rows.next()? {
+        Some(row) => {
+            let data = row.get_ref(0)?.as_blob()?;
+            Ok(Some(BlockHeader::decode(data)?))
+        },
+        None => Ok(None),
+    }
+}
+
+/// Loads all the block headers from the DB.
+pub fn get_block_headers(conn: &mut Connection) -> Result<Vec<BlockHeader>, anyhow::Error> {
+    let mut stmt = conn.prepare("SELECT block_header FROM block_headers;")?;
+    let mut rows = stmt.query([])?;
+    let mut result = vec![];
+    while let Some(row) = rows.next()? {
+        let block_header_data = row.get_ref(0)?.as_blob()?;
+        let block_header = BlockHeader::decode(block_header_data)?;
+        result.push(block_header);
+    }
+
+    Ok(result)
+}
+
+/// Save a [Note] to the DB.
+#[cfg(test)]
+pub fn add_note(
+    conn: &mut Connection,
+    note: Note,
+) -> Result<usize, anyhow::Error> {
+    use miden_node_store::errors::DbError;
+
+    let mut stmt = conn.prepare(
+        "
+        INSERT INTO
+        notes
+        (
+            block_num,
+            note_index,
+            note_hash,
+            sender,
+            tag,
+            num_assets,
+            merkle_path
+        )
+        VALUES
+        (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7
+        );",
+    )?;
+    let res = stmt.execute(params![
+        note.block_num,
+        note.note_index,
+        note.note_hash.ok_or(DbError::NoteMissingHash)?.encode_to_vec(),
+        note.sender,
+        note.tag,
+        note.num_assets,
+        note.merkle_path.ok_or(DbError::NoteMissingMerklePath)?.encode_to_vec(),
+    ])?;
+    Ok(res)
+}
+
+/// Return notes matching the tag and account_ids search criteria.
+///
+/// # Returns
+///
+/// - Empty vector if no tag created after `block_num` match `tags` or `account_ids`.
+/// - Otherwise, notes which the 16 high bits match `tags`, or the `sender` is one of the
+///   `account_ids`.
+///
+/// # Note
+///
+/// This method returns notes from a single block. To fetch all notes up to the chain tip,
+/// multiple requests are necessary.
+pub fn get_notes_since_block_by_tag_and_sender(
+    conn: &mut Connection,
+    tags: &[u32],
+    account_ids: &[AccountId],
+    block_num: BlockNumber,
+) -> Result<Vec<Note>, anyhow::Error> {
+    let tags: Vec<Value> = tags.iter().copied().map(u32_to_value).collect();
+    let account_ids = account_ids
+        .iter()
+        .copied()
+        .map(u64_to_value)
+        .collect::<Result<Vec<Value>, anyhow::Error>>()?;
+
+    let mut stmt = conn.prepare(
+        "
+        SELECT
+            block_num,
+            note_index,
+            note_hash,
+            sender,
+            tag,
+            num_assets,
+            merkle_path
+        FROM
+            notes
+        WHERE
+            -- find the next block which contains at least one note with a matching tag
+            block_num = (
+                SELECT
+                    block_num
+                FROM
+                    notes
+                WHERE
+                    ((tag >> 48) IN rarray(?1) OR sender IN rarray(?2)) AND
+                    block_num > ?3
+                ORDER BY
+                    block_num ASC
+                LIMIT
+                    1
+            ) AND
+            -- load notes that matches any of tags
+            (tag >> 48) IN rarray(?1);
+    ",
+    )?;
+    let mut rows = stmt.query(params![Rc::new(tags), Rc::new(account_ids), block_num])?;
+
+    let mut res = Vec::new();
+    while let Some(row) = rows.next()? {
+        let block_num = row.get(0)?;
+        let note_index = row.get(1)?;
+        let note_hash_data = row.get_ref(2)?.as_blob()?;
+        let note_hash = Some(decode_protobuf_digest(note_hash_data)?);
+        let sender = row.get(3)?;
+        let tag = row.get(4)?;
+        let num_assets = row.get(5)?;
+        let merkle_path_data = row.get_ref(6)?.as_blob()?;
+        let merkle_path = Some(MerklePath::decode(merkle_path_data)?);
+
+        let note = Note {
+            block_num,
+            note_index,
+            note_hash,
+            sender,
+            tag,
+            num_assets,
+            merkle_path,
+        };
+        res.push(note);
+    }
+    Ok(res)
+}
+
+/// Inserts or updates an account's hash in the DB.
+#[cfg(test)]
+pub fn update_account_hash(
+    conn: &mut Connection,
+    account_id: AccountId,
+    account_hash: Digest,
+    block_num: BlockNumber,
+) -> Result<usize, anyhow::Error> {
+    let mut stmt = conn.prepare("INSERT OR REPLACE INTO accounts (account_id, account_hash, block_num) VALUES (?1, ?2, ?3);")?;
+    Ok(stmt.execute(params![account_id, account_hash.encode_to_vec(), block_num])?)
+}
+
+// Returns the account hash of the ones that have changed in the range `(block_start, block_end]`.
+pub fn get_account_hash_by_block_range(
+    conn: &mut Connection,
+    block_start: BlockNumber,
+    block_end: BlockNumber,
+    account_ids: &[AccountId],
+) -> Result<Vec<AccountHashUpdate>, anyhow::Error> {
+    let account_ids = account_ids
+        .iter()
+        .copied()
+        .map(u64_to_value)
+        .collect::<Result<Vec<Value>, anyhow::Error>>()?;
+
+    let mut stmt = conn.prepare(
+        "
+        SELECT
+            account_id, account_hash, block_num
+        FROM
+            accounts
+        WHERE
+            block_num > ?1 AND
+            block_num <= ?2 AND
+            account_id IN rarray(?3)
+    ",
+    )?;
+
+    let mut rows = stmt.query(params![block_start, block_end, Rc::new(account_ids)])?;
+
+    let mut result = Vec::new();
+    while let Some(row) = rows.next()? {
+        let account_id_data: u64 = row.get(0)?;
+        let account_id: account_id::AccountId = account_id_data.into();
+        let account_hash_data = row.get_ref(1)?.as_blob()?;
+        let account_hash = Digest::decode(account_hash_data)?;
+        let block_num = row.get(2)?;
+
+        result.push(AccountHashUpdate {
+            account_id: Some(account_id),
+            account_hash: Some(account_hash),
+            block_num,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Loads all the account hashes from the DB.
+pub fn get_account_hashes(
+    conn: &mut Connection
+) -> Result<Vec<(AccountId, Digest)>, anyhow::Error> {
+    let mut stmt = conn.prepare("SELECT account_id, account_hash FROM accounts")?;
+    let mut rows = stmt.query([])?;
+
+    let mut result = Vec::new();
+    while let Some(row) = rows.next()? {
+        let account_id: u64 = row.get(0)?;
+        let account_hash_data = row.get_ref(1)?.as_blob()?;
+        let account_hash = Digest::decode(account_hash_data)?;
+
+        result.push((account_id, account_hash));
+    }
+
+    Ok(result)
+}
+
+pub fn get_state_sync(
+    conn: &mut Connection,
+    block_num: BlockNumber,
+    account_ids: &[AccountId],
+    note_tag_prefixes: &[u32],
+    nullifiers_prefix: &[u32],
+) -> Result<StateSyncUpdate, anyhow::Error> {
+    let notes =
+        get_notes_since_block_by_tag_and_sender(conn, note_tag_prefixes, account_ids, block_num)?;
+
+    let (block_header, chain_tip) = if !notes.is_empty() {
+        let block_header = get_block_header(conn, Some(notes[0].block_num))?
+            .ok_or(anyhow!("Block db is empty"))?;
+        let tip = get_block_header(conn, None)?.ok_or(anyhow!("Block db is empty"))?;
+
+        (block_header, tip.block_num)
+    } else {
+        let block_header = get_block_header(conn, None)?.ok_or(anyhow!("Block db is empty"))?;
+
+        let block_num = block_header.block_num;
+        (block_header, block_num)
+    };
+
+    let account_updates =
+        get_account_hash_by_block_range(conn, block_num, block_header.block_num, account_ids)?;
+
+    let nullifiers =
+        get_nullifiers_by_block_range(conn, block_num, block_header.block_num, nullifiers_prefix)?;
+
+    Ok(StateSyncUpdate {
+        notes,
+        block_header,
+        chain_tip,
+        account_updates,
+        nullifiers,
+    })
+}
+
+// UTILITIES
+// ================================================================================================
+
+/// Decodes a blob from the database into a [Digest].
+fn decode_protobuf_digest(data: &[u8]) -> Result<Digest, anyhow::Error> {
+    Ok(Digest::decode(data)?)
+}
+
+/// Decodes a blob from the database into a [RpoDigest].
+fn decode_rpo_digest(data: &[u8]) -> Result<RpoDigest, anyhow::Error> {
+    let mut reader = SliceReader::new(data);
+    RpoDigest::read_from(&mut reader).map_err(|_| anyhow!("Decoding nullifier from DB failed"))
+}
+
+/// Returns the high bits of the `u64` value used during searches.
+#[cfg(test)]
+pub fn u64_to_prefix(v: u64) -> u32 {
+    (v >> 48) as u32
+}
+
+/// Converts a `u64` into a [Value].
+///
+/// Sqlite uses `i64` as its internal representation format.
+pub fn u64_to_value(v: u64) -> Result<Value, anyhow::Error> {
+    let v: i64 = v.try_into()?;
+    Ok(Value::Integer(v))
+}
+
+/// Converts a `u32` into a [Value].
+///
+/// Sqlite uses `i64` as its internal representation format.
+pub fn u32_to_value(v: u32) -> Value {
+    let v: i64 = v.into();
+    Value::Integer(v)
+}

--- a/store/src/main.rs
+++ b/store/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod db;
 mod migrations;
 mod server;
+mod state;
 mod types;
 use anyhow::Result;
 use clap::Parser;

--- a/store/src/server/api.rs
+++ b/store/src/server/api.rs
@@ -1,60 +1,36 @@
-use crate::{config::StoreConfig, db::Db};
+use crate::{config::StoreConfig, db::Db, state::State};
 use anyhow::Result;
-use miden_crypto::{
-    hash::rpo::RpoDigest,
-    merkle::{Mmr, SimpleSmt, TieredSmt},
-    Felt, FieldElement, StarkField, Word,
-};
+use miden_crypto::hash::rpo::RpoDigest;
 use miden_node_proto::{
+    conversion::convert,
     digest::Digest,
     error::ParseError,
-    merkle::MerklePath,
-    mmr::MmrDelta,
     requests::{
         CheckNullifiersRequest, GetBlockHeaderByNumberRequest, GetBlockInputsRequest,
         GetTransactionInputsRequest, SyncStateRequest,
     },
     responses::{
-        AccountBlockInputRecord, AccountTransactionInputRecord, CheckNullifiersResponse,
-        GetBlockHeaderByNumberResponse, GetBlockInputsResponse, GetTransactionInputsResponse,
-        NullifierTransactionInputRecord, SyncStateResponse,
+        CheckNullifiersResponse, GetBlockHeaderByNumberResponse, GetBlockInputsResponse,
+        GetTransactionInputsResponse, SyncStateResponse,
     },
     store::api_server,
-    tsmt::{self, NullifierLeaf},
 };
-use miden_objects::BlockHeader;
 use std::{net::ToSocketAddrs, sync::Arc};
-use tokio::{sync::RwLock, time::Instant};
 use tonic::{transport::Server, Response, Status};
-use tracing::{info, instrument};
-
-// CONSTANTS
-// ================================================================================================
-
-const ACCOUNT_DB_DEPTH: u8 = 64;
+use tracing::info;
 
 // STORE INITIALIZER
 // ================================================================================================
 
 pub async fn serve(
     config: StoreConfig,
-    mut db: Db,
+    db: Db,
 ) -> Result<()> {
     let host_port = (config.endpoint.host.as_ref(), config.endpoint.port);
     let addrs: Vec<_> = host_port.to_socket_addrs()?.collect();
 
-    let nullifier_data = load_nullifier_tree(&mut db).await?;
-    let nullifier_lock = Arc::new(RwLock::new(nullifier_data));
-    let mmr_data = load_mmr(&mut db).await?;
-    let mmr_lock = Arc::new(RwLock::new(mmr_data));
-    let accounts_data = load_accounts(&mut db).await?;
-    let accounts_lock = Arc::new(RwLock::new(accounts_data));
-    let db = api_server::ApiServer::new(StoreApi {
-        db,
-        nullifier_tree: nullifier_lock,
-        chain_mmr: mmr_lock,
-        account_tree: accounts_lock,
-    });
+    let state = Arc::new(State::load(db).await?);
+    let db = api_server::ApiServer::new(StoreApi { state });
 
     info!(host = config.endpoint.host, port = config.endpoint.port, "Server initialized",);
     Server::builder().add_service(db).serve(addrs[0]).await?;
@@ -66,10 +42,7 @@ pub async fn serve(
 // ================================================================================================
 
 pub struct StoreApi {
-    db: Db,
-    nullifier_tree: Arc<RwLock<TieredSmt>>,
-    chain_mmr: Arc<RwLock<Mmr>>,
-    account_tree: Arc<RwLock<SimpleSmt>>,
+    state: Arc<State>,
 }
 
 #[tonic::async_trait]
@@ -86,7 +59,7 @@ impl api_server::Api for StoreApi {
     ) -> Result<Response<GetBlockHeaderByNumberResponse>, Status> {
         let request = request.into_inner();
         let block_header =
-            self.db.get_block_header(request.block_num).await.map_err(internal_error)?;
+            self.state.get_block_header(request.block_num).await.map_err(internal_error)?;
 
         Ok(Response::new(GetBlockHeaderByNumberResponse { block_header }))
     }
@@ -100,46 +73,15 @@ impl api_server::Api for StoreApi {
         request: tonic::Request<CheckNullifiersRequest>,
     ) -> Result<Response<CheckNullifiersResponse>, Status> {
         // Validate the nullifiers and convert them to RpoDigest values. Stop on first error.
-        let nullifiers = request
-            .into_inner()
-            .nullifiers
-            .into_iter()
-            .map(|v| {
-                v.try_into()
-                    .or(Err(Status::invalid_argument("Digest field is not in the modulus range")))
-            })
-            .collect::<Result<Vec<RpoDigest>, Status>>()?;
+        let request = request.into_inner();
+        let nullifiers = validate_nullifiers(&request.nullifiers)?;
 
-        let nullifier_tree = self.nullifier_tree.read().await;
+        // Query the state for the request's nullifiers
+        let proofs = self.state.check_nullifiers(&nullifiers).await;
 
-        let proofs = nullifiers
-            .into_iter()
-            .map(|nullifier| {
-                let proof: miden_crypto::merkle::TieredSmtProof = nullifier_tree.prove(nullifier);
-
-                let (path, entries) = proof.into_parts();
-
-                let merkle_path: Vec<Digest> = path.into_iter().map(|e| e.into()).collect();
-
-                let leaves: Vec<NullifierLeaf> = entries
-                    .into_iter()
-                    .map(|(key, value)| {
-                        Ok(NullifierLeaf {
-                            key: Some(key.into()),
-                            block_num: nullifier_value_to_blocknum(value),
-                        })
-                    })
-                    .collect::<Result<Vec<NullifierLeaf>>>()?;
-
-                Ok(tsmt::NullifierProof {
-                    merkle_path,
-                    leaves,
-                })
-            })
-            .collect::<Result<Vec<tsmt::NullifierProof>>>()
-            .map_err(internal_error)?;
-
-        Ok(Response::new(CheckNullifiersResponse { proofs }))
+        Ok(Response::new(CheckNullifiersResponse {
+            proofs: convert(proofs),
+        }))
     }
 
     /// Returns info which can be used by the client to sync up to the latest state of the chain
@@ -152,45 +94,20 @@ impl api_server::Api for StoreApi {
 
         let account_ids: Vec<u64> = request.account_ids.iter().map(|e| e.id).collect();
 
-        let state_sync = self
-            .db
-            .get_state_sync(
-                request.block_num,
-                &account_ids,
-                &request.note_tags,
-                &request.nullifiers,
-            )
+        let (state, delta, path) = self
+            .state
+            .sync_state(request.block_num, &account_ids, &request.note_tags, &request.nullifiers)
             .await
             .map_err(internal_error)?;
 
-        // scope to read from the mmr
-        let (delta, path): (MmrDelta, MerklePath) = {
-            let mmr = self.chain_mmr.read().await;
-            let delta = mmr
-                .get_delta(request.block_num as usize, state_sync.block_header.block_num as usize)
-                .map_err(internal_error)?
-                .try_into()
-                .map_err(internal_error)?;
-
-            let proof = mmr
-                .open(
-                    state_sync.block_header.block_num as usize,
-                    state_sync.block_header.block_num as usize,
-                )
-                .map_err(internal_error)?;
-
-            (delta, proof.merkle_path.into())
-        };
-
-        let notes = state_sync.notes.into_iter().map(|v| v.into()).collect();
         Ok(Response::new(SyncStateResponse {
-            chain_tip: state_sync.chain_tip,
-            block_header: Some(state_sync.block_header),
-            mmr_delta: Some(delta),
-            block_path: Some(path),
-            accounts: state_sync.account_updates,
-            notes,
-            nullifiers: state_sync.nullifiers,
+            chain_tip: state.chain_tip,
+            block_header: Some(state.block_header),
+            mmr_delta: Some(delta.into()),
+            block_path: Some(path.into()),
+            accounts: state.account_updates,
+            notes: convert(state.notes),
+            nullifiers: state.nullifiers,
         }))
     }
 
@@ -204,44 +121,19 @@ impl api_server::Api for StoreApi {
     ) -> Result<Response<GetBlockInputsResponse>, Status> {
         let request = request.into_inner();
 
-        let latest = self
-            .db
-            .get_block_header(None)
+        let nullifiers = validate_nullifiers(&request.nullifiers)?;
+        let account_ids: Vec<u64> = request.account_ids.iter().map(|e| e.id).collect();
+
+        let (latest, accumulator, account_states) = self
+            .state
+            .get_block_inputs(&account_ids, &nullifiers)
             .await
-            .map_err(internal_error)?
-            .ok_or(Status::internal("Latest block not found"))?;
-
-        // scope to read from the mmr
-        let accumulator = {
-            let mmr = self.chain_mmr.read().await;
-            mmr.peaks(latest.block_num as usize).map_err(internal_error)?
-        };
-        let mmr_peaks = accumulator.peaks().iter().map(|d| d.into()).collect();
-
-        // FIXME: race condition
-        // 1. latest query above runs
-        // 2. a concurrent apply_block request is executed, updating the state
-        // 3. the load below happens, using state updated by 2, which doesn't match the block from 1
-
-        // scope to read from the accounts
-        let mut account_states = Vec::with_capacity(request.account_ids.len());
-        {
-            let accounts = self.account_tree.read().await;
-            for account_id in request.account_ids {
-                let account_hash = accounts.get_leaf(account_id.id).map_err(internal_error)?;
-                let proof = accounts.get_leaf_path(account_id.id).map_err(internal_error)?;
-                account_states.push(AccountBlockInputRecord {
-                    account_id: Some(account_id),
-                    account_hash: Some(account_hash.into()),
-                    proof: Some(proof.into()),
-                });
-            }
-        }
+            .map_err(internal_error)?;
 
         Ok(Response::new(GetBlockInputsResponse {
             block_header: Some(latest),
-            mmr_peaks,
-            account_states,
+            mmr_peaks: convert(accumulator.peaks()),
+            account_states: convert(account_states),
             // TODO: nullifiers blocked by changes in crypto repo
             nullifiers: vec![],
         }))
@@ -253,100 +145,24 @@ impl api_server::Api for StoreApi {
     ) -> Result<Response<GetTransactionInputsResponse>, Status> {
         let request = request.into_inner();
 
-        // scope to read from the accounts
-        let mut account_states = Vec::with_capacity(request.account_ids.len());
-        {
-            let accounts = self.account_tree.read().await;
-            for account_id in request.account_ids {
-                let account_hash = accounts.get_leaf(account_id.id).map_err(internal_error)?;
-                account_states.push(AccountTransactionInputRecord {
-                    account_id: Some(account_id),
-                    account_hash: Some(account_hash.into()),
-                });
-            }
-        }
+        let nullifiers = validate_nullifiers(&request.nullifiers)?;
+        let account_ids: Vec<u64> = request.account_ids.iter().map(|e| e.id).collect();
 
-        // FIXME: race condition
-        // 1. account hashes is loaded above
-        // 2. a concurrent apply_block request is executed, updating the state
-        // 3. the load below happens, using state updated by 2, which doesn't match the block from 1
-
-        // scope to read from the nullifiers
-        let mut nullifiers = Vec::with_capacity(request.nullifiers.len());
-        {
-            let nullifier_tree = self.nullifier_tree.read().await;
-            for nullifier in request.nullifiers {
-                let value = nullifier_tree
-                    .get_value(nullifier.clone().try_into().map_err(invalid_argument)?);
-                let block_num = nullifier_value_to_blocknum(value);
-
-                nullifiers.push(NullifierTransactionInputRecord {
-                    nullifier: Some(nullifier),
-                    block_num,
-                });
-            }
-        }
+        let (accounts, nullifiers_blocks) = self
+            .state
+            .get_transaction_inputs(&account_ids, &nullifiers)
+            .await
+            .map_err(internal_error)?;
 
         Ok(Response::new(GetTransactionInputsResponse {
-            account_states,
-            nullifiers,
+            account_states: convert(accounts),
+            nullifiers: convert(nullifiers_blocks),
         }))
     }
 }
 
 // UTILITIES
 // ================================================================================================
-
-/// Given the leaf value of the nullifier TSMT, returns the nullifier's block number.
-///
-/// There are no nullifiers in the genesis block. The value zero is instead used to signal absence
-/// of a value.
-fn nullifier_value_to_blocknum(value: Word) -> u32 {
-    value[3].as_int().try_into().expect("invalid block number found in store")
-}
-
-#[instrument(skip(db))]
-async fn load_nullifier_tree(db: &mut Db) -> Result<TieredSmt> {
-    let nullifiers = db.get_nullifiers().await?;
-    let len = nullifiers.len();
-    let leaves = nullifiers.into_iter().map(|(nullifier, block)| {
-        (nullifier, [Felt::new(block as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO])
-    });
-
-    let now = Instant::now();
-    let nullifier_tree = TieredSmt::with_entries(leaves)?;
-    let elapsed = now.elapsed().as_secs();
-
-    info!(num_of_leaves = len, tree_construction = elapsed, "Loaded nullifier tree");
-    Ok(nullifier_tree)
-}
-
-#[instrument(skip(db))]
-async fn load_mmr(db: &mut Db) -> Result<Mmr> {
-    let block_hashes: Result<Vec<RpoDigest>, ParseError> = db
-        .get_block_headers()
-        .await?
-        .into_iter()
-        .map(|b| b.try_into().map(|b: BlockHeader| b.hash()))
-        .collect();
-
-    let mmr: Mmr = block_hashes?.into();
-    Ok(mmr)
-}
-
-#[instrument(skip(db))]
-async fn load_accounts(db: &mut Db) -> Result<SimpleSmt> {
-    let account_data: Result<Vec<(u64, Word)>> = db
-        .get_account_hashes()
-        .await?
-        .into_iter()
-        .map(|(id, account_hash)| Ok((id, account_hash.try_into()?)))
-        .collect();
-
-    let smt = SimpleSmt::with_leaves(ACCOUNT_DB_DEPTH, account_data?)?;
-
-    Ok(smt)
-}
 
 /// Formats an error
 fn internal_error<E: core::fmt::Debug>(err: E) -> Status {
@@ -355,4 +171,12 @@ fn internal_error<E: core::fmt::Debug>(err: E) -> Status {
 
 fn invalid_argument<E: core::fmt::Debug>(err: E) -> Status {
     Status::invalid_argument(format!("{:?}", err))
+}
+
+fn validate_nullifiers(nullifiers: &[Digest]) -> Result<Vec<RpoDigest>, Status> {
+    nullifiers
+        .into_iter()
+        .map(|v| v.try_into())
+        .collect::<Result<Vec<RpoDigest>, ParseError>>()
+        .map_err(|_| invalid_argument("Digest field is not in the modulus range"))
 }

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -1,0 +1,266 @@
+//! Abstraction to synchornize state modifications.
+//!
+//! The [State] provides data access and modifications methods, its main purpose is to ensure that
+//! data is atomically written, and that reads are consistent.
+use crate::{
+    db::{Db, StateSyncUpdate},
+    types::{AccountId, BlockNumber},
+};
+use anyhow::{anyhow, Result};
+use miden_crypto::{
+    hash::rpo::RpoDigest,
+    merkle::{
+        MerkleError, MerklePath, Mmr, MmrDelta, MmrPeaks, SimpleSmt, TieredSmt, TieredSmtProof,
+    },
+    Felt, FieldElement, Word,
+};
+use miden_node_proto::{
+    block_header::BlockHeader,
+    conversion::nullifier_value_to_blocknum,
+    error::ParseError,
+    responses::{
+        AccountBlockInputRecord, AccountTransactionInputRecord, NullifierTransactionInputRecord,
+    },
+};
+use tokio::{sync::RwLock, time::Instant};
+use tracing::{info, instrument};
+
+// CONSTANTS
+// ================================================================================================
+
+const ACCOUNT_DB_DEPTH: u8 = 64;
+
+// STRUCTURES
+// ================================================================================================
+
+/// Container for state that needs to be updated atomically.
+struct InnerState {
+    nullifier_tree: TieredSmt,
+    chain_mmr: Mmr,
+    account_tree: SimpleSmt,
+}
+
+/// The rollup state
+pub struct State {
+    db: Db,
+    inner: RwLock<InnerState>,
+}
+
+pub struct AccountStateForBlockInput {
+    account_id: AccountId,
+    account_hash: Word,
+    merkle_path: MerklePath,
+}
+
+impl From<AccountStateForBlockInput> for AccountBlockInputRecord {
+    fn from(value: AccountStateForBlockInput) -> Self {
+        Self {
+            account_id: Some(value.account_id.into()),
+            account_hash: Some(value.account_hash.into()),
+            proof: Some(value.merkle_path.into()),
+        }
+    }
+}
+
+pub struct AccountStateForTransactionInput {
+    account_id: AccountId,
+    account_hash: Word,
+}
+
+impl From<AccountStateForTransactionInput> for AccountTransactionInputRecord {
+    fn from(value: AccountStateForTransactionInput) -> Self {
+        Self {
+            account_id: Some(value.account_id.into()),
+            account_hash: Some(value.account_hash.into()),
+        }
+    }
+}
+
+pub struct NullifierStateForTransactionInput {
+    nullifier: RpoDigest,
+    block_num: u32,
+}
+
+impl From<NullifierStateForTransactionInput> for NullifierTransactionInputRecord {
+    fn from(value: NullifierStateForTransactionInput) -> Self {
+        Self {
+            nullifier: Some(value.nullifier.into()),
+            block_num: value.block_num,
+        }
+    }
+}
+
+impl State {
+    pub async fn load(mut db: Db) -> Result<Self, anyhow::Error> {
+        let nullifier_tree = load_nullifier_tree(&mut db).await?;
+        let chain_mmr = load_mmr(&mut db).await?;
+        let account_tree = load_accounts(&mut db).await?;
+
+        let inner = RwLock::new(InnerState {
+            nullifier_tree,
+            chain_mmr,
+            account_tree,
+        });
+
+        Ok(Self { db, inner })
+    }
+
+    pub async fn get_block_header(
+        &self,
+        block_num: Option<BlockNumber>,
+    ) -> Result<Option<BlockHeader>, anyhow::Error> {
+        self.db.get_block_header(block_num).await
+    }
+
+    pub async fn check_nullifiers(
+        &self,
+        nullifiers: &[RpoDigest],
+    ) -> Vec<TieredSmtProof> {
+        let inner = self.inner.read().await;
+        nullifiers.iter().map(|n| inner.nullifier_tree.prove(*n)).collect()
+    }
+
+    pub async fn sync_state(
+        &self,
+        block_num: BlockNumber,
+        account_ids: &[AccountId],
+        note_tag_prefixes: &[u32],
+        nullifier_prefixes: &[u32],
+    ) -> Result<(StateSyncUpdate, MmrDelta, MerklePath), anyhow::Error> {
+        let inner = self.inner.read().await;
+
+        let state_sync = self
+            .db
+            .get_state_sync(block_num, account_ids, note_tag_prefixes, nullifier_prefixes)
+            .await?;
+
+        let (delta, path) = {
+            let delta = inner
+                .chain_mmr
+                .get_delta(block_num as usize, state_sync.block_header.block_num as usize)?;
+
+            let proof = inner.chain_mmr.open(
+                state_sync.block_header.block_num as usize,
+                state_sync.block_header.block_num as usize,
+            )?;
+
+            (delta, proof.merkle_path)
+        };
+
+        Ok((state_sync, delta, path))
+    }
+
+    /// Returns data needed by the block producer to construct and prove the next block.
+    pub async fn get_block_inputs(
+        &self,
+        account_ids: &[AccountId],
+        _nullifiers: &[RpoDigest],
+    ) -> Result<(BlockHeader, MmrPeaks, Vec<AccountStateForBlockInput>), anyhow::Error> {
+        let inner = self.inner.read().await;
+
+        let latest = self.db.get_block_header(None).await?.ok_or(anyhow!("Database is empty"))?;
+        let accumulator = inner.chain_mmr.peaks(latest.block_num as usize)?;
+        let account_states = account_ids
+            .iter()
+            .cloned()
+            .map(|account_id| {
+                let account_hash = inner.account_tree.get_leaf(account_id)?;
+                let merkle_path = inner.account_tree.get_leaf_path(account_id)?;
+                Ok(AccountStateForBlockInput {
+                    account_id,
+                    account_hash,
+                    merkle_path,
+                })
+            })
+            .collect::<Result<Vec<AccountStateForBlockInput>, MerkleError>>()?;
+
+        // TODO: add nullifiers
+        Ok((latest, accumulator, account_states))
+    }
+
+    pub async fn get_transaction_inputs(
+        &self,
+        account_ids: &[AccountId],
+        nullifiers: &[RpoDigest],
+    ) -> Result<
+        (Vec<AccountStateForTransactionInput>, Vec<NullifierStateForTransactionInput>),
+        anyhow::Error,
+    > {
+        let inner = self.inner.read().await;
+
+        let accounts: Vec<_> = account_ids
+            .iter()
+            .cloned()
+            .map(|id| {
+                Ok(AccountStateForTransactionInput {
+                    account_id: id,
+                    account_hash: inner.account_tree.get_leaf(id)?,
+                })
+            })
+            .collect::<Result<Vec<AccountStateForTransactionInput>, MerkleError>>()?;
+
+        let nullifier_blocks = nullifiers
+            .iter()
+            .cloned()
+            .map(|nullifier| {
+                let value = inner.nullifier_tree.get_value(nullifier);
+                let block_num = nullifier_value_to_blocknum(value);
+
+                NullifierStateForTransactionInput {
+                    nullifier,
+                    block_num,
+                }
+            })
+            .collect();
+
+        Ok((accounts, nullifier_blocks))
+    }
+}
+
+// UTILITIES
+// ================================================================================================
+
+#[instrument(skip(db))]
+async fn load_nullifier_tree(db: &mut Db) -> Result<TieredSmt> {
+    let nullifiers = db.get_nullifiers().await?;
+    let len = nullifiers.len();
+    let leaves = nullifiers.into_iter().map(|(nullifier, block)| {
+        (nullifier, [Felt::new(block as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO])
+    });
+
+    let now = Instant::now();
+    let nullifier_tree = TieredSmt::with_entries(leaves)?;
+    let elapsed = now.elapsed().as_secs();
+
+    info!(num_of_leaves = len, tree_construction = elapsed, "Loaded nullifier tree");
+    Ok(nullifier_tree)
+}
+
+#[instrument(skip(db))]
+async fn load_mmr(db: &mut Db) -> Result<Mmr> {
+    use miden_objects::BlockHeader;
+
+    let block_hashes: Result<Vec<RpoDigest>, ParseError> = db
+        .get_block_headers()
+        .await?
+        .into_iter()
+        .map(|b| b.try_into().map(|b: BlockHeader| b.hash()))
+        .collect();
+
+    let mmr: Mmr = block_hashes?.into();
+    Ok(mmr)
+}
+
+#[instrument(skip(db))]
+async fn load_accounts(db: &mut Db) -> Result<SimpleSmt> {
+    let account_data: Result<Vec<(u64, Word)>> = db
+        .get_account_hashes()
+        .await?
+        .into_iter()
+        .map(|(id, account_hash)| Ok((id, account_hash.try_into()?)))
+        .collect();
+
+    let smt = SimpleSmt::with_leaves(ACCOUNT_DB_DEPTH, account_data?)?;
+
+    Ok(smt)
+}


### PR DESCRIPTION
Fixes the issues with data races. This PR does two main modifications:

1. Move the SQL queries to standalone functions, that operate over the `conn` and its required arguments.
2. Move all the tree states behind a single lock.

Moving the SQL queries to functions is useful because it allows for its reuse. E.g. `apply_block` must validate the new block header data inside a transaction, because the data stored in the DB is not normalized the validation can not be done via SQL constraints, so `apply_block` has to open a transaction, load the last block header from the DB, and perform the validation. Prior to this change the query inside `get_block_header` could only be used inside a new connection, after this change the `sql::get_block_header` can be used from multiple methods.

Moving the tree state behind a single read/write lock allows for atomic updates to the trees. 

This PR is more of a ground work, I will open the `apply_block` as a follow up.