### PR TITLE
store: apply_block endpoint

### DIFF
--- a/proto/proto/requests.proto
+++ b/proto/proto/requests.proto
@@ -2,7 +2,21 @@ syntax = "proto3";
 package requests;
 
 import "account_id.proto";
+import "block_header.proto";
 import "digest.proto";
+import "note.proto";
+
+message AccountUpdate {
+    account_id.AccountId account_id = 1;
+    digest.Digest account_hash = 2;
+}
+
+message ApplyBlockRequest {
+    block_header.BlockHeader block = 1;
+    repeated AccountUpdate accounts = 2;
+    repeated digest.Digest nullifiers = 3;
+    repeated note.Note notes = 4;
+}
 
 message CheckNullifiersRequest {
     repeated digest.Digest nullifiers = 1;

--- a/proto/proto/responses.proto
+++ b/proto/proto/responses.proto
@@ -8,6 +8,8 @@ import "merkle.proto";
 import "mmr.proto";
 import "tsmt.proto";
 
+message ApplyBlockResponse {}
+
 message CheckNullifiersResponse {
     // Each requested nullifier has its corresponding nullifier proof at the
     // same position.
@@ -30,12 +32,12 @@ message NullifierUpdate {
 }
 
 message NoteSyncRecord {
-    uint32 note_index = 2;
-    digest.Digest note_hash = 3;
-    uint64 sender  = 4;
-    uint64 tag = 5;
-    uint32 num_assets = 6;
-    merkle.MerklePath merkle_path = 7;
+    uint32 note_index = 1;
+    digest.Digest note_hash = 2;
+    uint64 sender  = 3;
+    uint64 tag = 4;
+    uint32 num_assets = 5;
+    merkle.MerklePath merkle_path = 6;
 }
 
 message SyncStateResponse {
@@ -71,7 +73,7 @@ message AccountBlockInputRecord {
 // A nullifier returned as a response to the GetBlockInputs
 message NullifierBlockInputRecord {
     digest.Digest nullifier = 1;
-    merkle.MerklePath proof = 3;
+    merkle.MerklePath proof = 2;
 }
 
 message GetBlockInputsResponse {
@@ -99,10 +101,10 @@ message AccountTransactionInputRecord {
 message NullifierTransactionInputRecord {
     digest.Digest nullifier = 1;
     // The block at which the nullifier has been consumed, zero if not consumed.
-    uint32 block_num = 3;
+    uint32 block_num = 2;
 }
 
 message GetTransactionInputsResponse {
-    repeated AccountTransactionInputRecord account_states = 3;
-    repeated NullifierTransactionInputRecord nullifiers = 4;
+    repeated AccountTransactionInputRecord account_states = 1;
+    repeated NullifierTransactionInputRecord nullifiers = 2;
 }

--- a/proto/proto/store.proto
+++ b/proto/proto/store.proto
@@ -8,6 +8,7 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
+    rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
     rpc GetBlockHeaderByNumber(requests.GetBlockHeaderByNumberRequest) returns (responses.GetBlockHeaderByNumberResponse) {}
     rpc GetBlockInputs(requests.GetBlockInputsRequest) returns (responses.GetBlockInputsResponse) {}

--- a/proto/src/generated/requests.rs
+++ b/proto/src/generated/requests.rs
@@ -1,6 +1,28 @@
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccountUpdate {
+    #[prost(message, optional, tag = "1")]
+    pub account_id: ::core::option::Option<super::account_id::AccountId>,
+    #[prost(message, optional, tag = "2")]
+    pub account_hash: ::core::option::Option<super::digest::Digest>,
+}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApplyBlockRequest {
+    #[prost(message, optional, tag = "1")]
+    pub block: ::core::option::Option<super::block_header::BlockHeader>,
+    #[prost(message, repeated, tag = "2")]
+    pub accounts: ::prost::alloc::vec::Vec<AccountUpdate>,
+    #[prost(message, repeated, tag = "3")]
+    pub nullifiers: ::prost::alloc::vec::Vec<super::digest::Digest>,
+    #[prost(message, repeated, tag = "4")]
+    pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
+}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersRequest {
     #[prost(message, repeated, tag = "1")]
     pub nullifiers: ::prost::alloc::vec::Vec<super::digest::Digest>,

--- a/proto/src/generated/responses.rs
+++ b/proto/src/generated/responses.rs
@@ -1,6 +1,10 @@
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApplyBlockResponse {}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersResponse {
     /// Each requested nullifier has its corresponding nullifier proof at the
     /// same position.
@@ -38,17 +42,17 @@ pub struct NullifierUpdate {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NoteSyncRecord {
-    #[prost(uint32, tag = "2")]
+    #[prost(uint32, tag = "1")]
     pub note_index: u32,
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag = "2")]
     pub note_hash: ::core::option::Option<super::digest::Digest>,
-    #[prost(uint64, tag = "4")]
+    #[prost(uint64, tag = "3")]
     pub sender: u64,
-    #[prost(uint64, tag = "5")]
+    #[prost(uint64, tag = "4")]
     pub tag: u64,
-    #[prost(uint32, tag = "6")]
+    #[prost(uint32, tag = "5")]
     pub num_assets: u32,
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag = "6")]
     pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
 }
 #[derive(Eq, PartialOrd, Ord, Hash)]
@@ -96,7 +100,7 @@ pub struct AccountBlockInputRecord {
 pub struct NullifierBlockInputRecord {
     #[prost(message, optional, tag = "1")]
     pub nullifier: ::core::option::Option<super::digest::Digest>,
-    #[prost(message, optional, tag = "3")]
+    #[prost(message, optional, tag = "2")]
     pub proof: ::core::option::Option<super::merkle::MerklePath>,
 }
 #[derive(Eq, PartialOrd, Ord, Hash)]
@@ -135,15 +139,15 @@ pub struct NullifierTransactionInputRecord {
     #[prost(message, optional, tag = "1")]
     pub nullifier: ::core::option::Option<super::digest::Digest>,
     /// The block at which the nullifier has been consumed, zero if not consumed.
-    #[prost(uint32, tag = "3")]
+    #[prost(uint32, tag = "2")]
     pub block_num: u32,
 }
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTransactionInputsResponse {
-    #[prost(message, repeated, tag = "3")]
+    #[prost(message, repeated, tag = "1")]
     pub account_states: ::prost::alloc::vec::Vec<AccountTransactionInputRecord>,
-    #[prost(message, repeated, tag = "4")]
+    #[prost(message, repeated, tag = "2")]
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierTransactionInputRecord>,
 }

--- a/proto/src/generated/rpc.rs
+++ b/proto/src/generated/rpc.rs
@@ -1,8 +1,8 @@
 /// Generated client implementations.
 pub mod api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -29,10 +29,7 @@ pub mod api_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_origin(
-            inner: T,
-            origin: Uri,
-        ) -> Self {
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
@@ -49,8 +46,9 @@ pub mod api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             ApiClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -59,19 +57,13 @@ pub mod api_client {
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
         /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
@@ -79,10 +71,7 @@ pub mod api_client {
         ///
         /// Default: `4MB`
         #[must_use]
-        pub fn max_decoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
             self.inner = self.inner.max_decoding_message_size(limit);
             self
         }
@@ -90,26 +79,28 @@ pub mod api_client {
         ///
         /// Default: `usize::MAX`
         #[must_use]
-        pub fn max_encoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
         pub async fn check_nullifiers(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::requests::CheckNullifiersRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::requests::CheckNullifiersRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::CheckNullifiersResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/rpc.Api/CheckNullifiers");
             let mut req = request.into_request();
@@ -118,19 +109,26 @@ pub mod api_client {
         }
         pub async fn get_block_header_by_number(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::requests::GetBlockHeaderByNumberRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::requests::GetBlockHeaderByNumberRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetBlockHeaderByNumberResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/rpc.Api/GetBlockHeaderByNumber");
+            let path = http::uri::PathAndQuery::from_static(
+                "/rpc.Api/GetBlockHeaderByNumber",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rpc.Api", "GetBlockHeaderByNumber"));
@@ -143,12 +141,15 @@ pub mod api_client {
             tonic::Response<super::super::responses::SyncStateResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/rpc.Api/SyncState");
             let mut req = request.into_request();
@@ -173,7 +174,9 @@ pub mod api_server {
         >;
         async fn get_block_header_by_number(
             &self,
-            request: tonic::Request<super::super::requests::GetBlockHeaderByNumberRequest>,
+            request: tonic::Request<
+                super::super::requests::GetBlockHeaderByNumberRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetBlockHeaderByNumberResponse>,
             tonic::Status,
@@ -220,19 +223,13 @@ pub mod api_server {
         }
         /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.accept_compression_encodings.enable(encoding);
             self
         }
         /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.send_compression_encodings.enable(encoding);
             self
         }
@@ -240,10 +237,7 @@ pub mod api_server {
         ///
         /// Default: `4MB`
         #[must_use]
-        pub fn max_decoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
             self.max_decoding_message_size = Some(limit);
             self
         }
@@ -251,10 +245,7 @@ pub mod api_server {
         ///
         /// Default: `usize::MAX`
         #[must_use]
-        pub fn max_encoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
             self.max_encoding_message_size = Some(limit);
             self
         }
@@ -274,28 +265,32 @@ pub mod api_server {
         ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
-        fn call(
-            &mut self,
-            req: http::Request<B>,
-        ) -> Self::Future {
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
                 "/rpc.Api/CheckNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct CheckNullifiersSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<super::super::requests::CheckNullifiersRequest>
-                        for CheckNullifiersSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::CheckNullifiersRequest,
+                    > for CheckNullifiersSvc<T> {
                         type Response = super::super::responses::CheckNullifiersResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
+                            request: tonic::Request<
+                                super::super::requests::CheckNullifiersRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Api>::check_nullifiers(&inner, request).await };
+                            let fut = async move {
+                                <T as Api>::check_nullifiers(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -321,17 +316,20 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/rpc.Api/GetBlockHeaderByNumber" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockHeaderByNumberSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<
-                            super::super::requests::GetBlockHeaderByNumberRequest,
-                        > for GetBlockHeaderByNumberSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::GetBlockHeaderByNumberRequest,
+                    > for GetBlockHeaderByNumberSvc<T> {
                         type Response = super::super::responses::GetBlockHeaderByNumberResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -340,7 +338,8 @@ pub mod api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Api>::get_block_header_by_number(&inner, request).await
+                                <T as Api>::get_block_header_by_number(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -367,22 +366,30 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/rpc.Api/SyncState" => {
                     #[allow(non_camel_case_types)]
                     struct SyncStateSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<super::super::requests::SyncStateRequest>
-                        for SyncStateSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::SyncStateRequest,
+                    > for SyncStateSvc<T> {
                         type Response = super::super::responses::SyncStateResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::requests::SyncStateRequest>,
+                            request: tonic::Request<
+                                super::super::requests::SyncStateRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Api>::sync_state(&inner, request).await };
+                            let fut = async move {
+                                <T as Api>::sync_state(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -408,15 +415,19 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -438,10 +449,7 @@ pub mod api_server {
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(
-            &self,
-            f: &mut std::fmt::Formatter<'_>,
-        ) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/proto/src/generated/store.rs
+++ b/proto/src/generated/store.rs
@@ -1,8 +1,8 @@
 /// Generated client implementations.
 pub mod api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -29,10 +29,7 @@ pub mod api_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_origin(
-            inner: T,
-            origin: Uri,
-        ) -> Self {
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
@@ -49,8 +46,9 @@ pub mod api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             ApiClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -59,19 +57,13 @@ pub mod api_client {
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
         /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
@@ -79,10 +71,7 @@ pub mod api_client {
         ///
         /// Default: `4MB`
         #[must_use]
-        pub fn max_decoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
             self.inner = self.inner.max_decoding_message_size(limit);
             self
         }
@@ -90,47 +79,80 @@ pub mod api_client {
         ///
         /// Default: `usize::MAX`
         #[must_use]
-        pub fn max_encoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        pub async fn apply_block(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::requests::ApplyBlockRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::ApplyBlockResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/store.Api/ApplyBlock");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("store.Api", "ApplyBlock"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn check_nullifiers(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::requests::CheckNullifiersRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::requests::CheckNullifiersRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::CheckNullifiersResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/store.Api/CheckNullifiers");
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/CheckNullifiers",
+            );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new("store.Api", "CheckNullifiers"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_block_header_by_number(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::requests::GetBlockHeaderByNumberRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::requests::GetBlockHeaderByNumberRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetBlockHeaderByNumberResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/store.Api/GetBlockHeaderByNumber");
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/GetBlockHeaderByNumber",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("store.Api", "GetBlockHeaderByNumber"));
@@ -138,17 +160,22 @@ pub mod api_client {
         }
         pub async fn get_block_inputs(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::requests::GetBlockInputsRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::requests::GetBlockInputsRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetBlockInputsResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/store.Api/GetBlockInputs");
             let mut req = request.into_request();
@@ -157,19 +184,26 @@ pub mod api_client {
         }
         pub async fn get_transaction_inputs(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::requests::GetTransactionInputsRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::requests::GetTransactionInputsRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetTransactionInputsResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/store.Api/GetTransactionInputs");
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/GetTransactionInputs",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("store.Api", "GetTransactionInputs"));
@@ -182,12 +216,15 @@ pub mod api_client {
             tonic::Response<super::super::responses::SyncStateResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/store.Api/SyncState");
             let mut req = request.into_request();
@@ -203,6 +240,13 @@ pub mod api_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ApiServer.
     #[async_trait]
     pub trait Api: Send + Sync + 'static {
+        async fn apply_block(
+            &self,
+            request: tonic::Request<super::super::requests::ApplyBlockRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::ApplyBlockResponse>,
+            tonic::Status,
+        >;
         async fn check_nullifiers(
             &self,
             request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
@@ -212,7 +256,9 @@ pub mod api_server {
         >;
         async fn get_block_header_by_number(
             &self,
-            request: tonic::Request<super::super::requests::GetBlockHeaderByNumberRequest>,
+            request: tonic::Request<
+                super::super::requests::GetBlockHeaderByNumberRequest,
+            >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetBlockHeaderByNumberResponse>,
             tonic::Status,
@@ -273,19 +319,13 @@ pub mod api_server {
         }
         /// Enable decompressing requests with the given encoding.
         #[must_use]
-        pub fn accept_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.accept_compression_encodings.enable(encoding);
             self
         }
         /// Compress responses with the given encoding, if the client supports it.
         #[must_use]
-        pub fn send_compressed(
-            mut self,
-            encoding: CompressionEncoding,
-        ) -> Self {
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.send_compression_encodings.enable(encoding);
             self
         }
@@ -293,10 +333,7 @@ pub mod api_server {
         ///
         /// Default: `4MB`
         #[must_use]
-        pub fn max_decoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
             self.max_decoding_message_size = Some(limit);
             self
         }
@@ -304,10 +341,7 @@ pub mod api_server {
         ///
         /// Default: `usize::MAX`
         #[must_use]
-        pub fn max_encoding_message_size(
-            mut self,
-            limit: usize,
-        ) -> Self {
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
             self.max_encoding_message_size = Some(limit);
             self
         }
@@ -327,28 +361,81 @@ pub mod api_server {
         ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
-        fn call(
-            &mut self,
-            req: http::Request<B>,
-        ) -> Self::Future {
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
+                "/store.Api/ApplyBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct ApplyBlockSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::ApplyBlockRequest,
+                    > for ApplyBlockSvc<T> {
+                        type Response = super::super::responses::ApplyBlockResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::requests::ApplyBlockRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::apply_block(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ApplyBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/store.Api/CheckNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct CheckNullifiersSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<super::super::requests::CheckNullifiersRequest>
-                        for CheckNullifiersSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::CheckNullifiersRequest,
+                    > for CheckNullifiersSvc<T> {
                         type Response = super::super::responses::CheckNullifiersResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
+                            request: tonic::Request<
+                                super::super::requests::CheckNullifiersRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Api>::check_nullifiers(&inner, request).await };
+                            let fut = async move {
+                                <T as Api>::check_nullifiers(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -374,17 +461,20 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/store.Api/GetBlockHeaderByNumber" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockHeaderByNumberSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<
-                            super::super::requests::GetBlockHeaderByNumberRequest,
-                        > for GetBlockHeaderByNumberSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::GetBlockHeaderByNumberRequest,
+                    > for GetBlockHeaderByNumberSvc<T> {
                         type Response = super::super::responses::GetBlockHeaderByNumberResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -393,7 +483,8 @@ pub mod api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Api>::get_block_header_by_number(&inner, request).await
+                                <T as Api>::get_block_header_by_number(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -420,23 +511,30 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/store.Api/GetBlockInputs" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockInputsSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<super::super::requests::GetBlockInputsRequest>
-                        for GetBlockInputsSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::GetBlockInputsRequest,
+                    > for GetBlockInputsSvc<T> {
                         type Response = super::super::responses::GetBlockInputsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::requests::GetBlockInputsRequest>,
+                            request: tonic::Request<
+                                super::super::requests::GetBlockInputsRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Api>::get_block_inputs(&inner, request).await };
+                            let fut = async move {
+                                <T as Api>::get_block_inputs(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -462,17 +560,20 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/store.Api/GetTransactionInputs" => {
                     #[allow(non_camel_case_types)]
                     struct GetTransactionInputsSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<
-                            super::super::requests::GetTransactionInputsRequest,
-                        > for GetTransactionInputsSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::GetTransactionInputsRequest,
+                    > for GetTransactionInputsSvc<T> {
                         type Response = super::super::responses::GetTransactionInputsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -508,22 +609,30 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/store.Api/SyncState" => {
                     #[allow(non_camel_case_types)]
                     struct SyncStateSvc<T: Api>(pub Arc<T>);
-                    impl<T: Api>
-                        tonic::server::UnaryService<super::super::requests::SyncStateRequest>
-                        for SyncStateSvc<T>
-                    {
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::SyncStateRequest,
+                    > for SyncStateSvc<T> {
                         type Response = super::super::responses::SyncStateResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::requests::SyncStateRequest>,
+                            request: tonic::Request<
+                                super::super::requests::SyncStateRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Api>::sync_state(&inner, request).await };
+                            let fut = async move {
+                                <T as Api>::sync_state(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -549,15 +658,19 @@ pub mod api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -579,10 +692,7 @@ pub mod api_server {
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(
-            &self,
-            f: &mut std::fmt::Formatter<'_>,
-        ) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "{:?}", self.0)
         }
     }

--- a/store/src/db/sql.rs
+++ b/store/src/db/sql.rs
@@ -1,6 +1,9 @@
 //! Wrapper functions for SQL statements.
 use super::StateSyncUpdate;
-use crate::types::{AccountId, BlockNumber};
+use crate::{
+    errors::StateError,
+    types::{AccountId, BlockNumber},
+};
 use anyhow::anyhow;
 use miden_crypto::{
     hash::rpo::RpoDigest,
@@ -15,33 +18,52 @@ use miden_node_proto::{
     responses::{AccountHashUpdate, NullifierUpdate},
 };
 use prost::Message;
-use rusqlite::{params, types::Value, Connection};
+use rusqlite::{params, types::Value, Connection, Transaction};
 use std::rc::Rc;
 
-#[cfg(test)]
-pub fn add_nullifier(
-    conn: &mut Connection,
-    nullifier: RpoDigest,
-    block_number: BlockNumber,
-) -> anyhow::Result<usize> {
+/// Insert nullifiers to the DB using the given [Transaction].
+///
+/// # Returns
+///
+/// The number of affected rows.
+///
+/// # Note
+///
+/// The [Transaction] object is not consumed. It's up to the caller to commit or rollback the
+/// transaction.
+pub fn insert_nullifiers_for_block(
+    transaction: &Transaction,
+    nullifiers: &[RpoDigest],
+    block_num: BlockNumber,
+) -> Result<usize, anyhow::Error> {
     use miden_crypto::StarkField;
 
-    let mut stmt = conn.prepare(
+    let mut stmt = transaction.prepare(
         "INSERT INTO nullifiers (nullifier, nullifier_prefix, block_number) VALUES (?1, ?2, ?3);",
     )?;
 
-    Ok(stmt.execute(params![
-        nullifier.as_bytes(),
-        u64_to_prefix(nullifier[0].as_int()),
-        block_number
-    ])?)
+    let mut count = 0;
+    for nullifier in nullifiers.iter() {
+        count += stmt.execute(params![
+            nullifier.as_bytes(),
+            u64_to_prefix(nullifier[0].as_int()),
+            block_num,
+        ])?
+    }
+    Ok(count)
 }
 
-pub fn get_nullifiers(
+/// Select all nullifiers to the DB using the given [Connection].
+///
+/// # Returns
+///
+/// The vector with the nullifiers and the block height at which they where created, or an error.
+pub fn select_nullifiers(
     conn: &mut Connection
 ) -> Result<Vec<(RpoDigest, BlockNumber)>, anyhow::Error> {
     let mut stmt = conn.prepare("SELECT nullifier, block_number FROM nullifiers;")?;
     let mut rows = stmt.query([])?;
+
     let mut result = vec![];
     while let Some(row) = rows.next()? {
         let nullifier_data = row.get_ref(0)?.as_blob()?;
@@ -49,16 +71,20 @@ pub fn get_nullifiers(
         let block_number = row.get(1)?;
         result.push((nullifier, block_number));
     }
-
     Ok(result)
 }
 
-/// Returns nullifiers created in the `(block_start, block_end]` range which also match the
-/// `nullifier_prefixes` filter.
+/// Select nullifiers created between `(block_start, block_end]` that also match the
+/// `nullifier_prefixes` filter using the given [Connection].
 ///
 /// Each value of the `nullifier_prefixes` is only the 16 most significat bits of the nullifier of
 /// interest to the client. This hides the details of the specific nullifier being requested.
-pub fn get_nullifiers_by_block_range(
+///
+/// # Returns
+///
+/// A vector of [NullifierUpdate] with the nullifiers and the block height at which they where
+/// created, or an error.
+pub fn select_nullifiers_by_block_range(
     conn: &mut Connection,
     block_start: BlockNumber,
     block_end: BlockNumber,
@@ -88,31 +114,40 @@ pub fn get_nullifiers_by_block_range(
         let nullifier_data = row.get_ref(0)?.as_blob()?;
         let nullifier: Digest = decode_rpo_digest(nullifier_data)?.into();
         let block_num = row.get(1)?;
-
         result.push(NullifierUpdate {
             nullifier: Some(nullifier),
             block_num,
         });
     }
-
     Ok(result)
 }
 
-/// Save a [BlockHeader] to the DB.
-#[cfg(test)]
-pub fn add_block_header(
-    conn: &mut Connection,
-    block_header: BlockHeader,
+/// Insert a [BlockHeader] to the DB using the given [Transaction].
+///
+/// # Returns
+///
+/// The number of affected rows.
+///
+/// # Note
+///
+/// The [Transaction] object is not consumed. It's up to the caller to commit or rollback the
+/// transaction.
+pub fn insert_block_header(
+    transaction: &Transaction,
+    block_header: &BlockHeader,
 ) -> Result<usize, anyhow::Error> {
-    let mut stmt =
-        conn.prepare("INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);")?;
+    let mut stmt = transaction
+        .prepare("INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);")?;
     Ok(stmt.execute(params![block_header.block_num, block_header.encode_to_vec()])?)
 }
 
-/// Search for a [BlockHeader] from the DB by its `block_num`.
+/// Select a [BlockHeader] from the DB by its `block_num` usiing the given [Connection].
 ///
-/// When `block_number` is [None], the latest block header is returned.
-pub fn get_block_header(
+/// # Returns
+///
+/// When `block_number` is [None], the latest block header is returned. Otherwise the block with the
+/// given block height is returned.
+pub fn select_block_header_by_block_num(
     conn: &mut Connection,
     block_number: Option<BlockNumber>,
 ) -> Result<Option<BlockHeader>, anyhow::Error> {
@@ -139,8 +174,12 @@ pub fn get_block_header(
     }
 }
 
-/// Loads all the block headers from the DB.
-pub fn get_block_headers(conn: &mut Connection) -> Result<Vec<BlockHeader>, anyhow::Error> {
+/// Select all block headers from the DB using the given [Connection].
+///
+/// # Returns
+///
+/// A vector of [BlockHeader] or an error.
+pub fn select_block_headers(conn: &mut Connection) -> Result<Vec<BlockHeader>, anyhow::Error> {
     let mut stmt = conn.prepare("SELECT block_header FROM block_headers;")?;
     let mut rows = stmt.query([])?;
     let mut result = vec![];
@@ -153,15 +192,21 @@ pub fn get_block_headers(conn: &mut Connection) -> Result<Vec<BlockHeader>, anyh
     Ok(result)
 }
 
-/// Save a [Note] to the DB.
-#[cfg(test)]
-pub fn add_note(
-    conn: &mut Connection,
-    note: Note,
+/// Insert notes to the DB using the given [Transaction].
+///
+/// # Returns
+///
+/// The number of affected rows.
+///
+/// # Note
+///
+/// The [Transaction] object is not consumed. It's up to the caller to commit or rollback the
+/// transaction.
+pub fn insert_notes(
+    transaction: &Transaction,
+    notes: &[Note],
 ) -> Result<usize, anyhow::Error> {
-    use miden_node_store::errors::DbError;
-
-    let mut stmt = conn.prepare(
+    let mut stmt = transaction.prepare(
         "
         INSERT INTO
         notes
@@ -179,19 +224,27 @@ pub fn add_note(
             ?1, ?2, ?3, ?4, ?5, ?6, ?7
         );",
     )?;
-    let res = stmt.execute(params![
-        note.block_num,
-        note.note_index,
-        note.note_hash.ok_or(DbError::NoteMissingHash)?.encode_to_vec(),
-        note.sender,
-        note.tag,
-        note.num_assets,
-        note.merkle_path.ok_or(DbError::NoteMissingMerklePath)?.encode_to_vec(),
-    ])?;
-    Ok(res)
+
+    let mut count = 0;
+    for note in notes.iter() {
+        count += stmt.execute(params![
+            note.block_num,
+            note.note_index,
+            note.note_hash.clone().ok_or(StateError::NoteMissingHash)?.encode_to_vec(),
+            note.sender,
+            note.tag,
+            note.num_assets,
+            note.merkle_path
+                .clone()
+                .ok_or(StateError::NoteMissingMerklePath)?
+                .encode_to_vec(),
+        ])?;
+    }
+
+    Ok(count)
 }
 
-/// Return notes matching the tag and account_ids search criteria.
+/// Select notes matching the tag and account_ids search criteria using the given [Connection].
 ///
 /// # Returns
 ///
@@ -203,7 +256,7 @@ pub fn add_note(
 ///
 /// This method returns notes from a single block. To fetch all notes up to the chain tip,
 /// multiple requests are necessary.
-pub fn get_notes_since_block_by_tag_and_sender(
+pub fn select_notes_since_block_by_tag_and_sender(
     conn: &mut Connection,
     tags: &[u32],
     account_ids: &[AccountId],
@@ -275,20 +328,37 @@ pub fn get_notes_since_block_by_tag_and_sender(
     Ok(res)
 }
 
-/// Inserts or updates an account's hash in the DB.
-#[cfg(test)]
-pub fn update_account_hash(
-    conn: &mut Connection,
-    account_id: AccountId,
-    account_hash: Digest,
+/// Inserts or updates accounts to the DB using the given [Transaction].
+///
+/// # Returns
+///
+/// The number of affected rows.
+///
+/// # Note
+///
+/// The [Transaction] object is not consumed. It's up to the caller to commit or rollback the
+/// transaction.
+pub fn upsert_accounts_with_blocknum(
+    transaction: &Transaction,
+    accounts: &[(AccountId, Digest)],
     block_num: BlockNumber,
 ) -> Result<usize, anyhow::Error> {
-    let mut stmt = conn.prepare("INSERT OR REPLACE INTO accounts (account_id, account_hash, block_num) VALUES (?1, ?2, ?3);")?;
-    Ok(stmt.execute(params![account_id, account_hash.encode_to_vec(), block_num])?)
+    let mut stmt = transaction.prepare("INSERT OR REPLACE INTO accounts (account_id, account_hash, block_num) VALUES (?1, ?2, ?3);")?;
+
+    let mut count = 0;
+    for (account_id, account_hash) in accounts.iter() {
+        count += stmt.execute(params![account_id, account_hash.encode_to_vec(), block_num])?
+    }
+    Ok(count)
 }
 
-// Returns the account hash of the ones that have changed in the range `(block_start, block_end]`.
-pub fn get_account_hash_by_block_range(
+/// Select [AccountHashUpdate] from the DB using the given [Connection], given that the account
+/// update was done between `(block_start, block_end]`.
+///
+/// # Returns
+///
+/// The vector of [AccountHashUpdate] with the matching accounts.
+pub fn select_accounts_by_block_range(
     conn: &mut Connection,
     block_start: BlockNumber,
     block_end: BlockNumber,
@@ -333,8 +403,12 @@ pub fn get_account_hash_by_block_range(
     Ok(result)
 }
 
-/// Loads all the account hashes from the DB.
-pub fn get_account_hashes(
+/// Select all account hashes from the DB using the given [Connection].
+///
+/// # Returns
+///
+/// The vector with the account id and corresponding hash, or an error.
+pub fn select_account_hashes(
     conn: &mut Connection
 ) -> Result<Vec<(AccountId, Digest)>, anyhow::Error> {
     let mut stmt = conn.prepare("SELECT account_id, account_hash FROM accounts")?;
@@ -352,6 +426,7 @@ pub fn get_account_hashes(
     Ok(result)
 }
 
+/// Loads the state necessary for a state sync.
 pub fn get_state_sync(
     conn: &mut Connection,
     block_num: BlockNumber,
@@ -359,27 +434,37 @@ pub fn get_state_sync(
     note_tag_prefixes: &[u32],
     nullifier_prefixes: &[u32],
 ) -> Result<StateSyncUpdate, anyhow::Error> {
-    let notes =
-        get_notes_since_block_by_tag_and_sender(conn, note_tag_prefixes, account_ids, block_num)?;
+    let notes = select_notes_since_block_by_tag_and_sender(
+        conn,
+        note_tag_prefixes,
+        account_ids,
+        block_num,
+    )?;
 
     let (block_header, chain_tip) = if !notes.is_empty() {
-        let block_header = get_block_header(conn, Some(notes[0].block_num))?
+        let block_header = select_block_header_by_block_num(conn, Some(notes[0].block_num))?
             .ok_or(anyhow!("Block db is empty"))?;
-        let tip = get_block_header(conn, None)?.ok_or(anyhow!("Block db is empty"))?;
+        let tip =
+            select_block_header_by_block_num(conn, None)?.ok_or(anyhow!("Block db is empty"))?;
 
         (block_header, tip.block_num)
     } else {
-        let block_header = get_block_header(conn, None)?.ok_or(anyhow!("Block db is empty"))?;
+        let block_header =
+            select_block_header_by_block_num(conn, None)?.ok_or(anyhow!("Block db is empty"))?;
 
         let block_num = block_header.block_num;
         (block_header, block_num)
     };
 
     let account_updates =
-        get_account_hash_by_block_range(conn, block_num, block_header.block_num, account_ids)?;
+        select_accounts_by_block_range(conn, block_num, block_header.block_num, account_ids)?;
 
-    let nullifiers =
-        get_nullifiers_by_block_range(conn, block_num, block_header.block_num, nullifier_prefixes)?;
+    let nullifiers = select_nullifiers_by_block_range(
+        conn,
+        block_num,
+        block_header.block_num,
+        nullifier_prefixes,
+    )?;
 
     Ok(StateSyncUpdate {
         notes,
@@ -388,6 +473,27 @@ pub fn get_state_sync(
         account_updates,
         nullifiers,
     })
+}
+
+/// Updates the DB with the state of a new block.
+///
+///
+/// # Returns
+///
+/// The number of affected rows in the DB.
+pub fn apply_block(
+    transaction: &Transaction,
+    block_header: &BlockHeader,
+    notes: &[Note],
+    nullifiers: &[RpoDigest],
+    accounts: &[(AccountId, Digest)],
+) -> Result<usize, anyhow::Error> {
+    let mut count = 0;
+    count += insert_block_header(transaction, block_header)?;
+    count += insert_notes(transaction, notes)?;
+    count += upsert_accounts_with_blocknum(transaction, accounts, block_header.block_num)?;
+    count += insert_nullifiers_for_block(transaction, nullifiers, block_header.block_num)?;
+    Ok(count)
 }
 
 // UTILITIES
@@ -405,7 +511,6 @@ fn decode_rpo_digest(data: &[u8]) -> Result<RpoDigest, anyhow::Error> {
 }
 
 /// Returns the high bits of the `u64` value used during searches.
-#[cfg(test)]
 pub fn u64_to_prefix(v: u64) -> u32 {
     (v >> 48) as u32
 }

--- a/store/src/errors.rs
+++ b/store/src/errors.rs
@@ -1,19 +1,68 @@
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum DbError {
-    NoteMissingMerklePath,
+use miden_crypto::hash::rpo::RpoDigest;
+use miden_node_proto::error::ParseError;
+
+#[derive(Clone, Debug)]
+pub enum StateError {
+    ConcurrentWrite,
+    DbBlockHeaderEmpty,
+    DigestError(ParseError),
+    DuplicatedNullifiers(Vec<RpoDigest>),
+    InvalidAccountId,
+    InvalidAccountRoot,
+    InvalidChainRoot,
+    InvalidNoteRoot,
+    InvalidNullifierRoot,
+    MissingAccountHash,
+    MissingAccountId,
+    MissingAccountRoot,
+    MissingBatchRoot,
+    MissingChainRoot,
+    MissingNoteHash,
+    MissingNoteRoot,
+    MissingNullifierRoot,
+    MissingPrevHash,
+    MissingProofHash,
+    NewBlockInvalidPrevHash,
     NoteMissingHash,
+    NoteMissingMerklePath,
 }
 
-impl std::error::Error for DbError {}
+impl std::error::Error for StateError {}
 
-impl std::fmt::Display for DbError {
+impl std::fmt::Display for StateError {
     fn fmt(
         &self,
         f: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         match self {
-            DbError::NoteMissingMerklePath => write!(f, "Note message is missing the merkle path"),
-            DbError::NoteMissingHash => write!(f, "Note message is missing the note's hash"),
+            StateError::ConcurrentWrite => write!(f, "Concurrent write detected"),
+            StateError::DbBlockHeaderEmpty => write!(f, "DB doesnt have any block header data"),
+            StateError::DigestError(digest_error) => write!(f, "{:?}", digest_error),
+            StateError::DuplicatedNullifiers(nullifiers) => {
+                write!(f, "Duplicated nullifiers {:?}", nullifiers)
+            },
+            StateError::InvalidAccountId => write!(f, "Received invalid account id"),
+            StateError::InvalidAccountRoot => write!(f, "Received invalid account tree root"),
+            StateError::InvalidChainRoot => write!(f, "Received invalid chain mmr hash"),
+            StateError::InvalidNoteRoot => write!(f, "Received invalid note root"),
+            StateError::InvalidNullifierRoot => write!(f, "Received invalid nullifier tree root"),
+            StateError::MissingAccountHash => write!(f, "Missing account_hash"),
+            StateError::MissingAccountId => write!(f, "Missing account_id"),
+            StateError::MissingAccountRoot => write!(f, "Missing account root"),
+            StateError::MissingBatchRoot => write!(f, "Missing batch root"),
+            StateError::MissingChainRoot => write!(f, "Missing chain root"),
+            StateError::MissingNoteHash => write!(f, "Missing note hash"),
+            StateError::MissingNoteRoot => write!(f, "Missing note root"),
+            StateError::MissingNullifierRoot => write!(f, "Missing nullifier root"),
+            StateError::MissingPrevHash => write!(f, "Missing prev hash"),
+            StateError::MissingProofHash => write!(f, "Missing proof hash"),
+            StateError::NewBlockInvalidPrevHash => {
+                write!(f, "New block prev_hash must match the chain's tip")
+            },
+            StateError::NoteMissingHash => write!(f, "Note message is missing the note's hash"),
+            StateError::NoteMissingMerklePath => {
+                write!(f, "Note message is missing the merkle path")
+            },
         }
     }
 }

--- a/store/src/main.rs
+++ b/store/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod config;
 mod db;
+mod errors;
 mod migrations;
 mod server;
 mod state;

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -2,8 +2,11 @@
 //!
 //! The [State] provides data access and modifications methods, its main purpose is to ensure that
 //! data is atomically written, and that reads are consistent.
+use std::mem;
+
 use crate::{
     db::{Db, StateSyncUpdate},
+    errors::StateError,
     types::{AccountId, BlockNumber},
 };
 use anyhow::{anyhow, Result};
@@ -12,18 +15,28 @@ use miden_crypto::{
     merkle::{
         MerkleError, MerklePath, Mmr, MmrDelta, MmrPeaks, SimpleSmt, TieredSmt, TieredSmtProof,
     },
-    Felt, FieldElement, Word,
+    Felt, FieldElement, Word, EMPTY_WORD,
 };
 use miden_node_proto::{
-    block_header::BlockHeader,
+    block_header,
     conversion::nullifier_value_to_blocknum,
+    digest::Digest,
     error::ParseError,
+    note::Note,
+    requests,
     responses::{
         AccountBlockInputRecord, AccountTransactionInputRecord, NullifierTransactionInputRecord,
     },
 };
-use tokio::{sync::RwLock, time::Instant};
-use tracing::{info, instrument};
+use miden_objects::{
+    notes::{NoteMetadata, NOTE_LEAF_DEPTH},
+    BlockHeader,
+};
+use tokio::{
+    sync::{oneshot, Mutex, RwLock},
+    time::Instant,
+};
+use tracing::{info, instrument, span, Level};
 
 // CONSTANTS
 // ================================================================================================
@@ -43,17 +56,25 @@ struct InnerState {
 /// The rollup state
 pub struct State {
     db: Db,
+
+    /// Read-write lock used to prevent writing to a structure while it is being used.
+    ///
+    /// The lock is writer-preferring, meaning the writer won't be starved.
     inner: RwLock<InnerState>,
+
+    /// To allow readers to access the tree data while an update in being performed, and prevent
+    /// TOCTOU issues, there must be no concurrent writers. This locks to serialize the writers.
+    writer: Mutex<()>,
 }
 
-pub struct AccountStateForBlockInput {
+pub struct AccountStateWithProof {
     account_id: AccountId,
     account_hash: Word,
     merkle_path: MerklePath,
 }
 
-impl From<AccountStateForBlockInput> for AccountBlockInputRecord {
-    fn from(value: AccountStateForBlockInput) -> Self {
+impl From<AccountStateWithProof> for AccountBlockInputRecord {
+    fn from(value: AccountStateWithProof) -> Self {
         Self {
             account_id: Some(value.account_id.into()),
             account_hash: Some(value.account_hash.into()),
@@ -62,17 +83,40 @@ impl From<AccountStateForBlockInput> for AccountBlockInputRecord {
     }
 }
 
-pub struct AccountStateForTransactionInput {
+pub struct AccountState {
     account_id: AccountId,
     account_hash: Word,
 }
 
-impl From<AccountStateForTransactionInput> for AccountTransactionInputRecord {
-    fn from(value: AccountStateForTransactionInput) -> Self {
+impl From<AccountState> for AccountTransactionInputRecord {
+    fn from(value: AccountState) -> Self {
         Self {
             account_id: Some(value.account_id.into()),
             account_hash: Some(value.account_hash.into()),
         }
+    }
+}
+
+impl TryFrom<requests::AccountUpdate> for AccountState {
+    type Error = StateError;
+
+    fn try_from(value: requests::AccountUpdate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            account_id: value.account_id.ok_or(StateError::MissingAccountId)?.into(),
+            account_hash: value
+                .account_hash
+                .ok_or(StateError::MissingAccountHash)?
+                .try_into()
+                .map_err(StateError::DigestError)?,
+        })
+    }
+}
+
+impl TryFrom<&requests::AccountUpdate> for AccountState {
+    type Error = StateError;
+
+    fn try_from(value: &requests::AccountUpdate) -> Result<Self, Self::Error> {
+        value.clone().try_into()
     }
 }
 
@@ -102,14 +146,157 @@ impl State {
             account_tree,
         });
 
-        Ok(Self { db, inner })
+        let writer = Mutex::new(());
+        Ok(Self { db, inner, writer })
+    }
+
+    /// Apply changes of a new block to the DB and in-memory data structures.
+    ///
+    /// ## Note on state consistency
+    ///
+    /// The server contains in-memory representations of the existing trees, the in-memory
+    /// representation must be kept consistent with the commited data, this is necessary so to
+    /// provide consistent results for all endpoints. In order to achieve consistency, the
+    /// following steps are used:
+    ///
+    /// - the request data is validated, prior to starting any modifications
+    /// - a transaction is open in the DB and the writes are started
+    ///  - while the transaction is not commited, concurrent reads are allowed, both the DB and
+    ///  the in-memory representations, which are consistent at this stage.
+    /// - prior to commiting the changes to the DB, an exclusive lock to the in-memory data is
+    /// acquired, preventing concurrent reads to the in-memory data, since that will be
+    /// out-of-sync w.r.t. the DB.
+    /// - the DB transaction is commited, and requests that read only from the DB can proceed to
+    /// use the fresh data
+    /// - the in-memory structures are updated, and the lock is released
+    pub async fn apply_block(
+        &self,
+        block_header: block_header::BlockHeader,
+        nullifiers: &[RpoDigest],
+        accounts: &[(AccountId, Digest)],
+        notes: &[Note],
+    ) -> Result<(), anyhow::Error> {
+        let _ = self.writer.try_lock().map_err(|_| StateError::ConcurrentWrite)?;
+
+        // ensures the right block header is being processed
+        let prev_block_msg = self
+            .db
+            .select_block_header_by_block_num(None)
+            .await?
+            .ok_or(StateError::DbBlockHeaderEmpty)?;
+        let block_num = (prev_block_msg.block_num as u32) + 1;
+        let prev_block: BlockHeader = prev_block_msg.try_into()?;
+        let prev_hash =
+            block_header.prev_hash.clone().ok_or(StateError::MissingPrevHash)?.try_into()?;
+        if prev_hash != prev_block.hash() {
+            return Err(StateError::NewBlockInvalidPrevHash.into());
+        }
+
+        // scope to read in-memory data, validate the request, and compute intermediary values
+        let (account_tree, chain_mmr, nullifier_tree) = {
+            let inner = self.inner.read().await;
+
+            let span = span!(Level::INFO, "updating in-memory data structures");
+            let guard = span.enter();
+
+            // nullifiers can be produced only once
+            let duplicate_nullifiers: Vec<_> = nullifiers
+                .iter()
+                .filter(|&&n| inner.nullifier_tree.get_value(n) != EMPTY_WORD)
+                .cloned()
+                .collect();
+            if !duplicate_nullifiers.is_empty() {
+                return Err(StateError::DuplicatedNullifiers(duplicate_nullifiers).into());
+            }
+
+            // update the in-memory datastructures and compute the new block header. Important, the
+            // structures are not yet commited
+            let mut chain_mmr = inner.chain_mmr.clone();
+            chain_mmr.add(prev_hash);
+            let peaks = chain_mmr.peaks(chain_mmr.forest())?;
+
+            if RpoDigest::from(peaks.hash_peaks())
+                != block_header
+                    .clone()
+                    .chain_root
+                    .ok_or(StateError::MissingChainRoot)?
+                    .try_into()?
+            {
+                return Err(StateError::InvalidChainRoot.into());
+            }
+
+            let mut nullifier_tree = inner.nullifier_tree.clone();
+            let nullifier_data = block_to_nullifier_data(block_num);
+            for nullifier in nullifiers {
+                nullifier_tree.insert(*nullifier, nullifier_data);
+            }
+
+            if nullifier_tree.root()
+                != block_header
+                    .nullifier_root
+                    .clone()
+                    .ok_or(StateError::MissingNullifierRoot)?
+                    .try_into()?
+            {
+                return Err(StateError::InvalidNullifierRoot.into());
+            }
+
+            let mut account_tree = inner.account_tree.clone();
+            for (account_id, account_hash) in accounts {
+                account_tree.update_leaf(*account_id, account_hash.try_into()?)?;
+            }
+
+            if account_tree.root()
+                != block_header
+                    .account_root
+                    .clone()
+                    .ok_or(StateError::MissingAccountRoot)?
+                    .try_into()?
+            {
+                return Err(StateError::InvalidAccountRoot.into());
+            }
+
+            let note_tree = build_notes_tree(notes)?;
+            if note_tree.root()
+                != block_header.note_root.clone().ok_or(StateError::MissingNoteRoot)?.try_into()?
+            {
+                return Err(StateError::InvalidNoteRoot.into());
+            }
+
+            drop(guard);
+
+            (account_tree, chain_mmr, nullifier_tree)
+        };
+
+        // signals the transaction is ready to be commited, and the write lock can be acquired
+        let (allow_acquire, acquired_allowed) = oneshot::channel::<()>();
+        // signals the write lock has been acquired, and the transaction can be commited
+        let (inform_acquire_done, acquire_done) = oneshot::channel::<()>();
+
+        self.db
+            .apply_block(allow_acquire, acquire_done, block_header, notes, nullifiers, accounts)
+            .await?;
+
+        acquired_allowed.await?;
+
+        // scope to update the in-memory data
+        {
+            let mut inner = self.inner.write().await;
+            let _ = inform_acquire_done.send(());
+
+            let _ = mem::replace(&mut inner.chain_mmr, chain_mmr);
+            let _ = mem::replace(&mut inner.nullifier_tree, nullifier_tree);
+            let _ = mem::replace(&mut inner.account_tree, account_tree);
+        }
+
+        Ok(())
     }
 
     pub async fn get_block_header(
         &self,
         block_num: Option<BlockNumber>,
-    ) -> Result<Option<BlockHeader>, anyhow::Error> {
-        self.db.get_block_header(block_num).await
+    ) -> Result<Option<block_header::BlockHeader>, anyhow::Error> {
+        self.db.select_block_header_by_block_num(block_num).await
     }
 
     pub async fn check_nullifiers(
@@ -155,10 +342,15 @@ impl State {
         &self,
         account_ids: &[AccountId],
         _nullifiers: &[RpoDigest],
-    ) -> Result<(BlockHeader, MmrPeaks, Vec<AccountStateForBlockInput>), anyhow::Error> {
+    ) -> Result<(block_header::BlockHeader, MmrPeaks, Vec<AccountStateWithProof>), anyhow::Error>
+    {
         let inner = self.inner.read().await;
 
-        let latest = self.db.get_block_header(None).await?.ok_or(anyhow!("Database is empty"))?;
+        let latest = self
+            .db
+            .select_block_header_by_block_num(None)
+            .await?
+            .ok_or(anyhow!("Database is empty"))?;
         let accumulator = inner.chain_mmr.peaks(latest.block_num as usize)?;
         let account_states = account_ids
             .iter()
@@ -166,13 +358,13 @@ impl State {
             .map(|account_id| {
                 let account_hash = inner.account_tree.get_leaf(account_id)?;
                 let merkle_path = inner.account_tree.get_leaf_path(account_id)?;
-                Ok(AccountStateForBlockInput {
+                Ok(AccountStateWithProof {
                     account_id,
                     account_hash,
                     merkle_path,
                 })
             })
-            .collect::<Result<Vec<AccountStateForBlockInput>, MerkleError>>()?;
+            .collect::<Result<Vec<AccountStateWithProof>, MerkleError>>()?;
 
         // TODO: add nullifiers
         Ok((latest, accumulator, account_states))
@@ -182,22 +374,19 @@ impl State {
         &self,
         account_ids: &[AccountId],
         nullifiers: &[RpoDigest],
-    ) -> Result<
-        (Vec<AccountStateForTransactionInput>, Vec<NullifierStateForTransactionInput>),
-        anyhow::Error,
-    > {
+    ) -> Result<(Vec<AccountState>, Vec<NullifierStateForTransactionInput>), anyhow::Error> {
         let inner = self.inner.read().await;
 
         let accounts: Vec<_> = account_ids
             .iter()
             .cloned()
             .map(|id| {
-                Ok(AccountStateForTransactionInput {
+                Ok(AccountState {
                     account_id: id,
                     account_hash: inner.account_tree.get_leaf(id)?,
                 })
             })
-            .collect::<Result<Vec<AccountStateForTransactionInput>, MerkleError>>()?;
+            .collect::<Result<Vec<AccountState>, MerkleError>>()?;
 
         let nullifier_blocks = nullifiers
             .iter()
@@ -220,13 +409,40 @@ impl State {
 // UTILITIES
 // ================================================================================================
 
+/// Returns the nullifier's block number given its leaf value in the TSMT.
+fn block_to_nullifier_data(block: BlockNumber) -> Word {
+    [Felt::new(block as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+}
+
+// /// Returns the block number encoded as a leaf value to be used in the TSMT.
+// fn nullifier_data_to_block(block: Word) -> BlockNumber {
+//     block[0].as_int() as BlockNumber
+// }
+
+/// Creates a [SimpleSmt] tree from the `notes`.
+pub fn build_notes_tree(notes: &[Note]) -> Result<SimpleSmt, anyhow::Error> {
+    // TODO: create SimpleSmt without this allocation
+    let mut entries: Vec<(u64, Word)> = Vec::with_capacity(notes.len() * 2);
+
+    for (index, note) in notes.iter().enumerate() {
+        let note_hash = note.note_hash.clone().ok_or(StateError::MissingNoteHash)?;
+        let account_id = note.sender.try_into().or(Err(StateError::InvalidAccountId))?;
+        let note_metadata = NoteMetadata::new(account_id, note.tag.into(), note.num_assets.into());
+        let index = (index as u64) * 2;
+        entries.push((index, note_hash.try_into()?));
+        entries.push((index + 1, note_metadata.into()));
+    }
+
+    Ok(SimpleSmt::with_leaves(NOTE_LEAF_DEPTH, entries)?)
+}
+
 #[instrument(skip(db))]
 async fn load_nullifier_tree(db: &mut Db) -> Result<TieredSmt> {
-    let nullifiers = db.get_nullifiers().await?;
+    let nullifiers = db.select_nullifiers().await?;
     let len = nullifiers.len();
-    let leaves = nullifiers.into_iter().map(|(nullifier, block)| {
-        (nullifier, [Felt::new(block as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO])
-    });
+    let leaves = nullifiers
+        .into_iter()
+        .map(|(nullifier, block)| (nullifier, block_to_nullifier_data(block)));
 
     let now = Instant::now();
     let nullifier_tree = TieredSmt::with_entries(leaves)?;
@@ -238,10 +454,8 @@ async fn load_nullifier_tree(db: &mut Db) -> Result<TieredSmt> {
 
 #[instrument(skip(db))]
 async fn load_mmr(db: &mut Db) -> Result<Mmr> {
-    use miden_objects::BlockHeader;
-
     let block_hashes: Result<Vec<RpoDigest>, ParseError> = db
-        .get_block_headers()
+        .select_block_headers()
         .await?
         .into_iter()
         .map(|b| b.try_into().map(|b: BlockHeader| b.hash()))
@@ -254,7 +468,7 @@ async fn load_mmr(db: &mut Db) -> Result<Mmr> {
 #[instrument(skip(db))]
 async fn load_accounts(db: &mut Db) -> Result<SimpleSmt> {
     let account_data: Result<Vec<(u64, Word)>> = db
-        .get_account_hashes()
+        .select_account_hashes()
         .await?
         .into_iter()
         .map(|(id, account_hash)| Ok((id, account_hash.try_into()?)))


### PR DESCRIPTION
fixes #19 

Notes:

- As with the other endpoints, the message here does not include values that can be computed locally. Namely the nullifiers/account/mmr roots. this is inline with the requests from @bobbinth on previous requests, and the suggestion from @plafer to remove unnecessary validation for the internal system.
- Because the data structures do not support multiple versions, they must be copied before applying the changes. I have created issues on crypto to discuss this.