### PR TITLE
Block: `created_notes` is now `NoteEnvelope`

### DIFF
--- a/block-producer/src/batch_builder/mod.rs
+++ b/block-producer/src/batch_builder/mod.rs
@@ -18,7 +18,7 @@ pub(crate) const CREATED_NOTES_SMT_DEPTH: u8 = 13;
 /// That is, conceptually, notes sit at depth 12; where in reality, depth 12 contains the
 /// hash of level 13, where both the `note_hash()` and metadata are stored (one per node).
 pub(crate) const MAX_NUM_CREATED_NOTES_PER_BATCH: usize =
-    2usize.pow((CREATED_NOTES_SMT_DEPTH - 1) as u32);
+    2_usize.pow((CREATED_NOTES_SMT_DEPTH - 1) as u32);
 
 // TRANSACTION BATCH
 // ================================================================================================

--- a/block-producer/src/batch_builder/mod.rs
+++ b/block-producer/src/batch_builder/mod.rs
@@ -17,7 +17,8 @@ pub(crate) const CREATED_NOTES_SMT_DEPTH: u8 = 13;
 /// The created notes tree uses an extra depth to store the 2 components of `NoteEnvelope`.
 /// That is, conceptually, notes sit at depth 12; where in reality, depth 12 contains the
 /// hash of level 13, where both the `note_hash()` and metadata are stored (one per node).
-const MAX_NUM_CREATED_NOTES_PER_BATCH: usize = 2usize.pow((CREATED_NOTES_SMT_DEPTH - 1) as u32);
+pub(crate) const MAX_NUM_CREATED_NOTES_PER_BATCH: usize =
+    2usize.pow((CREATED_NOTES_SMT_DEPTH - 1) as u32);
 
 // TRANSACTION BATCH
 // ================================================================================================

--- a/block-producer/src/block.rs
+++ b/block-producer/src/block.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeMap;
+
 use miden_objects::{accounts::AccountId, notes::NoteEnvelope, BlockHeader, Digest};
 
 #[derive(Debug, Clone)]
 pub struct Block {
     pub header: BlockHeader,
     pub updated_accounts: Vec<(AccountId, Digest)>,
-    pub created_notes: Vec<NoteEnvelope>,
+    pub created_notes: BTreeMap<u64, NoteEnvelope>,
     pub produced_nullifiers: Vec<Digest>,
     // TODO:
     // - full states for updated public accounts

--- a/block-producer/src/block.rs
+++ b/block-producer/src/block.rs
@@ -1,10 +1,10 @@
-use miden_objects::{accounts::AccountId, BlockHeader, Digest};
+use miden_objects::{accounts::AccountId, notes::NoteEnvelope, BlockHeader, Digest};
 
 #[derive(Debug, Clone)]
 pub struct Block {
     pub header: BlockHeader,
     pub updated_accounts: Vec<(AccountId, Digest)>,
-    pub created_notes: Vec<Digest>,
+    pub created_notes: Vec<NoteEnvelope>,
     pub produced_nullifiers: Vec<Digest>,
     // TODO:
     // - full states for updated public accounts

--- a/block-producer/src/block_builder/mod.rs
+++ b/block-producer/src/block_builder/mod.rs
@@ -61,8 +61,8 @@ where
     ) -> Result<(), BuildBlockError> {
         let account_updates: Vec<(AccountId, Digest)> =
             batches.iter().flat_map(|batch| batch.updated_accounts()).collect();
-        let created_notes: Vec<Digest> =
-            batches.iter().flat_map(|batch| batch.created_notes()).collect();
+        let created_notes =
+            batches.iter().flat_map(|batch| batch.created_notes()).cloned().collect();
         let produced_nullifiers: Vec<Digest> =
             batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();
 

--- a/block-producer/src/test_utils/block.rs
+++ b/block-producer/src/test_utils/block.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use miden_node_proto::domain::BlockInputs;
 use miden_objects::{
@@ -100,7 +100,7 @@ pub struct MockBlockBuilder {
     last_block_header: BlockHeader,
 
     updated_accounts: Option<Vec<(AccountId, Digest)>>,
-    created_notes: Option<Vec<NoteEnvelope>>,
+    created_notes: Option<BTreeMap<u64, NoteEnvelope>>,
     produced_nullifiers: Option<Vec<Digest>>,
 }
 
@@ -134,7 +134,7 @@ impl MockBlockBuilder {
 
     pub fn created_notes(
         mut self,
-        created_notes: Vec<NoteEnvelope>,
+        created_notes: BTreeMap<u64, NoteEnvelope>,
     ) -> Self {
         self.created_notes = Some(created_notes);
 

--- a/block-producer/src/test_utils/block.rs
+++ b/block-producer/src/test_utils/block.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use miden_node_proto::domain::BlockInputs;
-use miden_objects::{accounts::AccountId, crypto::merkle::Mmr, BlockHeader, Digest, ONE, ZERO};
+use miden_objects::{
+    accounts::AccountId, crypto::merkle::Mmr, notes::NoteEnvelope, BlockHeader, Digest, ONE, ZERO,
+};
 use miden_vm::crypto::SimpleSmt;
 
 use super::MockStoreSuccess;
@@ -98,7 +100,7 @@ pub struct MockBlockBuilder {
     last_block_header: BlockHeader,
 
     updated_accounts: Option<Vec<(AccountId, Digest)>>,
-    created_notes: Option<Vec<Digest>>,
+    created_notes: Option<Vec<NoteEnvelope>>,
     produced_nullifiers: Option<Vec<Digest>>,
 }
 
@@ -132,7 +134,7 @@ impl MockBlockBuilder {
 
     pub fn created_notes(
         mut self,
-        created_notes: Vec<Digest>,
+        created_notes: Vec<NoteEnvelope>,
     ) -> Self {
         self.created_notes = Some(created_notes);
 


### PR DESCRIPTION
Fixes the inconsistency with what the store expects