### PR TITLE
store: reduce note message size

### DIFF
--- a/proto/proto/requests.proto
+++ b/proto/proto/requests.proto
@@ -4,18 +4,25 @@ package requests;
 import "account_id.proto";
 import "block_header.proto";
 import "digest.proto";
-import "note.proto";
 
 message AccountUpdate {
     account_id.AccountId account_id = 1;
     digest.Digest account_hash = 2;
 }
 
+message NoteCreated {
+    digest.Digest note_hash = 1;
+    uint64 sender  = 2;
+    uint64 tag = 3;
+    uint32 num_assets = 4;
+    uint32 note_index = 5;
+}
+
 message ApplyBlockRequest {
     block_header.BlockHeader block = 1;
     repeated AccountUpdate accounts = 2;
     repeated digest.Digest nullifiers = 3;
-    repeated note.Note notes = 4;
+    repeated NoteCreated notes = 4;
 }
 
 message CheckNullifiersRequest {

--- a/proto/src/generated/requests.rs
+++ b/proto/src/generated/requests.rs
@@ -10,6 +10,21 @@ pub struct AccountUpdate {
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NoteCreated {
+    #[prost(message, optional, tag = "1")]
+    pub note_hash: ::core::option::Option<super::digest::Digest>,
+    #[prost(uint64, tag = "2")]
+    pub sender: u64,
+    #[prost(uint64, tag = "3")]
+    pub tag: u64,
+    #[prost(uint32, tag = "4")]
+    pub num_assets: u32,
+    #[prost(uint32, tag = "5")]
+    pub note_index: u32,
+}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ApplyBlockRequest {
     #[prost(message, optional, tag = "1")]
     pub block: ::core::option::Option<super::block_header::BlockHeader>,
@@ -18,7 +33,7 @@ pub struct ApplyBlockRequest {
     #[prost(message, repeated, tag = "3")]
     pub nullifiers: ::prost::alloc::vec::Vec<super::digest::Digest>,
     #[prost(message, repeated, tag = "4")]
-    pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
+    pub notes: ::prost::alloc::vec::Vec<NoteCreated>,
 }
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
Instead of requiring block producer to create a merkle tree to obtain the merkle paths, this uses the locally computed tree to retrieve the authentication path. Simplifying the block producer code and reducing the created note message size.