### PR TITLE
Consolidate note messages

### DIFF
--- a/proto/proto/note.proto
+++ b/proto/proto/note.proto
@@ -4,12 +4,33 @@ package note;
 import "digest.proto";
 import "merkle.proto";
 
+// TODO: remove this message as it can be replaced by an internal domain type in the Store
+// component
 message Note {
     uint32 block_num = 1;
     uint32 note_index = 2;
     digest.Digest note_hash = 3;
-    uint64 sender  = 4;
+    fixed64 sender  = 4;
     uint64 tag = 5;
     uint32 num_assets = 6;
     merkle.MerklePath merkle_path = 7;
+}
+
+// TODO: change `sender` to AccountId
+message NoteSyncRecord {
+    uint32 note_index = 1;
+    digest.Digest note_hash = 2;
+    fixed64 sender  = 3;
+    uint64 tag = 4;
+    uint32 num_assets = 5;
+    merkle.MerklePath merkle_path = 6;
+}
+
+// TODO: change `sender` to AccountId
+message NoteCreated {
+    uint32 note_index = 1;
+    digest.Digest note_hash = 2;
+    fixed64 sender  = 3;
+    uint64 tag = 4;
+    uint32 num_assets = 5;
 }

--- a/proto/proto/requests.proto
+++ b/proto/proto/requests.proto
@@ -4,25 +4,18 @@ package requests;
 import "account_id.proto";
 import "block_header.proto";
 import "digest.proto";
+import "note.proto";
 
 message AccountUpdate {
     account_id.AccountId account_id = 1;
     digest.Digest account_hash = 2;
 }
 
-message NoteCreated {
-    digest.Digest note_hash = 1;
-    uint64 sender  = 2;
-    uint64 tag = 3;
-    uint32 num_assets = 4;
-    uint32 note_index = 5;
-}
-
 message ApplyBlockRequest {
     block_header.BlockHeader block = 1;
     repeated AccountUpdate accounts = 2;
     repeated digest.Digest nullifiers = 3;
-    repeated NoteCreated notes = 4;
+    repeated note.NoteCreated notes = 4;
 }
 
 message CheckNullifiersRequest {

--- a/proto/proto/responses.proto
+++ b/proto/proto/responses.proto
@@ -6,6 +6,7 @@ import "block_header.proto";
 import "digest.proto";
 import "merkle.proto";
 import "mmr.proto";
+import "note.proto";
 import "tsmt.proto";
 
 message ApplyBlockResponse {}
@@ -31,15 +32,6 @@ message NullifierUpdate {
     uint32 block_num = 2;
 }
 
-message NoteSyncRecord {
-    uint32 note_index = 1;
-    digest.Digest note_hash = 2;
-    uint64 sender  = 3;
-    uint64 tag = 4;
-    uint32 num_assets = 5;
-    merkle.MerklePath merkle_path = 6;
-}
-
 message SyncStateResponse {
     // number of the latest block in the chain
     uint32 chain_tip = 1;
@@ -57,7 +49,7 @@ message SyncStateResponse {
     repeated AccountHashUpdate accounts = 5;
 
     // a list of all notes together with the Merkle paths from `block_header.note_root`
-    repeated NoteSyncRecord notes = 6;
+    repeated note.NoteSyncRecord notes = 6;
 
     // a list of nullifiers created between `block_ref` and `block_header.block_num`
     repeated NullifierUpdate nullifiers = 7;

--- a/proto/src/conversion.rs
+++ b/proto/src/conversion.rs
@@ -240,7 +240,7 @@ impl TryFrom<merkle::MerklePath> for MerklePath {
     }
 }
 
-impl From<note::Note> for responses::NoteSyncRecord {
+impl From<note::Note> for note::NoteSyncRecord {
     fn from(value: note::Note) -> Self {
         Self {
             note_index: value.note_index,
@@ -363,7 +363,7 @@ impl From<(AccountId, RpoDigest)> for requests::AccountUpdate {
     }
 }
 
-impl From<(u64, NoteEnvelope)> for requests::NoteCreated {
+impl From<(u64, NoteEnvelope)> for note::NoteCreated {
     fn from((note_idx, note): (u64, NoteEnvelope)) -> Self {
         Self {
             note_hash: Some(note.note_hash().into()),

--- a/proto/src/generated/note.rs
+++ b/proto/src/generated/note.rs
@@ -1,3 +1,5 @@
+/// TODO: remove this message as it can be replaced by an internal domain type in the Store
+/// component
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -8,7 +10,7 @@ pub struct Note {
     pub note_index: u32,
     #[prost(message, optional, tag = "3")]
     pub note_hash: ::core::option::Option<super::digest::Digest>,
-    #[prost(uint64, tag = "4")]
+    #[prost(fixed64, tag = "4")]
     pub sender: u64,
     #[prost(uint64, tag = "5")]
     pub tag: u64,
@@ -16,4 +18,38 @@ pub struct Note {
     pub num_assets: u32,
     #[prost(message, optional, tag = "7")]
     pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
+}
+/// TODO: change `sender` to AccountId
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NoteSyncRecord {
+    #[prost(uint32, tag = "1")]
+    pub note_index: u32,
+    #[prost(message, optional, tag = "2")]
+    pub note_hash: ::core::option::Option<super::digest::Digest>,
+    #[prost(fixed64, tag = "3")]
+    pub sender: u64,
+    #[prost(uint64, tag = "4")]
+    pub tag: u64,
+    #[prost(uint32, tag = "5")]
+    pub num_assets: u32,
+    #[prost(message, optional, tag = "6")]
+    pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
+}
+/// TODO: change `sender` to AccountId
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NoteCreated {
+    #[prost(uint32, tag = "1")]
+    pub note_index: u32,
+    #[prost(message, optional, tag = "2")]
+    pub note_hash: ::core::option::Option<super::digest::Digest>,
+    #[prost(fixed64, tag = "3")]
+    pub sender: u64,
+    #[prost(uint64, tag = "4")]
+    pub tag: u64,
+    #[prost(uint32, tag = "5")]
+    pub num_assets: u32,
 }

--- a/proto/src/generated/requests.rs
+++ b/proto/src/generated/requests.rs
@@ -10,21 +10,6 @@ pub struct AccountUpdate {
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NoteCreated {
-    #[prost(message, optional, tag = "1")]
-    pub note_hash: ::core::option::Option<super::digest::Digest>,
-    #[prost(uint64, tag = "2")]
-    pub sender: u64,
-    #[prost(uint64, tag = "3")]
-    pub tag: u64,
-    #[prost(uint32, tag = "4")]
-    pub num_assets: u32,
-    #[prost(uint32, tag = "5")]
-    pub note_index: u32,
-}
-#[derive(Eq, PartialOrd, Ord, Hash)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ApplyBlockRequest {
     #[prost(message, optional, tag = "1")]
     pub block: ::core::option::Option<super::block_header::BlockHeader>,
@@ -33,7 +18,7 @@ pub struct ApplyBlockRequest {
     #[prost(message, repeated, tag = "3")]
     pub nullifiers: ::prost::alloc::vec::Vec<super::digest::Digest>,
     #[prost(message, repeated, tag = "4")]
-    pub notes: ::prost::alloc::vec::Vec<NoteCreated>,
+    pub notes: ::prost::alloc::vec::Vec<super::note::NoteCreated>,
 }
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/generated/responses.rs
+++ b/proto/src/generated/responses.rs
@@ -41,23 +41,6 @@ pub struct NullifierUpdate {
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NoteSyncRecord {
-    #[prost(uint32, tag = "1")]
-    pub note_index: u32,
-    #[prost(message, optional, tag = "2")]
-    pub note_hash: ::core::option::Option<super::digest::Digest>,
-    #[prost(uint64, tag = "3")]
-    pub sender: u64,
-    #[prost(uint64, tag = "4")]
-    pub tag: u64,
-    #[prost(uint32, tag = "5")]
-    pub num_assets: u32,
-    #[prost(message, optional, tag = "6")]
-    pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
-}
-#[derive(Eq, PartialOrd, Ord, Hash)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncStateResponse {
     /// number of the latest block in the chain
     #[prost(uint32, tag = "1")]
@@ -76,7 +59,7 @@ pub struct SyncStateResponse {
     pub accounts: ::prost::alloc::vec::Vec<AccountHashUpdate>,
     /// a list of all notes together with the Merkle paths from `block_header.note_root`
     #[prost(message, repeated, tag = "6")]
-    pub notes: ::prost::alloc::vec::Vec<NoteSyncRecord>,
+    pub notes: ::prost::alloc::vec::Vec<super::note::NoteSyncRecord>,
     /// a list of nullifiers created between `block_ref` and `block_header.block_num`
     #[prost(message, repeated, tag = "7")]
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierUpdate>,

--- a/store/src/db/mod.rs
+++ b/store/src/db/mod.rs
@@ -141,7 +141,7 @@ impl Db {
     /// Inserts the data of a new block into the DB.
     ///
     /// `allow_acquire` and `acquire_done` are used to synchronize writes to the DB with writes to
-    /// the in-memory trees. Further detais available on [super::state::State::apply_block].
+    /// the in-memory trees. Further details available on [super::state::State::apply_block].
     pub async fn apply_block(
         &self,
         allow_acquire: oneshot::Sender<()>,

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -17,8 +17,8 @@ use miden_node_proto::{
     conversion::nullifier_value_to_blocknum,
     digest::Digest,
     error::ParseError,
-    note::Note,
-    requests::{AccountUpdate, NoteCreated},
+    note::{Note, NoteCreated},
+    requests::AccountUpdate,
     responses::{
         AccountBlockInputRecord, AccountTransactionInputRecord, NullifierTransactionInputRecord,
     },


### PR DESCRIPTION
This small PR just moves all note-related messages into `note.proto` file. Other changes:

- Left a few TODOs for the future.
- Re-ordered some fields to ensure consistent ordering.
- Changed data type of `sender` to `fixed64` (in the future should be changed to `AccountId`).