### PR TITLE
config: node with a single config file

### DIFF
--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -15,11 +15,6 @@ path = "src/main.rs"
 bench = false
 doctest = false
 
-[dev-dependencies]
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main", default-features = false }
-once_cell = { version = "1.18" }
-winterfell = "0.7"
-
 [dependencies]
 anyhow = { version = "1.0" }
 async-trait = { version = "0.1" }
@@ -41,3 +36,9 @@ toml = { version = "0.8" }
 tonic = { version = "0.10" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+figment = { version = "0.10", features = ["toml", "env", "test"] }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main", default-features = false }
+once_cell = { version = "1.18" }
+winterfell = "0.7"

--- a/block-producer/src/config.rs
+++ b/block-producer/src/config.rs
@@ -1,58 +1,94 @@
-use std::fmt::Display;
-
+use miden_node_store::config::StoreConfig;
+use miden_node_utils::config::{Config, HostPort};
 use serde::{Deserialize, Serialize};
 
 pub const HOST: &str = "localhost";
 // defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
 pub const PORT: u16 = 48046;
-pub const ENV_PREFIX: &str = "MIDEN_BLOCK_PRODUCER";
 pub const CONFIG_FILENAME: &str = "miden-block-producer.toml";
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
-pub struct Endpoint {
-    /// The host device the server will bind to.
-    pub host: String,
-    /// The port number to bind the server to.
-    pub port: u16,
-}
+// Main config
+// ================================================================================================
 
+/// Block producer specific configuration
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct BlockProducerConfig {
-    /// Main endpoint of the server.
-    pub endpoint: Endpoint,
+    pub host_port: HostPort,
 
-    /// Endpoint of the store gRPC server
+    /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_endpoint: String,
-}
-
-impl Default for Endpoint {
-    fn default() -> Self {
-        Self {
-            host: HOST.to_string(),
-            port: PORT,
-        }
-    }
-}
-
-impl Display for Endpoint {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}:{}", self.host, self.port)
-    }
 }
 
 impl Default for BlockProducerConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::default(),
-            store_endpoint: format!("http://localhost:{}", miden_node_store::config::PORT),
+            host_port: HostPort {
+                host: HOST.to_string(),
+                port: PORT,
+            },
+            store_endpoint: StoreConfig::default().as_endpoint(),
         }
     }
 }
 
-impl miden_node_utils::Config for BlockProducerConfig {
-    const ENV_PREFIX: &'static str = ENV_PREFIX;
+impl BlockProducerConfig {
+    pub fn as_endpoint(&self) -> String {
+        format!("http://{}:{}", self.host_port.host, self.host_port.port)
+    }
+}
+
+// Top-level config
+// ================================================================================================
+
+/// Block producer top-level configuration.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
+pub struct BlockProducerTopLevelConfig {
+    pub block_producer: BlockProducerConfig,
+}
+
+impl Config for BlockProducerTopLevelConfig {
     const CONFIG_FILENAME: &'static str = CONFIG_FILENAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+    use miden_node_utils::{config::HostPort, Config};
+
+    use super::{BlockProducerConfig, BlockProducerTopLevelConfig, CONFIG_FILENAME};
+
+    #[test]
+    fn test_block_producer_config() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                CONFIG_FILENAME,
+                r#"
+                    [block_producer]
+                    store_endpoint = "http://store:8000"
+
+                    [block_producer.host_port]
+                    host = "127.0.0.1"
+                    port = 8080
+                "#,
+            )?;
+
+            let config: BlockProducerTopLevelConfig =
+                BlockProducerTopLevelConfig::load_config(None).extract()?;
+
+            assert_eq!(
+                config,
+                BlockProducerTopLevelConfig {
+                    block_producer: BlockProducerConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        store_endpoint: "http://store:8000".to_string(),
+                    }
+                }
+            );
+
+            Ok(())
+        });
+    }
 }

--- a/block-producer/src/main.rs
+++ b/block-producer/src/main.rs
@@ -2,22 +2,22 @@ use anyhow::Result;
 use clap::Parser;
 use miden_node_block_producer::{
     cli::{Cli, Command},
-    config::BlockProducerConfig,
+    config::BlockProducerTopLevelConfig,
     server,
 };
-use miden_node_utils::Config;
+use miden_node_utils::config::Config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     miden_node_utils::logging::setup_logging()?;
 
     let cli = Cli::parse();
-    let config: BlockProducerConfig =
-        BlockProducerConfig::load_config(cli.config.as_deref()).extract()?;
+    let config: BlockProducerTopLevelConfig =
+        BlockProducerTopLevelConfig::load_config(cli.config.as_deref()).extract()?;
 
     match cli.command {
         Command::Serve { .. } => {
-            server::api::serve(config).await?;
+            server::api::serve(config.block_producer).await?;
         },
     }
 

--- a/block-producer/src/server/api.rs
+++ b/block-producer/src/server/api.rs
@@ -184,7 +184,7 @@ where
 }
 
 pub async fn serve(config: BlockProducerConfig) -> Result<()> {
-    let host_port = (config.endpoint.host.as_ref(), config.endpoint.port);
+    let host_port = (config.host_port.host.as_ref(), config.host_port.port);
     let addrs: Vec<_> = host_port.to_socket_addrs()?.collect();
 
     let store = Arc::new(DefaultStore {
@@ -225,8 +225,8 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
 
     info!(
         COMPONENT,
-        host = config.endpoint.host,
-        port = config.endpoint.port,
+        host = config.host_port.host,
+        port = config.host_port.port,
         "Server initialized",
     );
     Server::builder().add_service(block_producer).serve(addrs[0]).await?;

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,6 +15,10 @@ miden-node-block-producer = { version = "0.1", path = "../block-producer" }
 miden-node-rpc = { version = "0.1", path = "../rpc" }
 miden-node-store = { version = "0.1", path = "../store" }
 miden-node-utils = { path = "../utils" }
+serde = { version = "1.0" , features = ["derive"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+figment = { version = "0.10", features = ["toml", "env", "test"] }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,0 +1,150 @@
+use miden_node_block_producer::config::BlockProducerConfig;
+use miden_node_rpc::config::RpcConfig;
+use miden_node_store::config::StoreConfig;
+use miden_node_utils::config::Config;
+use serde::{Deserialize, Serialize};
+
+pub const CONFIG_FILENAME: &str = "miden-node.toml";
+
+// Top-level config
+// ================================================================================================
+
+/// Node top-level configuration.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
+pub struct NodeTopLevelConfig {
+    pub block_producer: BlockProducerConfig,
+    pub rpc: RpcConfig,
+    pub store: StoreConfig,
+}
+
+impl Config for NodeTopLevelConfig {
+    const CONFIG_FILENAME: &'static str = CONFIG_FILENAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+    use miden_node_block_producer::config::BlockProducerConfig;
+    use miden_node_rpc::config::RpcConfig;
+    use miden_node_store::config::StoreConfig;
+    use miden_node_utils::{config::HostPort, Config};
+
+    use super::{NodeTopLevelConfig, CONFIG_FILENAME};
+
+    #[test]
+    fn test_node_config() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                CONFIG_FILENAME,
+                r#"
+                    [block_producer]
+                    store_endpoint = "http://store:8000"
+
+                    [block_producer.host_port]
+                    host = "127.0.0.1"
+                    port = 8080
+
+                    [rpc]
+                    store_endpoint = "http://store:8000"
+                    block_producer_endpoint = "http://block_producer:8001"
+                    host_port = { host = "127.0.0.1",  port = 8080 }
+
+                    [store]
+                    sqlite = "local.sqlite3"
+
+                    [store.host_port]
+                    host = "127.0.0.1"
+                    port = 8080
+                "#,
+            )?;
+
+            let config: NodeTopLevelConfig = NodeTopLevelConfig::load_config(None).extract()?;
+
+            assert_eq!(
+                config,
+                NodeTopLevelConfig {
+                    block_producer: BlockProducerConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        store_endpoint: "http://store:8000".to_string(),
+                    },
+                    rpc: RpcConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        store_endpoint: "http://store:8000".to_string(),
+                        block_producer_endpoint: "http://block_producer:8001".to_string(),
+                    },
+                    store: StoreConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        sqlite: "local.sqlite3".into(),
+                    },
+                }
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_node_config_env() {
+        Jail::expect_with(|jail| {
+            // Block producer
+            // ------------------------------------------------------------------------------------
+            jail.set_env("MIDEN__BLOCK_PRODUCER__STORE_ENDPOINT", "http://store:8000");
+            jail.set_env("MIDEN__BLOCK_PRODUCER__HOST_PORT__HOST", "127.0.0.1");
+            jail.set_env("MIDEN__BLOCK_PRODUCER__HOST_PORT__PORT", 8080);
+
+            // Rpc
+            // ------------------------------------------------------------------------------------
+            jail.set_env("MIDEN__RPC__STORE_ENDPOINT", "http://store:8000");
+            jail.set_env("MIDEN__RPC__BLOCK_PRODUCER_ENDPOINT", "http://block_producer:8001");
+            jail.set_env("MIDEN__RPC__HOST_PORT__HOST", "127.0.0.1");
+            jail.set_env("MIDEN__RPC__HOST_PORT__PORT", 8080);
+
+            // Store
+            // ------------------------------------------------------------------------------------
+            jail.set_env("MIDEN__STORE__SQLITE", "local.sqlite3");
+            jail.set_env("MIDEN__STORE__HOST_PORT__HOST", "127.0.0.1");
+            jail.set_env("MIDEN__STORE__HOST_PORT__PORT", 8080);
+
+            let config: NodeTopLevelConfig = NodeTopLevelConfig::load_config(None).extract()?;
+
+            assert_eq!(
+                config,
+                NodeTopLevelConfig {
+                    block_producer: BlockProducerConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        store_endpoint: "http://store:8000".to_string(),
+                    },
+                    rpc: RpcConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        store_endpoint: "http://store:8000".to_string(),
+                        block_producer_endpoint: "http://block_producer:8001".to_string(),
+                    },
+                    store: StoreConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        sqlite: "local.sqlite3".into(),
+                    },
+                }
+            );
+
+            Ok(())
+        });
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,60 +1,32 @@
-use std::{path::PathBuf, time::Duration};
+use std::{path::Path, time::Duration};
 
-use miden_node_block_producer::{
-    config as block_producer_config, config::BlockProducerConfig, server as block_producer_server,
-};
-use miden_node_rpc::{config as rpc_config, config::RpcConfig, server as rpc_server};
-use miden_node_store::{
-    config::{self as store_config, StoreConfig},
-    db::Db,
-    server as store_server,
-};
+use config::{NodeTopLevelConfig, CONFIG_FILENAME};
+use miden_node_block_producer::server as block_producer_server;
+use miden_node_rpc::server as rpc_server;
+use miden_node_store::{db::Db, server as store_server};
 use miden_node_utils::Config;
 use tokio::task::JoinSet;
+
+mod config;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     miden_node_utils::logging::setup_logging()?;
 
+    let config: NodeTopLevelConfig =
+        NodeTopLevelConfig::load_config(Some(Path::new(CONFIG_FILENAME))).extract()?;
+
     let mut join_set = JoinSet::new();
+    let db = Db::get_conn(config.store.clone()).await?;
+    join_set.spawn(store_server::api::serve(config.store, db));
 
-    // start store
-    {
-        let config: StoreConfig = {
-            let config_path = PathBuf::from(store_config::CONFIG_FILENAME);
-
-            StoreConfig::load_config(Some(config_path).as_deref()).extract()?
-        };
-
-        let db = Db::get_conn(config.clone()).await?;
-
-        join_set.spawn(store_server::api::serve(config, db));
-    }
-
-    // wait for store to be started
+    // wait for store before starting block producer
     tokio::time::sleep(Duration::from_secs(1)).await;
+    join_set.spawn(block_producer_server::api::serve(config.block_producer));
 
-    // start block-producer
-    {
-        let config: BlockProducerConfig = {
-            let config_path = PathBuf::from(block_producer_config::CONFIG_FILENAME);
-
-            BlockProducerConfig::load_config(Some(config_path).as_deref()).extract()?
-        };
-
-        join_set.spawn(block_producer_server::api::serve(config));
-    }
-
-    // start rpc
-    {
-        let config: RpcConfig = {
-            let config_path = PathBuf::from(rpc_config::CONFIG_FILENAME);
-
-            RpcConfig::load_config(Some(config_path).as_deref()).extract()?
-        };
-
-        join_set.spawn(rpc_server::api::serve(config));
-    }
+    // wait for blockproducer before starting rpc
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    join_set.spawn(rpc_server::api::serve(config.rpc));
 
     // block on all tasks
     while let Some(_res) = join_set.join_next().await {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -33,3 +33,6 @@ miette = { version = "5.9", features = ["fancy"] }
 prost = { version = "0.12" }
 protox = { version = "0.5" }
 tonic-build = { version = "0.10" }
+
+[dev-dependencies]
+figment = { version = "0.10", features = ["toml", "env", "test"] }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -1,61 +1,97 @@
-use std::fmt::Display;
-
-use miden_node_store;
+use miden_node_block_producer::config::BlockProducerConfig;
+use miden_node_store::config::StoreConfig;
+use miden_node_utils::config::{Config, HostPort};
 use serde::{Deserialize, Serialize};
 
 pub const HOST: &str = "localhost";
 // defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16
 pub const PORT: u16 = 57291;
-pub const ENV_PREFIX: &str = "MIDEN_RPC";
 pub const CONFIG_FILENAME: &str = "miden-rpc.toml";
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
-pub struct Endpoint {
-    /// The host device the server will bind to.
-    pub host: String,
-    /// The port number to bind the server to.
-    pub port: u16,
-}
+// Main config
+// ================================================================================================
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct RpcConfig {
-    /// Main endpoint of the server.
-    pub endpoint: Endpoint,
-    /// Address of the store server in the format `http://<host>[:<port>]`.
-    pub store: String,
-    /// Address of the store server in the format `http://<host>[:<port>]`.
-    pub block_producer: String,
-}
-
-impl Default for Endpoint {
-    fn default() -> Self {
-        Self {
-            host: HOST.to_string(),
-            port: PORT,
-        }
-    }
-}
-
-impl Display for Endpoint {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}:{}", self.host, self.port)
-    }
+    pub host_port: HostPort,
+    /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
+    pub store_endpoint: String,
+    /// Block producer gRPC endpoint in the format `http://<host>[:<port>]`.
+    pub block_producer_endpoint: String,
 }
 
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::default(),
-            store: format!("http://localhost:{}", miden_node_store::config::PORT),
-            block_producer: format!("http://localhost:{}", miden_node_block_producer::config::PORT),
+            host_port: HostPort {
+                host: HOST.to_string(),
+                port: PORT,
+            },
+            store_endpoint: StoreConfig::default().as_endpoint(),
+            block_producer_endpoint: BlockProducerConfig::default().as_endpoint(),
         }
     }
 }
 
-impl miden_node_utils::Config for RpcConfig {
-    const ENV_PREFIX: &'static str = ENV_PREFIX;
+impl RpcConfig {
+    pub fn as_endpoint(&self) -> String {
+        format!("http://{}:{}", self.host_port.host, self.host_port.port)
+    }
+}
+
+// Top-level config
+// ================================================================================================
+
+/// Rpc top-level configuration.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
+pub struct RpcTopLevelConfig {
+    pub rpc: RpcConfig,
+}
+
+impl Config for RpcTopLevelConfig {
     const CONFIG_FILENAME: &'static str = CONFIG_FILENAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+    use miden_node_utils::{config::HostPort, Config};
+
+    use super::{RpcConfig, RpcTopLevelConfig, CONFIG_FILENAME};
+
+    #[test]
+    fn test_rpc_config() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                CONFIG_FILENAME,
+                r#"
+                    [rpc]
+                    store_endpoint = "http://store:8000"
+                    block_producer_endpoint = "http://block_producer:8001"
+
+                    [rpc.host_port]
+                    host = "127.0.0.1"
+                    port = 8080
+                "#,
+            )?;
+
+            let config: RpcTopLevelConfig = RpcTopLevelConfig::load_config(None).extract()?;
+
+            assert_eq!(
+                config,
+                RpcTopLevelConfig {
+                    rpc: RpcConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        store_endpoint: "http://store:8000".to_string(),
+                        block_producer_endpoint: "http://block_producer:8001".to_string(),
+                    }
+                }
+            );
+
+            Ok(())
+        });
+    }
 }

--- a/rpc/src/main.rs
+++ b/rpc/src/main.rs
@@ -5,7 +5,7 @@ use cli::{Cli, Command, Request};
 use hex::ToHex;
 use miden_crypto::merkle::{path_to_text, TieredSmtProof};
 use miden_node_proto::{requests::CheckNullifiersRequest, rpc::api_client, tsmt::NullifierProof};
-use miden_node_rpc::{config::RpcConfig, server::api};
+use miden_node_rpc::{config::RpcTopLevelConfig, server::api};
 use miden_node_utils::Config;
 
 #[tokio::main]
@@ -14,15 +14,17 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let config = RpcConfig::load_config(cli.config.as_deref()).extract()?;
+    let config: RpcTopLevelConfig =
+        RpcTopLevelConfig::load_config(cli.config.as_deref()).extract()?;
 
     match cli.command {
         Command::Serve => {
-            api::serve(config).await?;
+            api::serve(config.rpc).await?;
         },
         Command::Request(req) => match req {
             Request::CheckNullifiers { nullifiers } => {
-                let host_port = format!("http://{}:{}", config.endpoint.host, config.endpoint.port);
+                let host_port =
+                    format!("http://{}:{}", config.rpc.host_port.host, config.rpc.host_port.port);
                 let mut client = api_client::ApiClient::connect(host_port).await?;
                 let request = tonic::Request::new(CheckNullifiersRequest {
                     nullifiers: nullifiers.clone(),

--- a/rpc/src/server/api.rs
+++ b/rpc/src/server/api.rs
@@ -30,14 +30,15 @@ pub struct RpcApi {
 
 impl RpcApi {
     async fn from_config(config: &RpcConfig) -> Result<Self, Error> {
-        let store = store_client::ApiClient::connect(config.store.clone()).await?;
-        info!(COMPONENT, store = config.store, "Store client initialized",);
+        let store = store_client::ApiClient::connect(config.store_endpoint.clone()).await?;
+        info!(COMPONENT, store_endpoint = config.store_endpoint, "Store client initialized");
 
         let block_producer =
-            block_producer_client::ApiClient::connect(config.block_producer.clone()).await?;
+            block_producer_client::ApiClient::connect(config.block_producer_endpoint.clone())
+                .await?;
         info!(
             COMPONENT,
-            block_producer = config.block_producer,
+            block_producer_endpoint = config.block_producer_endpoint,
             "Block producer client initialized",
         );
 
@@ -87,15 +88,15 @@ impl api_server::Api for RpcApi {
 }
 
 pub async fn serve(config: RpcConfig) -> Result<()> {
-    let host_port = (config.endpoint.host.as_ref(), config.endpoint.port);
+    let host_port = (config.host_port.host.as_ref(), config.host_port.port);
     let addrs: Vec<_> = host_port.to_socket_addrs()?.collect();
 
     let api = RpcApi::from_config(&config).await?;
     let rpc = api_server::ApiServer::new(api);
 
     info!(
-        host = config.endpoint.host,
-        port = config.endpoint.port,
+        host = config.host_port.host,
+        port = config.host_port.port,
         COMPONENT,
         "Server initialized"
     );

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -41,3 +41,6 @@ miette = { version = "5.9", features = ["fancy"] }
 prost = { version = "0.12" }
 protox = { version = "0.5" }
 tonic-build = { version = "0.10" }
+
+[dev-dependencies]
+figment = { version = "0.10", features = ["toml", "env", "test"] }

--- a/store/src/config.rs
+++ b/store/src/config.rs
@@ -1,12 +1,12 @@
-use std::{fmt::Display, path::PathBuf};
+use std::path::PathBuf;
 
+use miden_node_utils::config::{Config, HostPort};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 pub const HOST: &str = "localhost";
 // defined as: sum(ord(c)**p for (p, c) in enumerate('miden-store', 1)) % 2**16
 pub const PORT: u16 = 28943;
-pub const ENV_PREFIX: &str = "MIDEN_STORE";
 pub const CONFIG_FILENAME: &str = "miden-store.toml";
 pub const STORE_FILENAME: &str = "miden-store.sqlite3";
 
@@ -17,50 +17,86 @@ pub static DEFAULT_STORE_PATH: Lazy<PathBuf> = Lazy::new(|| {
         .unwrap_or_default()
 });
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
-pub struct Endpoint {
-    /// The host device the server will bind to.
-    pub host: String,
-    /// The port number to bind the server to.
-    pub port: u16,
-}
+// Main config
+// ================================================================================================
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct StoreConfig {
-    /// Main endpoint of the server.
-    pub endpoint: Endpoint,
+    /// Defines the lisening socket.
+    pub host_port: HostPort,
     /// SQLite database file
     pub sqlite: PathBuf,
-}
-
-impl Default for Endpoint {
-    fn default() -> Self {
-        Self {
-            host: HOST.to_string(),
-            port: PORT,
-        }
-    }
-}
-
-impl Display for Endpoint {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}:{}", self.host, self.port)
-    }
 }
 
 impl Default for StoreConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::default(),
+            host_port: HostPort {
+                host: HOST.to_string(),
+                port: PORT,
+            },
             sqlite: DEFAULT_STORE_PATH.clone(),
         }
     }
 }
 
-impl miden_node_utils::Config for StoreConfig {
-    const ENV_PREFIX: &'static str = ENV_PREFIX;
+impl StoreConfig {
+    pub fn as_endpoint(&self) -> String {
+        format!("http://{}:{}", self.host_port.host, self.host_port.port)
+    }
+}
+
+// Top-level config
+// ================================================================================================
+
+/// Store top-level configuration.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
+pub struct StoreTopLevelConfig {
+    pub store: StoreConfig,
+}
+
+impl Config for StoreTopLevelConfig {
     const CONFIG_FILENAME: &'static str = CONFIG_FILENAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+    use miden_node_utils::Config;
+
+    use super::{HostPort, StoreConfig, StoreTopLevelConfig, CONFIG_FILENAME};
+
+    #[test]
+    fn test_store_config() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                CONFIG_FILENAME,
+                r#"
+                    [store]
+                    sqlite = "local.sqlite3"
+
+                    [store.host_port]
+                    host = "127.0.0.1"
+                    port = 8080
+                "#,
+            )?;
+
+            let config: StoreTopLevelConfig = StoreTopLevelConfig::load_config(None).extract()?;
+
+            assert_eq!(
+                config,
+                StoreTopLevelConfig {
+                    store: StoreConfig {
+                        host_port: HostPort {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
+                        sqlite: "local.sqlite3".into(),
+                    }
+                }
+            );
+
+            Ok(())
+        });
+    }
 }

--- a/store/src/main.rs
+++ b/store/src/main.rs
@@ -2,20 +2,21 @@ mod cli;
 use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, Command};
-use miden_node_store::{config::StoreConfig, db::Db, server};
-use miden_node_utils::Config;
+use miden_node_store::{config::StoreTopLevelConfig, db::Db, server};
+use miden_node_utils::config::Config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     miden_node_utils::logging::setup_logging()?;
 
     let cli = Cli::parse();
-    let config: StoreConfig = StoreConfig::load_config(cli.config.as_deref()).extract()?;
-    let db = Db::get_conn(config.clone()).await?;
+    let config: StoreTopLevelConfig =
+        StoreTopLevelConfig::load_config(cli.config.as_deref()).extract()?;
+    let db = Db::get_conn(config.store.clone()).await?;
 
     match cli.command {
         Command::Serve { .. } => {
-            server::api::serve(config, db).await?;
+            server::api::serve(config.store, db).await?;
         },
     }
 

--- a/store/src/server/api.rs
+++ b/store/src/server/api.rs
@@ -28,15 +28,15 @@ pub async fn serve(
     config: StoreConfig,
     db: Db,
 ) -> Result<()> {
-    let host_port = (config.endpoint.host.as_ref(), config.endpoint.port);
+    let host_port = (config.host_port.host.as_ref(), config.host_port.port);
     let addrs: Vec<_> = host_port.to_socket_addrs()?.collect();
 
     let state = Arc::new(State::load(db).await?);
     let store = api_server::ApiServer::new(StoreApi { state });
 
     info!(
-        host = config.endpoint.host,
-        port = config.endpoint.port,
+        host = config.host_port.host,
+        port = config.host_port.port,
         COMPONENT,
         "Server initialized",
     );

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -5,14 +5,26 @@ use figment::{
     providers::{Env, Format, Serialized, Toml},
     Figment,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-/// Trait with the basic to load configurations for different services.
+/// Environment variable default prefix.
+pub const ENV_PREFIX: &str = "MIDEN__";
+
+/// The `(host, port)` pair for the server's listening socket.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+pub struct HostPort {
+    /// Host used by the store.
+    pub host: String,
+    /// Port number used by the store.
+    pub port: u16,
+}
+
+/// Trait with the basic logic to load configurations for different services.
 ///
 /// This trait makes sure the priority and features are consistent across different services.
 pub trait Config: Default + Serialize {
     const CONFIG_FILENAME: &'static str;
-    const ENV_PREFIX: &'static str;
+    const ENV_PREFIX: &'static str = ENV_PREFIX;
 
     fn load_user_config() -> Option<Figment> {
         let dirs = directories::ProjectDirs::from("", "Polygon", "Miden")?;
@@ -29,7 +41,7 @@ pub trait Config: Default + Serialize {
     }
 
     fn load_env_config() -> Figment {
-        Figment::from(Env::prefixed(Self::ENV_PREFIX))
+        Figment::from(Env::prefixed(Self::ENV_PREFIX).split("__"))
     }
 
     /// Loads the user configuration.


### PR DESCRIPTION
- This renamed the `Endpoint` structs, to make it clear they are not reusable
- Added a endpoint method to render the corresponding `Endpoint` url. (an URL is needed because of the protocol)
- Added a top-level config for each server. This gives a namespace for the individual serve types, allowing them to be in the same file. - Configs are under `store`, `block_producer`, and `rpc` namespaces.
- Added tests for the above.
- Now ENV variables are separated by `__` instead of a `_`. This allow configuration names with `_` to be set via environment variables.

fixes #100