### PR TITLE
Fix logging output

### DIFF
--- a/utils/src/logging.rs
+++ b/utils/src/logging.rs
@@ -4,14 +4,12 @@ use tracing_subscriber::{self, fmt::format::FmtSpan, EnvFilter};
 
 pub fn setup_logging() -> Result<()> {
     let subscriber = tracing_subscriber::fmt()
-        .json()
+        .pretty()
         .compact()
         .with_level(true)
         .with_file(true)
         .with_line_number(true)
-        .with_thread_ids(false)
-        .with_thread_names(true)
-        .with_target(true)
+        .with_target(false)
         .with_env_filter(EnvFilter::from_default_env())
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .finish();


### PR DESCRIPTION
Changes the logging output from:

```
2023-12-20T19:51:01.287915Z  INFO tokio-runtime-worker serve: miden_node_store::server::api: store/src/server/api.rs:38: {"COMPONENT":"miden-store","host":"localhost","message":"Server initialized","port":28943} {}
```

to

```
2023-12-20T19:52:25.752035Z  INFO rpc/src/server/api.rs:97: Server initialized, host: "localhost", port: 57291, COMPONENT: "miden-rpc"
```

Specifically:

- "pretty" output chosen over "json"; I find it much easier to read
- Remove the thread information: it is always `tokio-runtime-worker` anyways so doesn't add valuable information
- `target: false`: This removes the module in which the log occurred, as we already have the exact file & line number where the log occurred (from which I can infer the module if I need to, but typically I mostly look at the span information instead)