### PR TITLE
Move `DefaultStore` in block producer into `store` module

### DIFF
--- a/block-producer/src/main.rs
+++ b/block-producer/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Command::Serve { .. } => {
-            server::api::serve(config.block_producer).await?;
+            server::serve(config.block_producer).await?;
         },
     }
 

--- a/block-producer/src/server/api.rs
+++ b/block-producer/src/server/api.rs
@@ -1,162 +1,30 @@
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
-use async_trait::async_trait;
 use miden_crypto::utils::Deserializable;
 use miden_node_proto::{
-    account_id,
-    block_producer::api_server,
-    conversion::convert,
-    digest,
-    domain::BlockInputs,
-    requests::{
-        ApplyBlockRequest, GetBlockInputsRequest, GetTransactionInputsRequest,
-        SubmitProvenTransactionRequest,
-    },
+    block_producer::api_server, requests::SubmitProvenTransactionRequest,
     responses::SubmitProvenTransactionResponse,
-    store::api_client as store_client,
 };
-use miden_objects::{accounts::AccountId, transaction::ProvenTransaction, Digest};
-use tonic::{
-    transport::{Channel, Server},
-    Status,
-};
-use tracing::info;
+use miden_objects::transaction::ProvenTransaction;
+use tonic::Status;
 
-use crate::{
-    batch_builder::{DefaultBatchBuilder, DefaultBatchBuilderOptions},
-    block::Block,
-    block_builder::DefaultBlockBuilder,
-    config::BlockProducerConfig,
-    state_view::DefaultStateView,
-    store::{ApplyBlock, ApplyBlockError, BlockInputsError, Store, TxInputs, TxInputsError},
-    txqueue::{DefaultTransactionQueue, DefaultTransactionQueueOptions, TransactionQueue},
-    SharedProvenTx, COMPONENT, SERVER_BATCH_SIZE, SERVER_BLOCK_FREQUENCY,
-    SERVER_BUILD_BATCH_FREQUENCY, SERVER_MAX_BATCHES_PER_BLOCK,
-};
+use crate::txqueue::TransactionQueue;
 
-struct DefaultStore {
-    store: store_client::ApiClient<Channel>,
-}
-
-#[async_trait]
-impl ApplyBlock for DefaultStore {
-    async fn apply_block(
-        &self,
-        block: Arc<Block>,
-    ) -> Result<(), ApplyBlockError> {
-        let request = tonic::Request::new(ApplyBlockRequest {
-            block: Some(block.header.into()),
-            accounts: convert(block.updated_accounts.clone()),
-            nullifiers: convert(block.produced_nullifiers.clone()),
-            notes: convert(block.created_notes.clone()),
-        });
-
-        let _ = self
-            .store
-            .clone()
-            .apply_block(request)
-            .await
-            .map_err(|status| ApplyBlockError::GrpcClientError(status.message().to_string()))?;
-
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Store for DefaultStore {
-    async fn get_tx_inputs(
-        &self,
-        proven_tx: SharedProvenTx,
-    ) -> Result<TxInputs, TxInputsError> {
-        let request = tonic::Request::new(GetTransactionInputsRequest {
-            account_id: Some(proven_tx.account_id().into()),
-            nullifiers: proven_tx
-                .consumed_notes()
-                .iter()
-                .map(|nullifier| (*nullifier).into())
-                .collect(),
-        });
-        let response = self
-            .store
-            .clone()
-            .get_transaction_inputs(request)
-            .await
-            .map_err(|status| TxInputsError::GrpcClientError(status.message().to_string()))?
-            .into_inner();
-
-        let account_hash = {
-            let account_state = response
-                .account_state
-                .ok_or(TxInputsError::MalformedResponse("account_states empty".to_string()))?;
-
-            let account_id_from_store: AccountId = account_state
-                .account_id
-                .clone()
-                .ok_or(TxInputsError::MalformedResponse("empty account id".to_string()))?
-                .try_into()?;
-
-            if account_id_from_store != proven_tx.account_id() {
-                return Err(TxInputsError::MalformedResponse(format!(
-                    "incorrect account id returned from store. Got: {}, expected: {}",
-                    account_id_from_store,
-                    proven_tx.account_id()
-                )));
-            }
-
-            account_state.account_hash.clone().map(Digest::try_from).transpose()?
-        };
-
-        let nullifiers = {
-            let mut nullifiers = Vec::new();
-
-            for nullifier_record in response.nullifiers {
-                let nullifier = nullifier_record
-                    .nullifier
-                    .ok_or(TxInputsError::MalformedResponse(
-                        "nullifier record contains empty nullifier".to_string(),
-                    ))?
-                    .try_into()?;
-
-                // `block_num` is nonzero if already consumed; 0 otherwise
-                nullifiers.push((nullifier, nullifier_record.block_num != 0))
-            }
-
-            nullifiers.into_iter().collect()
-        };
-
-        Ok(TxInputs {
-            account_hash,
-            nullifiers,
-        })
-    }
-
-    async fn get_block_inputs(
-        &self,
-        updated_accounts: impl Iterator<Item = &AccountId> + Send,
-        produced_nullifiers: impl Iterator<Item = &Digest> + Send,
-    ) -> Result<BlockInputs, BlockInputsError> {
-        let request = tonic::Request::new(GetBlockInputsRequest {
-            account_ids: updated_accounts
-                .map(|&account_id| account_id::AccountId::from(account_id))
-                .collect(),
-            nullifiers: produced_nullifiers.map(digest::Digest::from).collect(),
-        });
-
-        let store_response = self
-            .store
-            .clone()
-            .get_block_inputs(request)
-            .await
-            .map_err(|err| BlockInputsError::GrpcClientError(err.message().to_string()))?
-            .into_inner();
-
-        Ok(store_response.try_into()?)
-    }
-}
+// BLOCK PRODUCER
+// ================================================================================================
 
 pub struct BlockProducerApi<T> {
     queue: Arc<T>,
+}
+
+impl<T> BlockProducerApi<T>
+where
+    T: TransactionQueue,
+{
+    pub fn new(queue: Arc<T>) -> Self {
+        Self { queue }
+    }
 }
 
 #[tonic::async_trait]
@@ -180,55 +48,4 @@ where
 
         Ok(tonic::Response::new(SubmitProvenTransactionResponse {}))
     }
-}
-
-pub async fn serve(config: BlockProducerConfig) -> Result<()> {
-    let endpoint = (config.endpoint.host.as_ref(), config.endpoint.port);
-    let addrs: Vec<_> = endpoint.to_socket_addrs()?.collect();
-
-    let store = Arc::new(DefaultStore {
-        store: store_client::ApiClient::connect(config.store_url.to_string()).await?,
-    });
-    let block_builder = DefaultBlockBuilder::new(store.clone());
-    let batch_builder_options = DefaultBatchBuilderOptions {
-        block_frequency: SERVER_BLOCK_FREQUENCY,
-        max_batches_per_block: SERVER_MAX_BATCHES_PER_BLOCK,
-    };
-    let batch_builder =
-        Arc::new(DefaultBatchBuilder::new(Arc::new(block_builder), batch_builder_options));
-    let state_view = DefaultStateView::new(store.clone());
-
-    let transaction_queue_options = DefaultTransactionQueueOptions {
-        build_batch_frequency: SERVER_BUILD_BATCH_FREQUENCY,
-        batch_size: SERVER_BATCH_SIZE,
-    };
-    let queue = Arc::new(DefaultTransactionQueue::new(
-        Arc::new(state_view),
-        batch_builder.clone(),
-        transaction_queue_options,
-    ));
-
-    let block_producer = api_server::ApiServer::new(BlockProducerApi {
-        queue: queue.clone(),
-    });
-
-    tokio::spawn(async move {
-        info!(COMPONENT, "transaction queue started");
-        queue.run().await
-    });
-
-    tokio::spawn(async move {
-        info!(COMPONENT, "batch builder started");
-        batch_builder.run().await
-    });
-
-    info!(
-        COMPONENT,
-        host = config.endpoint.host,
-        port = config.endpoint.port,
-        "Server initialized",
-    );
-    Server::builder().add_service(block_producer).serve(addrs[0]).await?;
-
-    Ok(())
 }

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -1,1 +1,74 @@
+use std::{net::ToSocketAddrs, sync::Arc};
+
+use anyhow::Result;
+use miden_node_proto::{block_producer::api_server, store::api_client as store_client};
+use tonic::transport::Server;
+use tracing::info;
+
+use crate::{
+    batch_builder::{DefaultBatchBuilder, DefaultBatchBuilderOptions},
+    block_builder::DefaultBlockBuilder,
+    config::BlockProducerConfig,
+    state_view::DefaultStateView,
+    store::DefaultStore,
+    txqueue::{DefaultTransactionQueue, DefaultTransactionQueueOptions},
+    COMPONENT, SERVER_BATCH_SIZE, SERVER_BLOCK_FREQUENCY, SERVER_BUILD_BATCH_FREQUENCY,
+    SERVER_MAX_BATCHES_PER_BLOCK,
+};
+
+// TODO: does this need to be public?
 pub mod api;
+use api::BlockProducerApi;
+
+// SERVER INITIALIZER
+// ================================================================================================
+
+/// TODO: add comments
+pub async fn serve(config: BlockProducerConfig) -> Result<()> {
+    let endpoint = (config.endpoint.host.as_ref(), config.endpoint.port);
+    let addrs: Vec<_> = endpoint.to_socket_addrs()?.collect();
+
+    let store = Arc::new(DefaultStore::new(
+        store_client::ApiClient::connect(config.store_url.to_string()).await?,
+    ));
+    let block_builder = DefaultBlockBuilder::new(store.clone());
+    let batch_builder_options = DefaultBatchBuilderOptions {
+        block_frequency: SERVER_BLOCK_FREQUENCY,
+        max_batches_per_block: SERVER_MAX_BATCHES_PER_BLOCK,
+    };
+    let batch_builder =
+        Arc::new(DefaultBatchBuilder::new(Arc::new(block_builder), batch_builder_options));
+    let state_view = DefaultStateView::new(store.clone());
+
+    let transaction_queue_options = DefaultTransactionQueueOptions {
+        build_batch_frequency: SERVER_BUILD_BATCH_FREQUENCY,
+        batch_size: SERVER_BATCH_SIZE,
+    };
+    let queue = Arc::new(DefaultTransactionQueue::new(
+        Arc::new(state_view),
+        batch_builder.clone(),
+        transaction_queue_options,
+    ));
+
+    let block_producer = api_server::ApiServer::new(BlockProducerApi::new(queue.clone()));
+
+    tokio::spawn(async move {
+        info!(COMPONENT, "transaction queue started");
+        queue.run().await
+    });
+
+    tokio::spawn(async move {
+        info!(COMPONENT, "batch builder started");
+        batch_builder.run().await
+    });
+
+    info!(
+        COMPONENT,
+        host = config.endpoint.host,
+        port = config.endpoint.port,
+        "Server initialized",
+    );
+    Server::builder().add_service(block_producer).serve(addrs[0]).await?;
+
+    Ok(())
+}

--- a/block-producer/src/store/errors.rs
+++ b/block-producer/src/store/errors.rs
@@ -1,0 +1,29 @@
+use miden_node_proto::error::ParseError;
+use thiserror::Error;
+
+// TODO: consolidate errors in this file
+#[derive(Debug, PartialEq, Error)]
+pub enum TxInputsError {
+    #[error("gRPC client failed with error: {0}")]
+    GrpcClientError(String),
+    #[error("malformed response from store: {0}")]
+    MalformedResponse(String),
+    #[error("failed to parse protobuf message: {0}")]
+    ParseError(#[from] ParseError),
+    #[error("dummy")]
+    Dummy,
+}
+
+#[derive(Debug, PartialEq, Error)]
+pub enum BlockInputsError {
+    #[error("failed to parse protobuf message: {0}")]
+    ParseError(#[from] ParseError),
+    #[error("gRPC client failed with error: {0}")]
+    GrpcClientError(String),
+}
+
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum ApplyBlockError {
+    #[error("gRPC client failed with error: {0}")]
+    GrpcClientError(String),
+}

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -1,37 +1,39 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
-use miden_node_proto::{domain::BlockInputs, error::ParseError};
+use miden_node_proto::{
+    account_id,
+    conversion::convert,
+    digest,
+    domain::BlockInputs,
+    requests::{ApplyBlockRequest, GetBlockInputsRequest, GetTransactionInputsRequest},
+    store::api_client as store_client,
+};
 use miden_objects::{accounts::AccountId, Digest};
-use thiserror::Error;
+use tonic::transport::Channel;
 
 use crate::{block::Block, SharedProvenTx};
 
-// TODO: consolidate errors in this file
-#[derive(Debug, PartialEq, Error)]
-pub enum TxInputsError {
-    #[error("gRPC client failed with error: {0}")]
-    GrpcClientError(String),
-    #[error("malformed response from store: {0}")]
-    MalformedResponse(String),
-    #[error("failed to parse protobuf message: {0}")]
-    ParseError(#[from] ParseError),
-    #[error("dummy")]
-    Dummy,
-}
+mod errors;
+pub use errors::{ApplyBlockError, BlockInputsError, TxInputsError};
 
-#[derive(Debug, PartialEq, Error)]
-pub enum BlockInputsError {
-    #[error("failed to parse protobuf message: {0}")]
-    ParseError(#[from] ParseError),
-    #[error("gRPC client failed with error: {0}")]
-    GrpcClientError(String),
-}
+// STORE TRAIT
+// ================================================================================================
 
-#[derive(Debug, PartialEq, Eq, Error)]
-pub enum ApplyBlockError {
-    #[error("gRPC client failed with error: {0}")]
-    GrpcClientError(String),
+#[async_trait]
+pub trait Store: ApplyBlock {
+    /// TODO: add comments
+    async fn get_tx_inputs(
+        &self,
+        proven_tx: SharedProvenTx,
+    ) -> Result<TxInputs, TxInputsError>;
+
+    /// TODO: add comments
+    async fn get_block_inputs(
+        &self,
+        updated_accounts: impl Iterator<Item = &AccountId> + Send,
+        produced_nullifiers: impl Iterator<Item = &Digest> + Send,
+    ) -> Result<BlockInputs, BlockInputsError>;
 }
 
 #[async_trait]
@@ -42,7 +44,7 @@ pub trait ApplyBlock: Send + Sync + 'static {
     ) -> Result<(), ApplyBlockError>;
 }
 
-/// Information needed from the store to verify a transaction
+/// Information needed from the store to verify a transaction.
 pub struct TxInputs {
     /// The account hash in the store corresponding to tx's account ID
     pub account_hash: Option<Digest>,
@@ -51,16 +53,132 @@ pub struct TxInputs {
     pub nullifiers: BTreeMap<Digest, bool>,
 }
 
+// DEFAULT STORE IMPLEMENTATION
+// ================================================================================================
+
+pub struct DefaultStore {
+    store: store_client::ApiClient<Channel>,
+}
+
+impl DefaultStore {
+    /// TODO: this should probably take store connection string and create a connection internally
+    pub fn new(store: store_client::ApiClient<Channel>) -> Self {
+        Self { store }
+    }
+}
+
 #[async_trait]
-pub trait Store: ApplyBlock {
+impl ApplyBlock for DefaultStore {
+    async fn apply_block(
+        &self,
+        block: Arc<Block>,
+    ) -> Result<(), ApplyBlockError> {
+        let request = tonic::Request::new(ApplyBlockRequest {
+            block: Some(block.header.into()),
+            accounts: convert(block.updated_accounts.clone()),
+            nullifiers: convert(block.produced_nullifiers.clone()),
+            notes: convert(block.created_notes.clone()),
+        });
+
+        let _ = self
+            .store
+            .clone()
+            .apply_block(request)
+            .await
+            .map_err(|status| ApplyBlockError::GrpcClientError(status.message().to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Store for DefaultStore {
     async fn get_tx_inputs(
         &self,
         proven_tx: SharedProvenTx,
-    ) -> Result<TxInputs, TxInputsError>;
+    ) -> Result<TxInputs, TxInputsError> {
+        let request = tonic::Request::new(GetTransactionInputsRequest {
+            account_id: Some(proven_tx.account_id().into()),
+            nullifiers: proven_tx
+                .consumed_notes()
+                .iter()
+                .map(|nullifier| (*nullifier).into())
+                .collect(),
+        });
+        let response = self
+            .store
+            .clone()
+            .get_transaction_inputs(request)
+            .await
+            .map_err(|status| TxInputsError::GrpcClientError(status.message().to_string()))?
+            .into_inner();
+
+        let account_hash = {
+            let account_state = response
+                .account_state
+                .ok_or(TxInputsError::MalformedResponse("account_states empty".to_string()))?;
+
+            let account_id_from_store: AccountId = account_state
+                .account_id
+                .clone()
+                .ok_or(TxInputsError::MalformedResponse("empty account id".to_string()))?
+                .try_into()?;
+
+            if account_id_from_store != proven_tx.account_id() {
+                return Err(TxInputsError::MalformedResponse(format!(
+                    "incorrect account id returned from store. Got: {}, expected: {}",
+                    account_id_from_store,
+                    proven_tx.account_id()
+                )));
+            }
+
+            account_state.account_hash.clone().map(Digest::try_from).transpose()?
+        };
+
+        let nullifiers = {
+            let mut nullifiers = Vec::new();
+
+            for nullifier_record in response.nullifiers {
+                let nullifier = nullifier_record
+                    .nullifier
+                    .ok_or(TxInputsError::MalformedResponse(
+                        "nullifier record contains empty nullifier".to_string(),
+                    ))?
+                    .try_into()?;
+
+                // `block_num` is nonzero if already consumed; 0 otherwise
+                nullifiers.push((nullifier, nullifier_record.block_num != 0))
+            }
+
+            nullifiers.into_iter().collect()
+        };
+
+        Ok(TxInputs {
+            account_hash,
+            nullifiers,
+        })
+    }
 
     async fn get_block_inputs(
         &self,
         updated_accounts: impl Iterator<Item = &AccountId> + Send,
         produced_nullifiers: impl Iterator<Item = &Digest> + Send,
-    ) -> Result<BlockInputs, BlockInputsError>;
+    ) -> Result<BlockInputs, BlockInputsError> {
+        let request = tonic::Request::new(GetBlockInputsRequest {
+            account_ids: updated_accounts
+                .map(|&account_id| account_id::AccountId::from(account_id))
+                .collect(),
+            nullifiers: produced_nullifiers.map(digest::Digest::from).collect(),
+        });
+
+        let store_response = self
+            .store
+            .clone()
+            .get_block_inputs(request)
+            .await
+            .map_err(|err| BlockInputsError::GrpcClientError(err.message().to_string()))?
+            .into_inner();
+
+        Ok(store_response.try_into()?)
+    }
 }

--- a/node/src/commands.rs
+++ b/node/src/commands.rs
@@ -37,9 +37,9 @@ pub async fn start(config_filepath: &Path) -> anyhow::Result<()> {
 
     // wait for store before starting block producer
     tokio::time::sleep(Duration::from_secs(1)).await;
-    join_set.spawn(block_producer_server::api::serve(config.block_producer));
+    join_set.spawn(block_producer_server::serve(config.block_producer));
 
-    // wait for blockproducer before starting rpc
+    // wait for block producer before starting rpc
     tokio::time::sleep(Duration::from_secs(1)).await;
     join_set.spawn(rpc_server::api::serve(config.rpc));
 


### PR DESCRIPTION
This PR mostly moves code around (there should be no actual code changes). Specifically, moves `DefaultStore` into `store` module and server start up one module.