### PR TITLE
block-producer: apply_block on state_view

### DIFF
--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -21,7 +21,7 @@ async fn test_apply_block_called_nonempty_batches() {
             .build(),
     );
 
-    let block_builder = DefaultBlockBuilder::new(store.clone());
+    let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());
 
     let batches: Vec<SharedTxBatch> = {
         let batch_1 = {
@@ -56,7 +56,7 @@ async fn test_apply_block_called_empty_batches() {
             .build(),
     );
 
-    let block_builder = DefaultBlockBuilder::new(store.clone());
+    let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());
 
     block_builder.build_block(Vec::new()).await.unwrap();
 
@@ -69,7 +69,7 @@ async fn test_apply_block_called_empty_batches() {
 async fn test_build_block_failure() {
     let store = Arc::new(MockStoreFailure);
 
-    let block_builder = DefaultBlockBuilder::new(store.clone());
+    let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());
 
     let result = block_builder.build_block(Vec::new()).await;
 


### PR DESCRIPTION
As keenly noticed by @bobbinth, the `block-producer` wasn't wired correctly: `apply_block()` must be called on `StateView`, not the `Store` directly. This PR fixes that.

Initially I thought having only one trait for applying a block (`ApplyBlock`), which both `StateView` and `Store` implement, would be elegant. However, this prevents the type system from telling us when we wired things incorrectly (as we did now). We should potentially revisit this decision and split `ApplyBlock` in 2 traits.