### PR TITLE
Fix `forest` parameter in `sync_state`

### DIFF
--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -360,7 +360,7 @@ impl State {
 
             let proof = inner.chain_mmr.open(
                 state_sync.block_header.block_num as usize,
-                state_sync.block_header.block_num as usize,
+                state_sync.block_header.block_num as usize + 1,
             )?;
 
             (delta, proof.merkle_path)


### PR DESCRIPTION
When addressing #114, we forgot to apply the fix to `State::sync_state` as well. Although I suspect the current code probably didn't work before addressing #114, since I would ultimately expect [this check](https://github.com/0xPolygonMiden/crypto/blob/862ccf54dd24a80b74f1c63baab19ecd34e4f15b/src/merkle/mmr/mod.rs#L37) to fail?

There is still a bug with state sync though (#130)