### PR TITLE
Fix chain MMR updates in the store

### DIFF
--- a/store/src/db/sql.rs
+++ b/store/src/db/sql.rs
@@ -201,7 +201,7 @@ pub fn insert_block_header(
     Ok(stmt.execute(params![block_header.block_num, block_header.encode_to_vec()])?)
 }
 
-/// Select a [BlockHeader] from the DB by its `block_num` usiing the given [Connection].
+/// Select a [BlockHeader] from the DB by its `block_num` using the given [Connection].
 ///
 /// # Returns
 ///

--- a/store/src/errors.rs
+++ b/store/src/errors.rs
@@ -8,20 +8,14 @@ pub enum StateError {
     DigestError(ParseError),
     DuplicatedNullifiers(Vec<RpoDigest>),
     InvalidAccountId,
-    InvalidAccountRoot,
-    InvalidChainRoot,
-    InvalidNoteRoot,
-    InvalidNullifierRoot,
     MissingAccountHash,
     MissingAccountId,
-    MissingAccountRoot,
-    MissingBatchRoot,
-    MissingChainRoot,
     MissingNoteHash,
-    MissingNoteRoot,
-    MissingNullifierRoot,
-    MissingPrevHash,
-    MissingProofHash,
+    NewBlockInvalidAccountRoot,
+    NewBlockInvalidBlockNum,
+    NewBlockInvalidChainRoot,
+    NewBlockInvalidNoteRoot,
+    NewBlockInvalidNullifierRoot,
     NewBlockInvalidPrevHash,
     NoteMissingHash,
     NoteMissingMerklePath,
@@ -42,20 +36,22 @@ impl std::fmt::Display for StateError {
                 write!(f, "Duplicated nullifiers {:?}", nullifiers)
             },
             StateError::InvalidAccountId => write!(f, "Received invalid account id"),
-            StateError::InvalidAccountRoot => write!(f, "Received invalid account tree root"),
-            StateError::InvalidChainRoot => write!(f, "Received invalid chain mmr hash"),
-            StateError::InvalidNoteRoot => write!(f, "Received invalid note root"),
-            StateError::InvalidNullifierRoot => write!(f, "Received invalid nullifier tree root"),
             StateError::MissingAccountHash => write!(f, "Missing account_hash"),
             StateError::MissingAccountId => write!(f, "Missing account_id"),
-            StateError::MissingAccountRoot => write!(f, "Missing account root"),
-            StateError::MissingBatchRoot => write!(f, "Missing batch root"),
-            StateError::MissingChainRoot => write!(f, "Missing chain root"),
             StateError::MissingNoteHash => write!(f, "Missing note hash"),
-            StateError::MissingNoteRoot => write!(f, "Missing note root"),
-            StateError::MissingNullifierRoot => write!(f, "Missing nullifier root"),
-            StateError::MissingPrevHash => write!(f, "Missing prev hash"),
-            StateError::MissingProofHash => write!(f, "Missing proof hash"),
+            StateError::NewBlockInvalidAccountRoot => {
+                write!(f, "Received invalid account tree root")
+            },
+            StateError::NewBlockInvalidBlockNum => {
+                write!(f, "New block number must be 1 greater than the current block number")
+            },
+            StateError::NewBlockInvalidChainRoot => {
+                write!(f, "New block chain root is not consistent with chain MMR")
+            },
+            StateError::NewBlockInvalidNoteRoot => write!(f, "Received invalid note root"),
+            StateError::NewBlockInvalidNullifierRoot => {
+                write!(f, "Received invalid nullifier tree root")
+            },
             StateError::NewBlockInvalidPrevHash => {
                 write!(f, "New block prev_hash must match the chain's tip")
             },

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -160,20 +160,20 @@ impl State {
     /// ## Note on state consistency
     ///
     /// The server contains in-memory representations of the existing trees, the in-memory
-    /// representation must be kept consistent with the commited data, this is necessary so to
+    /// representation must be kept consistent with the committed data, this is necessary so to
     /// provide consistent results for all endpoints. In order to achieve consistency, the
     /// following steps are used:
     ///
-    /// - the request data is validated, prior to starting any modifications
-    /// - a transaction is open in the DB and the writes are started
-    ///  - while the transaction is not commited, concurrent reads are allowed, both the DB and
-    ///  the in-memory representations, which are consistent at this stage.
-    /// - prior to commiting the changes to the DB, an exclusive lock to the in-memory data is
-    /// acquired, preventing concurrent reads to the in-memory data, since that will be
-    /// out-of-sync w.r.t. the DB.
-    /// - the DB transaction is commited, and requests that read only from the DB can proceed to
-    /// use the fresh data
-    /// - the in-memory structures are updated, and the lock is released
+    /// - the request data is validated, prior to starting any modifications.
+    /// - a transaction is open in the DB and the writes are started.
+    /// - while the transaction is not committed, concurrent reads are allowed, both the DB and
+    ///   the in-memory representations, which are consistent at this stage.
+    /// - prior to committing the changes to the DB, an exclusive lock to the in-memory data is
+    ///   acquired, preventing concurrent reads to the in-memory data, since that will be
+    ///   out-of-sync w.r.t. the DB.
+    /// - the DB transaction is committed, and requests that read only from the DB can proceed to
+    ///   use the fresh data.
+    /// - the in-memory structures are updated, and the lock is released.
     pub async fn apply_block(
         &self,
         block_header: block_header::BlockHeader,
@@ -183,17 +183,20 @@ impl State {
     ) -> Result<(), anyhow::Error> {
         let _ = self.writer.try_lock().map_err(|_| StateError::ConcurrentWrite)?;
 
+        let new_block: BlockHeader = block_header.clone().try_into()?;
+
         // ensures the right block header is being processed
-        let prev_block_msg = self
+        let prev_block: BlockHeader = self
             .db
             .select_block_header_by_block_num(None)
             .await?
-            .ok_or(StateError::DbBlockHeaderEmpty)?;
-        let block_num = prev_block_msg.block_num + 1;
-        let prev_block: BlockHeader = prev_block_msg.try_into()?;
-        let prev_hash =
-            block_header.prev_hash.clone().ok_or(StateError::MissingPrevHash)?.try_into()?;
-        if prev_hash != prev_block.hash() {
+            .ok_or(StateError::DbBlockHeaderEmpty)?
+            .try_into()?;
+
+        if new_block.block_num() != prev_block.block_num() + 1 {
+            return Err(StateError::NewBlockInvalidBlockNum.into());
+        }
+        if new_block.prev_hash() != prev_block.hash() {
             return Err(StateError::NewBlockInvalidPrevHash.into());
         }
 
@@ -214,58 +217,51 @@ impl State {
                 return Err(StateError::DuplicatedNullifiers(duplicate_nullifiers).into());
             }
 
-            // update the in-memory datastructures and compute the new block header. Important, the
-            // structures are not yet commited
-            let mut chain_mmr = inner.chain_mmr.clone();
-            chain_mmr.add(prev_hash);
-            let peaks = chain_mmr.peaks(chain_mmr.forest())?;
+            // update the in-memory data structures and compute the new block header. Important, the
+            // structures are not yet committed
 
-            if peaks.hash_peaks()
-                != block_header
-                    .clone()
-                    .chain_root
-                    .ok_or(StateError::MissingChainRoot)?
-                    .try_into()?
-            {
-                return Err(StateError::InvalidChainRoot.into());
-            }
+            // update chain MMR
+            let chain_mmr = {
+                let mut chain_mmr = inner.chain_mmr.clone();
 
-            let mut nullifier_tree = inner.nullifier_tree.clone();
-            let nullifier_data = block_to_nullifier_data(block_num);
-            for nullifier in nullifiers.iter() {
-                nullifier_tree.insert(*nullifier, nullifier_data);
-            }
+                // new_block.chain_root must be equal to the chain MMR root prior to the update
+                let peaks = chain_mmr.peaks(chain_mmr.forest())?;
+                if peaks.hash_peaks() != new_block.chain_root() {
+                    return Err(StateError::NewBlockInvalidChainRoot.into());
+                }
 
-            if nullifier_tree.root()
-                != block_header
-                    .nullifier_root
-                    .clone()
-                    .ok_or(StateError::MissingNullifierRoot)?
-                    .try_into()?
-            {
-                return Err(StateError::InvalidNullifierRoot.into());
-            }
+                chain_mmr.add(new_block.hash());
+                chain_mmr
+            };
 
+            // update nullifier tree
+            let nullifier_tree = {
+                let mut nullifier_tree = inner.nullifier_tree.clone();
+                let nullifier_data = block_to_nullifier_data(new_block.block_num());
+                for nullifier in nullifiers.iter() {
+                    nullifier_tree.insert(*nullifier, nullifier_data);
+                }
+
+                if nullifier_tree.root() != new_block.nullifier_root() {
+                    return Err(StateError::NewBlockInvalidNullifierRoot.into());
+                }
+                nullifier_tree
+            };
+
+            // update account tree
             let mut account_tree = inner.account_tree.clone();
             for (account_id, account_hash) in accounts.iter() {
                 account_tree.update_leaf(*account_id, account_hash.try_into()?)?;
             }
 
-            if account_tree.root()
-                != block_header
-                    .account_root
-                    .clone()
-                    .ok_or(StateError::MissingAccountRoot)?
-                    .try_into()?
-            {
-                return Err(StateError::InvalidAccountRoot.into());
+            if account_tree.root() != new_block.account_root() {
+                return Err(StateError::NewBlockInvalidAccountRoot.into());
             }
 
+            // build notes tree
             let note_tree = build_notes_tree(&notes)?;
-            if note_tree.root()
-                != block_header.note_root.clone().ok_or(StateError::MissingNoteRoot)?.try_into()?
-            {
-                return Err(StateError::InvalidNoteRoot.into());
+            if note_tree.root() != new_block.note_root() {
+                return Err(StateError::NewBlockInvalidNoteRoot.into());
             }
 
             drop(guard);
@@ -273,7 +269,7 @@ impl State {
             let notes = notes
                 .iter()
                 .map(|note| {
-                    // Safety: This should never happen, the note_tree is created direclty form
+                    // Safety: This should never happen, the note_tree is created directly form
                     // this list of notes
                     let merkle_path =
                         note_tree.get_leaf_path(note.note_index as u64).map_err(|_| {
@@ -281,7 +277,7 @@ impl State {
                         })?;
 
                     Ok(Note {
-                        block_num,
+                        block_num: new_block.block_num(),
                         note_hash: note.note_hash.clone(),
                         sender: note.sender,
                         note_index: note.note_index,
@@ -295,9 +291,9 @@ impl State {
             (account_tree, chain_mmr, nullifier_tree, notes)
         };
 
-        // signals the transaction is ready to be commited, and the write lock can be acquired
+        // signals the transaction is ready to be committed, and the write lock can be acquired
         let (allow_acquire, acquired_allowed) = oneshot::channel::<()>();
-        // signals the write lock has been acquired, and the transaction can be commited
+        // signals the write lock has been acquired, and the transaction can be committed
         let (inform_acquire_done, acquire_done) = oneshot::channel::<()>();
 
         // The DB and in-memory state updates need to be synchronized and are partially
@@ -394,7 +390,9 @@ impl State {
             );
         }
 
-        let peaks = inner.chain_mmr.peaks(inner.chain_mmr.forest())?;
+        // using current block number gets us the peaks of the chain MMR as of one block ago;
+        // this is done so that latest.chain_root matches the returned peaks
+        let peaks = inner.chain_mmr.peaks(latest.block_num as usize)?;
         let account_states = account_ids
             .iter()
             .cloned()


### PR DESCRIPTION
This PR should fix #133. There were a couple of bugs in the store in the `apply_block` and `get_block_inputs` endpoints. All these are basically "off-by-one" errors in regards to how we handle block numbering. Specifically:

- `get_block_inputs` returned the current state of chain MMR rather than the state as of one block ago. We need the state as of one block ago because we want to send a consistent tuple `(current_block, chain_peaks)` but if we send the latest peaks, that would already include `current_block` in them.
- in `apply_block` we were adding the pervious block header to the chain MMR rather than the new block header.

Also, did some minor refactoring of errors.