### PR TITLE
removed `Arc<>` on `Block` for `ApplyBlock`

### DIFF
--- a/block-producer/src/block_builder/mod.rs
+++ b/block-producer/src/block_builder/mod.rs
@@ -101,14 +101,14 @@ where
 
         let block_num = new_block_header.block_num();
 
-        let block = Arc::new(Block {
+        let block = Block {
             header: new_block_header,
             updated_accounts: account_updates,
             created_notes,
             produced_nullifiers,
-        });
+        };
 
-        self.state_view.apply_block(block.clone()).await?;
+        self.state_view.apply_block(block).await?;
 
         info!(COMPONENT, "block #{block_num} built!");
 

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -96,7 +96,7 @@ where
 {
     async fn apply_block(
         &self,
-        block: Arc<Block>,
+        block: Block,
     ) -> Result<(), ApplyBlockError> {
         self.store.apply_block(block.clone()).await?;
 

--- a/block-producer/src/state_view/tests/apply_block.rs
+++ b/block-producer/src/state_view/tests/apply_block.rs
@@ -46,7 +46,7 @@ async fn test_apply_block_ab1() {
         )
         .build();
 
-    let apply_block_res = state_view.apply_block(Arc::new(block)).await;
+    let apply_block_res = state_view.apply_block(block).await;
     assert!(apply_block_res.is_ok());
 
     assert_eq!(*store.num_apply_block_called.read().await, 1);
@@ -91,7 +91,7 @@ async fn test_apply_block_ab2() {
         )
         .build();
 
-    let apply_block_res = state_view.apply_block(Arc::new(block)).await;
+    let apply_block_res = state_view.apply_block(block).await;
     assert!(apply_block_res.is_ok());
 
     let accounts_still_in_flight = state_view.accounts_in_flight.read().await;
@@ -138,7 +138,7 @@ async fn test_apply_block_ab3() {
         )
         .build();
 
-    let apply_block_res = state_view.apply_block(Arc::new(block)).await;
+    let apply_block_res = state_view.apply_block(block).await;
     assert!(apply_block_res.is_ok());
 
     // Craft a new transaction which tries to consume the same note that was consumed in in the

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 use miden_node_proto::{
@@ -40,7 +40,7 @@ pub trait Store: ApplyBlock {
 pub trait ApplyBlock: Send + Sync + 'static {
     async fn apply_block(
         &self,
-        block: Arc<Block>,
+        block: Block,
     ) -> Result<(), ApplyBlockError>;
 }
 
@@ -71,13 +71,13 @@ impl DefaultStore {
 impl ApplyBlock for DefaultStore {
     async fn apply_block(
         &self,
-        block: Arc<Block>,
+        block: Block,
     ) -> Result<(), ApplyBlockError> {
         let request = tonic::Request::new(ApplyBlockRequest {
             block: Some(block.header.into()),
-            accounts: convert(block.updated_accounts.clone()),
-            nullifiers: convert(block.produced_nullifiers.clone()),
-            notes: convert(block.created_notes.clone()),
+            accounts: convert(block.updated_accounts),
+            nullifiers: convert(block.produced_nullifiers),
+            notes: convert(block.created_notes),
         });
 
         let _ = self

--- a/block-producer/src/test_utils/store.rs
+++ b/block-producer/src/test_utils/store.rs
@@ -120,7 +120,7 @@ impl MockStoreSuccess {
 impl ApplyBlock for MockStoreSuccess {
     async fn apply_block(
         &self,
-        block: Arc<Block>,
+        block: Block,
     ) -> Result<(), ApplyBlockError> {
         // Intentionally, we take and hold both locks, to prevent calls to `get_tx_inputs()` from going through while we're updating the store's data structure
         let mut locked_accounts = self.accounts.write().await;
@@ -231,7 +231,7 @@ pub struct MockStoreFailure;
 impl ApplyBlock for MockStoreFailure {
     async fn apply_block(
         &self,
-        _block: Arc<Block>,
+        _block: Block,
     ) -> Result<(), ApplyBlockError> {
         Err(ApplyBlockError::GrpcClientError(String::new()))
     }


### PR DESCRIPTION
In this PR I propose to remove `Arc<>` on `Block` for `ApplyBlock`, the Arc<> not being used creates overhead and forces us to use `.clone()` often. Incurring a performance hit.

closes: #99 