### PR TITLE
Removed additional cli parameters from block-producer, store and RPC.

### DIFF
--- a/block-producer/src/cli/mod.rs
+++ b/block-producer/src/cli/mod.rs
@@ -16,14 +16,5 @@ pub struct Cli {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
 pub enum Command {
-    Serve {
-        #[arg(short, long)]
-        /// Binding port number
-        port: Option<u16>,
-
-        // short option `-h` conflicts with `--help`, so it is not enabled.
-        #[arg(long)]
-        /// Binding host
-        host: Option<String>,
-    },
+    Serve,
 }

--- a/rpc/src/cli/mod.rs
+++ b/rpc/src/cli/mod.rs
@@ -11,15 +11,6 @@ pub struct Cli {
     #[arg(short, long, value_name = "FILE", default_value = config::CONFIG_FILENAME)]
     pub config: PathBuf,
 
-    #[arg(short, long)]
-    /// Binding port number
-    port: Option<u16>,
-
-    // short option `-h` conflicts with `--help`, so it is not enabled.
-    #[arg(long)]
-    /// Binding host
-    host: Option<String>,
-
     #[command(subcommand)]
     pub command: Command,
 }

--- a/store/src/cli/mod.rs
+++ b/store/src/cli/mod.rs
@@ -9,23 +9,11 @@ pub struct Cli {
     #[arg(short, long, value_name = "FILE", default_value = config::CONFIG_FILENAME)]
     pub config: PathBuf,
 
-    #[arg(short, long, value_name = "SQLITE_FILE")]
-    pub sqlite: Option<PathBuf>,
-
     #[command(subcommand)]
     pub command: Command,
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
 pub enum Command {
-    Serve {
-        #[arg(short, long)]
-        /// Binding port number
-        port: Option<u16>,
-
-        // short option `-h` conflicts with `--help`, so it is not enabled.
-        #[arg(long)]
-        /// Binding host
-        host: Option<String>,
-    },
+    Serve,
 }


### PR DESCRIPTION
In this PR I propose a removal of additional cli parameters from block-producer, store and RPC.

They were not in use for now and we were launching the node using config files, hence not needing them for now. 

In the future we will think about how we want to handle the launch of the node.

closes: #124 