### PR TITLE
git: ignore test db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ Cargo.lock
 
 # VS Code
 .vscode/
+
+# Sqlite db files
+*.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal


### PR DESCRIPTION
As per the PR title. The XDG placement of the DB was removed, meaning the files are now generated where the binary is executed, and this can be inside the git repo. This adds the sqlite files to the gitignore