### PR TITLE
node: add control plane logic, and integrate shutdown logic to store rpc

### DIFF
--- a/block-producer/src/cli/mod.rs
+++ b/block-producer/src/cli/mod.rs
@@ -16,5 +16,6 @@ pub struct Cli {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
 pub enum Command {
+    /// Starts the block producer gRPC service.
     Serve,
 }

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -16,13 +16,8 @@ use crate::{
     SERVER_MAX_BATCHES_PER_BLOCK,
 };
 
-// TODO: does this need to be public?
 pub mod api;
 
-// BLOCK PRODUCER INITIALIZER
-// ================================================================================================
-
-/// TODO: add comments
 pub async fn serve(config: BlockProducerConfig) -> Result<()> {
     let endpoint = (config.endpoint.host.as_ref(), config.endpoint.port);
     let addrs: Vec<_> = endpoint.to_socket_addrs()?.collect();

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -15,6 +15,7 @@ fn main() -> miette::Result<()> {
     // Compile the proto file for all servers APIs
     let protos = &[
         proto_dir.join("block_producer.proto"),
+        proto_dir.join("control_plane.proto"),
         proto_dir.join("store.proto"),
         proto_dir.join("rpc.proto"),
     ];

--- a/proto/proto/control_plane.proto
+++ b/proto/proto/control_plane.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package control_plane;
+
+message ShutdownRequest {}
+message ShutdownResponse {}
+
+service Api {
+    rpc Shutdown(ShutdownRequest) returns (ShutdownResponse) {}
+}

--- a/proto/src/generated/control_plane.rs
+++ b/proto/src/generated/control_plane.rs
@@ -1,0 +1,299 @@
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShutdownRequest {}
+#[derive(Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShutdownResponse {}
+/// Generated client implementations.
+pub mod api_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct ApiClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ApiClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ApiClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ApiClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            ApiClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn shutdown(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ShutdownRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ShutdownResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/control_plane.Api/Shutdown",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("control_plane.Api", "Shutdown"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod api_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ApiServer.
+    #[async_trait]
+    pub trait Api: Send + Sync + 'static {
+        async fn shutdown(
+            &self,
+            request: tonic::Request<super::ShutdownRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ShutdownResponse>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct ApiServer<T: Api> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Api> ApiServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ApiServer<T>
+    where
+        T: Api,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/control_plane.Api/Shutdown" => {
+                    #[allow(non_camel_case_types)]
+                    struct ShutdownSvc<T: Api>(pub Arc<T>);
+                    impl<T: Api> tonic::server::UnaryService<super::ShutdownRequest>
+                    for ShutdownSvc<T> {
+                        type Response = super::ShutdownResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ShutdownRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::shutdown(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ShutdownSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Api> Clone for ApiServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Api> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Api> tonic::server::NamedService for ApiServer<T> {
+        const NAME: &'static str = "control_plane.Api";
+    }
+}

--- a/proto/src/generated/mod.rs
+++ b/proto/src/generated/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod block_header;
 pub mod block_producer;
+pub mod control_plane;
 pub mod digest;
 pub mod merkle;
 pub mod mmr;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -10,6 +10,6 @@ pub mod hex;
 // RE-EXPORTS
 // ------------------------------------------------------------------------------------------------
 pub use generated::{
-    account, block_header, block_producer, digest, merkle, mmr, note, requests, responses, rpc,
-    store, tsmt,
+    account, block_header, block_producer, control_plane, digest, merkle, mmr, note, requests,
+    responses, rpc, store, tsmt,
 };

--- a/rpc/src/cli/mod.rs
+++ b/rpc/src/cli/mod.rs
@@ -15,5 +15,16 @@ pub struct Cli {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
 pub enum Command {
+    /// Starts the RPC gRPC service.
     Serve,
+
+    #[command(subcommand)]
+    /// Administer the RPC via gRPC.
+    Admin(Admin),
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
+pub enum Admin {
+    /// Starts a server clean sthudown.
+    Shutdown,
 }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -1,4 +1,4 @@
-use miden_node_utils::config::Endpoint;
+use miden_node_utils::{config::Endpoint, control_plane::ControlPlaneConfig};
 use serde::{Deserialize, Serialize};
 
 pub const CONFIG_FILENAME: &str = "miden-rpc.toml";
@@ -28,6 +28,7 @@ impl RpcConfig {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct RpcTopLevelConfig {
     pub rpc: RpcConfig,
+    pub control_plane: ControlPlaneConfig,
 }
 
 #[cfg(test)]
@@ -35,7 +36,10 @@ mod tests {
     use std::path::PathBuf;
 
     use figment::Jail;
-    use miden_node_utils::config::{load_config, Endpoint};
+    use miden_node_utils::{
+        config::{load_config, Endpoint},
+        control_plane::ControlPlaneConfig,
+    };
 
     use super::{RpcConfig, RpcTopLevelConfig, CONFIG_FILENAME};
 
@@ -46,10 +50,14 @@ mod tests {
                 CONFIG_FILENAME,
                 r#"
                     [rpc]
-                    store_url = "http://store:8000"
-                    block_producer_url = "http://block_producer:8001"
+                    store_url = "http://store:80"
+                    block_producer_url = "http://block_producer:81"
 
                     [rpc.endpoint]
+                    host = "0.0.0.0"
+                    port = 82
+
+                    [control_plane.endpoint]
                     host = "127.0.0.1"
                     port = 8080
                 "#,
@@ -63,11 +71,17 @@ mod tests {
                 RpcTopLevelConfig {
                     rpc: RpcConfig {
                         endpoint: Endpoint {
+                            host: "0.0.0.0".to_string(),
+                            port: 82,
+                        },
+                        store_url: "http://store:80".to_string(),
+                        block_producer_url: "http://block_producer:81".to_string(),
+                    },
+                    control_plane: ControlPlaneConfig {
+                        endpoint: Endpoint {
                             host: "127.0.0.1".to_string(),
                             port: 8080,
                         },
-                        store_url: "http://store:8000".to_string(),
-                        block_producer_url: "http://block_producer:8001".to_string(),
                     }
                 }
             );

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -1,32 +1,76 @@
-use std::net::ToSocketAddrs;
+use std::{future::Future, net::ToSocketAddrs};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use miden_node_proto::rpc::api_server;
+use miden_node_utils::control_plane::{
+    create_server as control_plane_create_server, ControlPlane, ControlPlaneConfig,
+};
+use tokio::sync::oneshot::Receiver;
 use tonic::transport::Server;
-use tracing::info;
+use tracing::{error, info, instrument};
 
 use crate::{config::RpcConfig, COMPONENT};
 
 mod api;
 
-// RPC INITIALIZER
-// ================================================================================================
+pub async fn serve(
+    config: RpcConfig,
+    control_plane_config: ControlPlaneConfig,
+) -> Result<()> {
+    let mut control_plane = ControlPlane::new();
 
-pub async fn serve(config: RpcConfig) -> Result<()> {
+    let shutdown = control_plane.shutdown_waiter()?;
+    let rpc_server = create_server(config, shutdown).await?;
+
+    let control_plane_server =
+        control_plane_create_server(control_plane_config, control_plane).await?;
+
+    let (control_plane_res, store_res) =
+        tokio::join!(tokio::spawn(control_plane_server), tokio::spawn(rpc_server));
+
+    match control_plane_res {
+        Ok(Ok(_)) => info!(COMPONENT, "Control plane successfully shut down"),
+        Ok(Err(err)) => error!(COMPONENT, "Control plane shut down with an error {err:?}"),
+        Err(_) => error!(COMPONENT, "Control plane join failed"),
+    }
+    match store_res {
+        Ok(Ok(_)) => info!(COMPONENT, "RPC successfully shut down"),
+        Ok(Err(err)) => error!(COMPONENT, "RPC shut down with an error {err:?}"),
+        Err(_) => error!(COMPONENT, "RPC join failed"),
+    }
+
+    Ok(())
+}
+
+/// Configures the RPC service and returns a future to execute it.
+#[instrument(skip_all)]
+pub async fn create_server(
+    config: RpcConfig,
+    shutdown: Receiver<()>,
+) -> Result<impl Future<Output = Result<()>>> {
     let endpoint = (config.endpoint.host.as_ref(), config.endpoint.port);
     let addrs: Vec<_> = endpoint.to_socket_addrs()?.collect();
 
     let api = api::RpcApi::from_config(&config).await?;
-    let rpc = api_server::ApiServer::new(api);
+    let svc = api_server::ApiServer::new(api);
 
     info!(
         host = config.endpoint.host,
         port = config.endpoint.port,
         COMPONENT,
-        "Server initialized"
+        "RPC server initialized"
     );
 
-    Server::builder().add_service(rpc).serve(addrs[0]).await?;
-
-    Ok(())
+    Ok(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown(addrs[0], async {
+                match shutdown.await {
+                    Ok(_) => info!(COMPONENT, "Rpc shutdown"),
+                    Err(_) => error!(COMPONENT, "Rpc channel closed"),
+                }
+            })
+            .await
+            .map_err(|e| anyhow!("Server failed: {e:?}"))
+    })
 }

--- a/store/src/cli/mod.rs
+++ b/store/src/cli/mod.rs
@@ -25,6 +25,10 @@ pub enum Command {
     #[command(subcommand)]
     /// Queries the Store via gRPC.
     Query(Query),
+
+    #[command(subcommand)]
+    /// Administer the Store via gRPC.
+    Admin(Admin),
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
@@ -105,6 +109,12 @@ pub struct GetTransactionInputsArgs {
     /// Nullifiers to query.
     #[arg(value_parser=parse_nullifier)]
     pub nullifiers: Vec<Digest>,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
+pub enum Admin {
+    /// Starts a server clean sthudown.
+    Shutdown,
 }
 
 /// Parses an `u64` used to repesent an account id, returns an error if the u64 doesn't fit in the

--- a/store/src/config.rs
+++ b/store/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use miden_node_utils::config::Endpoint;
+use miden_node_utils::{config::Endpoint, control_plane::ControlPlaneConfig};
 use serde::{Deserialize, Serialize};
 
 pub const CONFIG_FILENAME: &str = "miden-store.toml";
@@ -10,7 +10,7 @@ pub const CONFIG_FILENAME: &str = "miden-store.toml";
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct StoreConfig {
-    /// Defines the lisening socket.
+    /// Defines the listening socket.
     pub endpoint: Endpoint,
     /// SQLite database file
     pub database_filepath: PathBuf,
@@ -31,6 +31,7 @@ impl StoreConfig {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct StoreTopLevelConfig {
     pub store: StoreConfig,
+    pub control_plane: ControlPlaneConfig,
 }
 
 #[cfg(test)]
@@ -40,7 +41,7 @@ mod tests {
     use figment::Jail;
     use miden_node_utils::config::load_config;
 
-    use super::{Endpoint, StoreConfig, StoreTopLevelConfig};
+    use super::{ControlPlaneConfig, Endpoint, StoreConfig, StoreTopLevelConfig};
     use crate::config::CONFIG_FILENAME;
 
     #[test]
@@ -54,6 +55,10 @@ mod tests {
                     genesis_filepath = "genesis.dat"
 
                     [store.endpoint]
+                    host = "0.0.0.0"
+                    port = 80
+
+                    [control_plane.endpoint]
                     host = "127.0.0.1"
                     port = 8080
                 "#,
@@ -67,11 +72,17 @@ mod tests {
                 StoreTopLevelConfig {
                     store: StoreConfig {
                         endpoint: Endpoint {
-                            host: "127.0.0.1".to_string(),
-                            port: 8080,
+                            host: "0.0.0.0".to_string(),
+                            port: 80,
                         },
                         database_filepath: "local.sqlite3".into(),
                         genesis_filepath: "genesis.dat".into()
+                    },
+                    control_plane: ControlPlaneConfig {
+                        endpoint: Endpoint {
+                            host: "127.0.0.1".to_string(),
+                            port: 8080,
+                        },
                     }
                 }
             );

--- a/store/src/server/mod.rs
+++ b/store/src/server/mod.rs
@@ -1,35 +1,77 @@
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::{future::Future, net::ToSocketAddrs, sync::Arc};
 
-use anyhow::Result;
-use miden_node_proto::store::api_server;
+use anyhow::{anyhow, Result};
+use miden_node_proto::store::api_server::ApiServer as StoreApiServer;
+use miden_node_utils::control_plane::{
+    create_server as control_plane_create_server, ControlPlane, ControlPlaneConfig,
+};
+use tokio::sync::oneshot::Receiver;
 use tonic::transport::Server;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
 
 use crate::{config::StoreConfig, db::Db, state::State, COMPONENT};
 
 mod api;
 
-// STORE INITIALIZER
-// ================================================================================================
-
-#[instrument(skip(config, db))]
 pub async fn serve(
-    config: StoreConfig,
+    store_config: StoreConfig,
+    control_plane_config: ControlPlaneConfig,
     db: Db,
 ) -> Result<()> {
+    let mut control_plane = ControlPlane::new();
+
+    let store_shutdown = control_plane.shutdown_waiter()?;
+    let store_server = create_server(store_config, db, store_shutdown).await?;
+    let control_plane_server =
+        control_plane_create_server(control_plane_config, control_plane).await?;
+
+    let (control_plane_res, store_res) =
+        tokio::join!(tokio::spawn(control_plane_server), tokio::spawn(store_server));
+
+    match control_plane_res {
+        Ok(Ok(_)) => info!(COMPONENT, "Control plane successfully shut down"),
+        Ok(Err(err)) => error!(COMPONENT, "Control plane shut down with an error {err:?}"),
+        Err(_) => error!(COMPONENT, "Control plane join failed"),
+    }
+    match store_res {
+        Ok(Ok(_)) => info!(COMPONENT, "Store successfully shut down"),
+        Ok(Err(err)) => error!(COMPONENT, "Store shut down with an error {err:?}"),
+        Err(_) => error!(COMPONENT, "Store join failed"),
+    }
+
+    Ok(())
+}
+
+/// Configures the store service and returns a future to execute it.
+#[instrument(skip_all)]
+pub async fn create_server(
+    config: StoreConfig,
+    db: Db,
+    shutdown: Receiver<()>,
+) -> Result<impl Future<Output = Result<()>>> {
     let endpoint = (config.endpoint.host.as_ref(), config.endpoint.port);
     let addrs: Vec<_> = endpoint.to_socket_addrs()?.collect();
 
     let state = Arc::new(State::load(db).await?);
-    let store = api_server::ApiServer::new(api::StoreApi { state });
+    let svc = StoreApiServer::new(api::StoreApi { state });
 
     info!(
-        host = config.endpoint.host,
-        port = config.endpoint.port,
+        public_host = config.endpoint.host,
+        public_port = config.endpoint.port,
         COMPONENT,
-        "Server initialized",
+        "Store server initialized",
     );
-    Server::builder().add_service(store).serve(addrs[0]).await?;
 
-    Ok(())
+    Ok(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown(addrs[0], async {
+                match shutdown.await {
+                    Ok(_) => info!(COMPONENT, "Store shutdown"),
+                    Err(_) => error!(COMPONENT, "Store channel closed"),
+                }
+            })
+            .await
+            .map_err(|e| anyhow!("Server failed: {e:?}"))
+    })
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0" }
 figment = { version = "0.10", features = ["toml", "env"] }
+miden-node-proto = { path = "../proto" }
 serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.29" }
+tonic = { version = "0.10" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/utils/src/control_plane.rs
+++ b/utils/src/control_plane.rs
@@ -1,0 +1,148 @@
+use anyhow::{anyhow, Result};
+use miden_node_proto::control_plane::api_server::ApiServer;
+use miden_node_proto::control_plane::{api_server, ShutdownRequest, ShutdownResponse};
+use serde::{Deserialize, Serialize};
+use std::{error::Error, fmt::Display, future::Future, net::ToSocketAddrs};
+use tokio::sync::{oneshot, RwLock};
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+use tracing::{error, info};
+
+use crate::config::Endpoint;
+
+pub const COMPONENT: &str = "control_plane";
+
+// CONTROL PLANE CONFIG
+// ================================================================================================
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+pub struct ControlPlaneConfig {
+    /// Defines the listening socket.
+    pub endpoint: Endpoint,
+}
+
+// CONTROL PLANE
+// ================================================================================================
+
+type ShutdownMsg = ();
+
+/// Logic to receive administering commands from the user, and dispatch commands to the running
+/// server.
+#[derive(Debug, Default)]
+pub struct ControlPlane {
+    /// List of tasks registered to be notified on shutdown.
+    ///
+    /// The control plane constructor will allocated a vector to store the waiter. Because the
+    /// server can be stopped only once, when that happens the vector is taken. If a client tries to
+    /// request for a shutdown signal after that, an error is returned instead.
+    shutdown: Option<Vec<oneshot::Sender<ShutdownMsg>>>,
+}
+
+/// Thin wrapper around [ControlPlane] providing interior mutability.
+#[derive(Debug)]
+pub struct ControlPlaneServer {
+    control_plane: RwLock<ControlPlane>,
+}
+
+impl ControlPlaneServer {
+    pub fn new(control_plane: ControlPlane) -> Self {
+        Self {
+            control_plane: RwLock::new(control_plane),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ControlPlaneError {
+    PlaneAlreadyShutdown,
+}
+
+impl Display for ControlPlaneError {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        match self {
+            ControlPlaneError::PlaneAlreadyShutdown => write!(f, "Server shutdown started"),
+        }
+    }
+}
+
+impl Error for ControlPlaneError {}
+
+impl ControlPlane {
+    pub fn new() -> Self {
+        Self {
+            shutdown: Some(Vec::new()),
+        }
+    }
+
+    /// Returns a oneshot channel which will receive a shutdown msg.
+    ///
+    /// If the control plane has already been closed, returns an error instead.
+    pub fn shutdown_waiter(&mut self) -> Result<oneshot::Receiver<ShutdownMsg>, ControlPlaneError> {
+        match self.shutdown {
+            Some(ref mut shutdown) => {
+                let (sender, receiver) = oneshot::channel();
+                shutdown.push(sender);
+                Ok(receiver)
+            },
+            _ => Err(ControlPlaneError::PlaneAlreadyShutdown),
+        }
+    }
+
+    /// Shutdown the server.
+    ///
+    /// This can be done only once, subsequent calls are noops.
+    pub fn shutdown(&mut self) {
+        if let Some(waiter) = self.shutdown.take() {
+            for sender in waiter {
+                if sender.send(()).is_err() {
+                    error!(COMPONENT, "Sending shutdown message failed");
+                };
+            }
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl api_server::Api for ControlPlaneServer {
+    async fn shutdown(
+        &self,
+        _request: Request<ShutdownRequest>,
+    ) -> Result<Response<ShutdownResponse>, Status> {
+        let mut control_plane = self.control_plane.write().await;
+        control_plane.shutdown();
+        Ok(Response::new(ShutdownResponse {}))
+    }
+}
+
+// UTILS
+// ================================================================================================
+
+/// Creates a server for the control plane.
+///
+/// This consumed the control plane, since it will be driven by the server. Any additional setup
+/// with the contorl plane must be done before creating the server with this function.
+pub async fn create_server(
+    config: ControlPlaneConfig,
+    mut control_plane: ControlPlane,
+) -> Result<impl Future<Output = Result<()>>> {
+    let shutdown = control_plane.shutdown_waiter()?;
+    let endpoint = (config.endpoint.host.as_ref(), config.endpoint.port);
+    let addrs: Vec<_> = endpoint.to_socket_addrs()?.collect();
+    let svc = ApiServer::new(ControlPlaneServer::new(control_plane));
+
+    Ok(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_shutdown(addrs[0], async {
+                match shutdown.await {
+                    Ok(_) => info!(COMPONENT, "Control plane shutdown"),
+                    Err(_) => error!(COMPONENT, "Control plane channel closed"),
+                }
+            })
+            .await
+            .map_err(|e| anyhow!("Server failed: {e:?}"))
+    })
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod control_plane;
 pub mod logging;


### PR DESCRIPTION
This PR does a few things:

- Add a control plane gRPC spec.
    - It may not be the best idea to share a single admin interface across all services, but for the time being it is a good first step, and there will likely be some commands that are consistently available for all services
- Add a control plane implementation, which supports shutdown signaling
    - Added this because I needed something for testing, even though the interface may change in the future when tonic upgrades to a new hyper version
- Add admin cli command, that sends the command to the control plane
- Integrate the control plane into RPC and Store
    - I started integrating it into block_producer, but it needs to spawn 3 different tasks, which requires a more complicated API, so I'm leaving it off for now


This is a short example, logs of the store node:

```
2024-01-19T20:17:56.275488Z  INFO store/src/db/mod.rs:81: Connected to the DB, sqlite: "local.sqlite3", COMPONENT: "miden-store"
2024-01-19T20:17:56.329984Z  INFO create_server: store/src/server/mod.rs:46: new
2024-01-19T20:17:56.330020Z  INFO create_server:load: store/src/state.rs:137: new
2024-01-19T20:17:56.330041Z  INFO create_server:load:load_nullifier_tree: store/src/state.rs:491: new
2024-01-19T20:17:56.330196Z  INFO create_server:load:load_nullifier_tree: store/src/state.rs:503: Loaded nullifier tree, num_of_leaves: 0, tree_construction: 0, COMPONENT: "miden-store"
2024-01-19T20:17:56.330235Z  INFO create_server:load:load_nullifier_tree: store/src/state.rs:491: close, time.busy: 93.1µs, time.idle: 101µs
2024-01-19T20:17:56.330280Z  INFO create_server:load:load_mmr: store/src/state.rs:512: new
2024-01-19T20:17:56.395261Z  INFO create_server:load:load_mmr: store/src/state.rs:512: close, time.busy: 64.6ms, time.idle: 394µs
2024-01-19T20:17:56.395299Z  INFO create_server:load:load_accounts: store/src/state.rs:525: new
2024-01-19T20:17:56.410493Z  INFO create_server:load:load_accounts: store/src/state.rs:525: close, time.busy: 15.1ms, time.idle: 124µs
2024-01-19T20:17:56.410524Z  INFO create_server:load: store/src/state.rs:137: close, time.busy: 79.9ms, time.idle: 572µs
2024-01-19T20:17:56.410541Z  INFO create_server: store/src/server/mod.rs:58: Store server initialized, public_host: "127.0.0.1", public_port: 8080, COMPONENT: "miden-store"
2024-01-19T20:17:56.410559Z  INFO create_server: store/src/server/mod.rs:46: close, time.busy: 80.0ms, time.idle: 570µs
2024-01-19T20:18:06.094696Z  INFO store/src/server/mod.rs:70: Store shutdown, COMPONENT: "miden-store"
2024-01-19T20:18:06.094832Z  INFO utils/src/control_plane.rs:141: Control plane shutdown, COMPONENT: "control_plane"
2024-01-19T20:18:06.095355Z  INFO store/src/server/mod.rs:32: Control plane successfully shut down, COMPONENT: "miden-store"
2024-01-19T20:18:06.095371Z  INFO store/src/server/mod.rs:37: Store successfully shut down, COMPONENT: "miden-store"
```

logs of the admin cli:

```
2024-01-19T20:18:06.035484Z  INFO store/src/db/mod.rs:81: Connected to the DB, sqlite: "local.sqlite3", COMPONENT: "miden-store"
ShutdownResponse
```