### PR TITLE
Removed `num_assets` from NoteMetadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto.git", branch = "next" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main" }
-miden_objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "bobbin-note-meta" }
+miden_objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "bobbin-note-meta" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["block-producer", "node", "proto", "rpc", "store", "utils"]
 resolver = "2"
 
 [workspace.dependencies]
-miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto.git", branch = "next" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "bobbin-note-meta" }
-miden_objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "bobbin-note-meta" }
+miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden_objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -21,14 +21,14 @@ async-trait = { version = "0.1" }
 clap = { version = "4.3", features = ["derive"] }
 figment = { version = "0.10", features = ["toml", "env"] }
 itertools = { version = "0.12" }
-miden-air = { package = "miden-air", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden-air = { package = "miden-air", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-crypto = { workspace = true }
 miden-node-proto = { path = "../proto" }
 miden-node-store = { path = "../store" }
 miden-node-utils = { path = "../utils" }
 miden_objects = { workspace = true }
-miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-miden_vm = { package = "miden-vm", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden_vm = { package = "miden-vm", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { version = "1.29", features = [
@@ -45,6 +45,6 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "bobbin-note-meta", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 once_cell = { version = "1.18" }
 winterfell = "0.7"

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -31,7 +31,13 @@ miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMi
 miden_vm = { package = "miden-vm", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
+tokio = { version = "1.29", features = [
+    "rt-multi-thread",
+    "net",
+    "macros",
+    "sync",
+    "time",
+] }
 toml = { version = "0.8" }
 tonic = { version = "0.10" }
 tracing = { workspace = true }
@@ -39,6 +45,6 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "bobbin-note-meta", default-features = false }
 once_cell = { version = "1.18" }
 winterfell = "0.7"

--- a/block-producer/src/block_builder/prover/tests.rs
+++ b/block-producer/src/block_builder/prover/tests.rs
@@ -409,10 +409,7 @@ async fn test_compute_note_root_success() {
     .into_iter()
     .zip(account_ids.iter())
     .map(|(note_digest, &account_id)| {
-        NoteEnvelope::new(
-            note_digest.into(),
-            NoteMetadata::new(account_id, Felt::from(1u64), Felt::from(0u64)),
-        )
+        NoteEnvelope::new(note_digest.into(), NoteMetadata::new(account_id, Felt::from(1u64)))
     })
     .collect();
 

--- a/block-producer/src/test_utils/proven_tx.rs
+++ b/block-producer/src/test_utils/proven_tx.rs
@@ -9,7 +9,7 @@ use miden_objects::{
     accounts::AccountId,
     notes::{NoteEnvelope, NoteMetadata, Nullifier},
     transaction::{InputNotes, OutputNotes, ProvenTransaction},
-    Digest, ONE, ZERO,
+    Digest, ONE,
 };
 use once_cell::sync::Lazy;
 use winterfell::{
@@ -63,10 +63,7 @@ impl MockProvenTxBuilder {
             .map(|note_index| {
                 let note_hash = Rpo256::hash(&note_index.to_be_bytes());
 
-                NoteEnvelope::new(
-                    note_hash.into(),
-                    NoteMetadata::new(self.mock_account.id, ONE, ZERO),
-                )
+                NoteEnvelope::new(note_hash.into(), NoteMetadata::new(self.mock_account.id, ONE))
             })
             .collect();
 

--- a/proto/proto/note.proto
+++ b/proto/proto/note.proto
@@ -10,7 +10,6 @@ message Note {
     digest.Digest note_hash = 3;
     fixed64 sender  = 4;
     uint64 tag = 5;
-    uint32 num_assets = 6;
     merkle.MerklePath merkle_path = 7;
 }
 
@@ -20,7 +19,6 @@ message NoteSyncRecord {
     digest.Digest note_hash = 2;
     fixed64 sender  = 3;
     uint64 tag = 4;
-    uint32 num_assets = 5;
     merkle.MerklePath merkle_path = 6;
 }
 
@@ -30,5 +28,4 @@ message NoteCreated {
     digest.Digest note_hash = 2;
     fixed64 sender  = 3;
     uint64 tag = 4;
-    uint32 num_assets = 5;
 }

--- a/proto/src/conversion.rs
+++ b/proto/src/conversion.rs
@@ -252,7 +252,6 @@ impl From<note::Note> for note::NoteSyncRecord {
             note_hash: value.note_hash,
             sender: value.sender,
             tag: value.tag,
-            num_assets: value.num_assets,
             merkle_path: value.merkle_path,
         }
     }
@@ -379,7 +378,6 @@ impl From<(u64, NoteEnvelope)> for note::NoteCreated {
             note_hash: Some(note.note_id().into()),
             sender: note.metadata().sender().into(),
             tag: note.metadata().tag().into(),
-            num_assets: u64::from(note.metadata().num_assets()) as u32,
             note_index: note_idx as u32,
         }
     }

--- a/proto/src/generated/note.rs
+++ b/proto/src/generated/note.rs
@@ -12,8 +12,6 @@ pub struct Note {
     pub sender: u64,
     #[prost(uint64, tag = "5")]
     pub tag: u64,
-    #[prost(uint32, tag = "6")]
-    pub num_assets: u32,
     #[prost(message, optional, tag = "7")]
     pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
 }
@@ -30,8 +28,6 @@ pub struct NoteSyncRecord {
     pub sender: u64,
     #[prost(uint64, tag = "4")]
     pub tag: u64,
-    #[prost(uint32, tag = "5")]
-    pub num_assets: u32,
     #[prost(message, optional, tag = "6")]
     pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
 }
@@ -48,6 +44,4 @@ pub struct NoteCreated {
     pub sender: u64,
     #[prost(uint64, tag = "4")]
     pub tag: u64,
-    #[prost(uint32, tag = "5")]
-    pub num_assets: u32,
 }

--- a/store/src/db/migrations.rs
+++ b/store/src/db/migrations.rs
@@ -22,13 +22,11 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             note_hash BLOB NOT NULL,
             sender INTEGER NOT NULL,
             tag INTEGER NOT NULL,
-            num_assets INTEGER NOT NULL,
             merkle_path BLOB NOT NULL,
 
             PRIMARY KEY (block_num, note_index),
             CONSTRAINT notes_block_number_is_u32 CHECK (block_num >= 0 AND block_num < 4294967296),
             CONSTRAINT notes_note_index_is_u32 CHECK (note_index >= 0 AND note_index < 4294967296),
-            CONSTRAINT notes_num_assets_is_u8 CHECK (num_assets >= 0 AND num_assets < 256),
             FOREIGN KEY (block_num) REFERENCES block_header (block_num)
         ) STRICT, WITHOUT ROWID;
 

--- a/store/src/db/sql.rs
+++ b/store/src/db/sql.rs
@@ -91,7 +91,7 @@ pub fn select_notes(conn: &mut Connection) -> Result<Vec<Note>, anyhow::Error> {
         let note_hash_data = row.get_ref(2)?.as_blob()?;
         let note_hash = Digest::decode(note_hash_data)?;
 
-        let merkle_path_data = row.get_ref(6)?.as_blob()?;
+        let merkle_path_data = row.get_ref(5)?.as_blob()?;
         let merkle_path = MerklePath::decode(merkle_path_data)?;
 
         notes.push(Note {
@@ -100,7 +100,6 @@ pub fn select_notes(conn: &mut Connection) -> Result<Vec<Note>, anyhow::Error> {
             note_hash: Some(note_hash),
             sender: column_value_as_u64(row, 3)?,
             tag: column_value_as_u64(row, 4)?,
-            num_assets: row.get(5)?,
             merkle_path: Some(merkle_path),
         })
     }
@@ -276,12 +275,11 @@ pub fn insert_notes(
             note_hash,
             sender,
             tag,
-            num_assets,
             merkle_path
         )
         VALUES
         (
-            ?1, ?2, ?3, ?4, ?5, ?6, ?7
+            ?1, ?2, ?3, ?4, ?5, ?6 
         );",
     )?;
 
@@ -293,7 +291,6 @@ pub fn insert_notes(
             note.note_hash.clone().ok_or(StateError::NoteMissingHash)?.encode_to_vec(),
             u64_to_value(note.sender),
             u64_to_value(note.tag),
-            note.num_assets as u8,
             note.merkle_path
                 .clone()
                 .ok_or(StateError::NoteMissingMerklePath)?
@@ -333,7 +330,6 @@ pub fn select_notes_since_block_by_tag_and_sender(
             note_hash,
             sender,
             tag,
-            num_assets,
             merkle_path
         FROM
             notes
@@ -366,8 +362,7 @@ pub fn select_notes_since_block_by_tag_and_sender(
         let note_hash = Some(decode_protobuf_digest(note_hash_data)?);
         let sender = column_value_as_u64(row, 3)?;
         let tag = column_value_as_u64(row, 4)?;
-        let num_assets = row.get(5)?;
-        let merkle_path_data = row.get_ref(6)?.as_blob()?;
+        let merkle_path_data = row.get_ref(5)?.as_blob()?;
         let merkle_path = Some(MerklePath::decode(merkle_path_data)?);
 
         let note = Note {
@@ -376,7 +371,6 @@ pub fn select_notes_since_block_by_tag_and_sender(
             note_hash,
             sender,
             tag,
-            num_assets,
             merkle_path,
         };
         res.push(note);

--- a/store/src/db/tests.rs
+++ b/store/src/db/tests.rs
@@ -286,7 +286,6 @@ fn test_notes() {
         note_hash: Some(num_to_protobuf_digest(3)),
         sender: 4,
         tag,
-        num_assets: 6,
         merkle_path: Some(MerklePath {
             siblings: merkle_path.clone(),
         }),
@@ -327,7 +326,6 @@ fn test_notes() {
         note_hash: Some(num_to_protobuf_digest(3)),
         sender: note.sender,
         tag: note.tag,
-        num_assets: note.num_assets,
         merkle_path: Some(MerklePath {
             siblings: merkle_path,
         }),

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -282,7 +282,6 @@ impl State {
                         sender: note.sender,
                         note_index: note.note_index,
                         tag: note.tag,
-                        num_assets: note.num_assets,
                         merkle_path: Some(merkle_path.into()),
                     })
                 })
@@ -479,7 +478,7 @@ pub fn build_notes_tree(
     for note in notes.iter() {
         let note_hash = note.note_hash.clone().ok_or(StateError::MissingNoteHash)?;
         let account_id = note.sender.try_into().or(Err(StateError::InvalidAccountId))?;
-        let note_metadata = NoteMetadata::new(account_id, note.tag.into(), note.num_assets.into());
+        let note_metadata = NoteMetadata::new(account_id, note.tag.into());
         let index = note.note_index as u64;
         entries.push((index, note_hash.try_into()?));
         entries.push((index + 1, note_metadata.into()));


### PR DESCRIPTION
Removed `num_assets` from `NoteMetadata` in the miden-node, this will enable the clean update of from the breaking changes made in the miden-base.

Linked to: https://github.com/0xPolygonMiden/miden-base/pull/414

Closes: #169 