### PR TITLE
sync_state: remove block_path, fixes #164

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,9 @@ insert_final_newline = true
 [*.rs]
 max_line_length = 100
 
+[*.proto]
+max_line_length = 100
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/proto/proto/account.proto
+++ b/proto/proto/account.proto
@@ -4,10 +4,9 @@ package account;
 import "digest.proto";
 
 message AccountId {
-    // A miden account is defined with a little bit of proof-of-work, the id itself
-    // is defined as the first word of a hash digest. For this reason account ids
-    // can be considered as random values, because of that the encoding bellow uses
-    // fixed 64 bits, instead of zig-zag encoding.
+    // A miden account is defined with a little bit of proof-of-work, the id itself is defined as
+    // the first word of a hash digest. For this reason account ids can be considered as random
+    // values, because of that the encoding bellow uses fixed 64 bits, instead of zig-zag encoding.
     fixed64 id = 1;
 }
 

--- a/proto/proto/requests.proto
+++ b/proto/proto/requests.proto
@@ -31,14 +31,34 @@ message GetBlockHeaderByNumberRequest {
 }
 
 // State synchronization request.
+//
+// Specifies state updates the client is intersted in. The server will return the first block which
+// contains a note matching `note_tags` or the chain tip. And the corresponding updates to
+// `nullifiers` and `account_ids` for that block range.
 message SyncStateRequest {
-    // Send updates to the client starting at this block.
+    // Last block known by the client. The response will contain data starting from the next block,
+    // until the first block which contains a note of matching the requested tag, or the chain tip
+    // if there are no notes.
     uint32 block_num = 1;
 
+    // Accounts' hash to include in the response.
+    //
+    // An account hash will be included if-and-only-if it is the latest update. Meaning it is
+    // possible there was an update to the account for the given range, but if it is not the latest,
+    // it won't be included in the response.
     repeated account.AccountId account_ids = 2;
 
-    // Tags and nullifiers are filters, both filters correspond to the high 16 bits of the real values.
+    // Determines the tags which the client is interested in. These are only the 16high bits of the
+    // note's complete tag.
+    //
+    // The above means it is not possible to request an specific note, but only a "note family",
+    // this is done to increase the privacy of the client, by hiding the note's the client is
+    // intereted on.
     repeated uint32 note_tags = 3;
+
+    // Determines the nullifiers the client is interested in.
+    //
+    // Similarly to the note_tags, this determins only the 16high bits of the target nullifier.
     repeated uint32 nullifiers = 4;
 }
 

--- a/proto/proto/responses.proto
+++ b/proto/proto/responses.proto
@@ -12,8 +12,7 @@ import "tsmt.proto";
 message ApplyBlockResponse {}
 
 message CheckNullifiersResponse {
-    // Each requested nullifier has its corresponding nullifier proof at the
-    // same position.
+    // Each requested nullifier has its corresponding nullifier proof at the same position.
     repeated tsmt.NullifierProof proofs = 1;
 }
 
@@ -39,19 +38,16 @@ message SyncStateResponse {
     // block header of the block with the first note matching the specified criteria
     block_header.BlockHeader block_header = 2;
 
-    // data needed to update the partial MMR from `block_num` to `block_header.block_num`
+    // data needed to update the partial MMR from `block_num + 1` to `block_header.block_num`
     mmr.MmrDelta mmr_delta = 3;
 
-    // Merkle path in the updated chain MMR to the block at `block_header.block_num`
-    merkle.MerklePath block_path = 4;
-
-    // a list of account hashes updated after `block_num` but not after `block_header.block_num`
+    // a list of account hashes updated after `block_num + 1` but not after `block_header.block_num`
     repeated AccountHashUpdate accounts = 5;
 
     // a list of all notes together with the Merkle paths from `block_header.note_root`
     repeated note.NoteSyncRecord notes = 6;
 
-    // a list of nullifiers created between `block_num` and `block_header.block_num`
+    // a list of nullifiers created between `block_num + 1` and `block_header.block_num`
     repeated NullifierUpdate nullifiers = 7;
 }
 

--- a/proto/proto/tsmt.proto
+++ b/proto/proto/tsmt.proto
@@ -2,18 +2,18 @@
 //
 // Notes about TSMT:
 // - The tree is a key value store, both are digest values.
-// - The key's most significant element is used to deterministically assign the
-//   pair to one of the tree's entries.
-// - The tree is denominated tiered because entries are only possible at
-//   specific tiers, each tier corresponding to a depth (16/32/48/64).
-// - The key's most significant quibbles (16 bits), are used to determine the
-//   pair's entry at a given tier.
-// - Depths 16/32/48 contain at most one value. Pair collision on these tiers
-//   causes them to to be pushed to lower tiers.
-// - The depth 64 may store a list of entries. The entries are stored in sorted
-//   order, determined by their keys.
-// - The tree supports non-inclusion proofs. Achieved with a merkle path and
-//   the absenced of the key in the opened leaf.
+// - The key's most significant element is used to deterministically assign the pair to one of the
+//   tree's entries.
+// - The tree is denominated tiered because entries are only possible at specific tiers, each tier
+//   corresponding to a depth (16/32/48/64).
+// - The key's most significant quibbles (16 bits), are used to determine the pair's entry at a
+//   given tier.
+// - Depths 16/32/48 contain at most one value. Pair collision on these tiers causes them to to be
+//   pushed to lower tiers.
+// - The depth 64 may store a list of entries. The entries are stored in sorted order, determined by
+//   their keys.
+// - The tree supports non-inclusion proofs. Achieved with a merkle path and the absenced of the key
+//   in the opened leaf.
 // - The tree is initialized with null word [0,0,0,0] for the leaves.
 syntax = "proto3";
 package tsmt;
@@ -27,13 +27,12 @@ message NullifierLeaf {
 
 // A Nullifier proof is a special case of a TSMT proof, where the leaf is a u32.
 //
-// This proof supports both inclusion and non-inclusion proofs. This is an
-// inclusion proof if target key is in the `leaves` list, non-inclusion
-// otherwise.
+// This proof supports both inclusion and non-inclusion proofs. This is an inclusion proof if target
+// key is in the `leaves` list, non-inclusion otherwise.
 message NullifierProof {
-    // For depth 64 this may have multiple entries. The list is empty if there
-    // is no leaf. If the list is non empty, a check for the target value has
-    // to be done to determine if it is a inclusion or non-inclusion proof.
+    // For depth 64 this may have multiple entries. The list is empty if there is no leaf. If the
+    // list is non empty, a check for the target value has to be done to determine if it is a
+    // inclusion or non-inclusion proof.
     repeated NullifierLeaf leaves = 1;
 
     // The merkle path authenticating the leaf values.

--- a/proto/src/generated/account.rs
+++ b/proto/src/generated/account.rs
@@ -2,10 +2,9 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountId {
-    /// A miden account is defined with a little bit of proof-of-work, the id itself
-    /// is defined as the first word of a hash digest. For this reason account ids
-    /// can be considered as random values, because of that the encoding bellow uses
-    /// fixed 64 bits, instead of zig-zag encoding.
+    /// A miden account is defined with a little bit of proof-of-work, the id itself is defined as
+    /// the first word of a hash digest. For this reason account ids can be considered as random
+    /// values, because of that the encoding bellow uses fixed 64 bits, instead of zig-zag encoding.
     #[prost(fixed64, tag = "1")]
     pub id: u64,
 }

--- a/proto/src/generated/requests.rs
+++ b/proto/src/generated/requests.rs
@@ -38,18 +38,37 @@ pub struct GetBlockHeaderByNumberRequest {
     pub block_num: ::core::option::Option<u32>,
 }
 /// State synchronization request.
+///
+/// Specifies state updates the client is intersted in. The server will return the first block which
+/// contains a note matching `note_tags` or the chain tip. And the corresponding updates to
+/// `nullifiers` and `account_ids` for that block range.
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncStateRequest {
-    /// Send updates to the client starting at this block.
+    /// Last block known by the client. The response will contain data starting from the next block,
+    /// until the first block which contains a note of matching the requested tag, or the chain tip
+    /// if there are no notes.
     #[prost(uint32, tag = "1")]
     pub block_num: u32,
+    /// Accounts' hash to include in the response.
+    ///
+    /// An account hash will be included if-and-only-if it is the latest update. Meaning it is
+    /// possible there was an update to the account for the given range, but if it is not the latest,
+    /// it won't be included in the response.
     #[prost(message, repeated, tag = "2")]
     pub account_ids: ::prost::alloc::vec::Vec<super::account::AccountId>,
-    /// Tags and nullifiers are filters, both filters correspond to the high 16 bits of the real values.
+    /// Determines the tags which the client is interested in. These are only the 16high bits of the
+    /// note's complete tag.
+    ///
+    /// The above means it is not possible to request an specific note, but only a "note family",
+    /// this is done to increase the privacy of the client, by hiding the note's the client is
+    /// intereted on.
     #[prost(uint32, repeated, tag = "3")]
     pub note_tags: ::prost::alloc::vec::Vec<u32>,
+    /// Determines the nullifiers the client is interested in.
+    ///
+    /// Similarly to the note_tags, this determins only the 16high bits of the target nullifier.
     #[prost(uint32, repeated, tag = "4")]
     pub nullifiers: ::prost::alloc::vec::Vec<u32>,
 }

--- a/proto/src/generated/responses.rs
+++ b/proto/src/generated/responses.rs
@@ -6,8 +6,7 @@ pub struct ApplyBlockResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersResponse {
-    /// Each requested nullifier has its corresponding nullifier proof at the
-    /// same position.
+    /// Each requested nullifier has its corresponding nullifier proof at the same position.
     #[prost(message, repeated, tag = "1")]
     pub proofs: ::prost::alloc::vec::Vec<super::tsmt::NullifierProof>,
 }
@@ -48,19 +47,16 @@ pub struct SyncStateResponse {
     /// block header of the block with the first note matching the specified criteria
     #[prost(message, optional, tag = "2")]
     pub block_header: ::core::option::Option<super::block_header::BlockHeader>,
-    /// data needed to update the partial MMR from `block_num` to `block_header.block_num`
+    /// data needed to update the partial MMR from `block_num + 1` to `block_header.block_num`
     #[prost(message, optional, tag = "3")]
     pub mmr_delta: ::core::option::Option<super::mmr::MmrDelta>,
-    /// Merkle path in the updated chain MMR to the block at `block_header.block_num`
-    #[prost(message, optional, tag = "4")]
-    pub block_path: ::core::option::Option<super::merkle::MerklePath>,
-    /// a list of account hashes updated after `block_num` but not after `block_header.block_num`
+    /// a list of account hashes updated after `block_num + 1` but not after `block_header.block_num`
     #[prost(message, repeated, tag = "5")]
     pub accounts: ::prost::alloc::vec::Vec<AccountHashUpdate>,
     /// a list of all notes together with the Merkle paths from `block_header.note_root`
     #[prost(message, repeated, tag = "6")]
     pub notes: ::prost::alloc::vec::Vec<super::note::NoteSyncRecord>,
-    /// a list of nullifiers created between `block_num` and `block_header.block_num`
+    /// a list of nullifiers created between `block_num + 1` and `block_header.block_num`
     #[prost(message, repeated, tag = "7")]
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierUpdate>,
 }

--- a/proto/src/generated/tsmt.rs
+++ b/proto/src/generated/tsmt.rs
@@ -9,16 +9,15 @@ pub struct NullifierLeaf {
 }
 /// A Nullifier proof is a special case of a TSMT proof, where the leaf is a u32.
 ///
-/// This proof supports both inclusion and non-inclusion proofs. This is an
-/// inclusion proof if target key is in the `leaves` list, non-inclusion
-/// otherwise.
+/// This proof supports both inclusion and non-inclusion proofs. This is an inclusion proof if target
+/// key is in the `leaves` list, non-inclusion otherwise.
 #[derive(Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NullifierProof {
-    /// For depth 64 this may have multiple entries. The list is empty if there
-    /// is no leaf. If the list is non empty, a check for the target value has
-    /// to be done to determine if it is a inclusion or non-inclusion proof.
+    /// For depth 64 this may have multiple entries. The list is empty if there is no leaf. If the
+    /// list is non empty, a check for the target value has to be done to determine if it is a
+    /// inclusion or non-inclusion proof.
     #[prost(message, repeated, tag = "1")]
     pub leaves: ::prost::alloc::vec::Vec<NullifierLeaf>,
     /// The merkle path authenticating the leaf values.

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -85,11 +85,10 @@ contains excessive notes and nullifiers, client can make additional filtering of
 
 * `chain_tip`: `uint32` – number of the latest block in the chain.
 * `block_header`: `BlockHeader` – block header of the block with the first note matching the specified criteria.
-* `mmr_delta`: `MmrDelta` – data needed to update the partial MMR from `block_num` to `block_header.block_num`.
-* `block_path`: `MerklePath` – Merkle path in the updated chain MMR to the block at `block_header.block_num`.
-* `accounts`: `[AccountHashUpdate]` – a list of account hashes updated after `block_num` but not after `block_header.block_num`.
+* `mmr_delta`: `MmrDelta` – data needed to update the partial MMR from `block_num + 1` to `block_header.block_num`.
+* `accounts`: `[AccountHashUpdate]` – a list of account hashes updated after `block_num + 1` but not after `block_header.block_num`.
 * `notes`: `[NoteSyncRecord]` – a list of all notes together with the Merkle paths from `block_header.note_root`.
-* `nullifiers`: `[NullifierUpdate]` – a list of nullifiers created between `block_num` and `block_header.block_num`.
+* `nullifiers`: `[NullifierUpdate]` – a list of nullifiers created between `block_num + 1` and `block_header.block_num`.
 
 ### SubmitProvenTransaction
 

--- a/store/README.md
+++ b/store/README.md
@@ -131,11 +131,10 @@ contains excessive notes and nullifiers, client can make additional filtering of
 
 * `chain_tip`: `uint32` – number of the latest block in the chain.
 * `block_header`: `BlockHeader` – block header of the block with the first note matching the specified criteria.
-* `mmr_delta`: `MmrDelta` – data needed to update the partial MMR from `block_num` to `block_header.block_num`.
-* `block_path`: `MerklePath` – Merkle path in the updated chain MMR to the block at `block_header.block_num`.
-* `accounts`: `[AccountHashUpdate]` – a list of account hashes updated after `block_num` but not after `block_header.block_num`.
+* `mmr_delta`: `MmrDelta` – data needed to update the partial MMR from `block_num + 1` to `block_header.block_num`.
+* `accounts`: `[AccountHashUpdate]` – a list of account hashes updated after `block_num + 1` but not after `block_header.block_num`.
 * `notes`: `[NoteSyncRecord]` – a list of all notes together with the Merkle paths from `block_header.note_root`.
-* `nullifiers`: `[NullifierUpdate]` – a list of nullifiers created between `block_num` and `block_header.block_num`.
+* `nullifiers`: `[NullifierUpdate]` – a list of nullifiers created between `block_num + 1` and `block_header.block_num`.
 
 ## Methods for testing purposes
 

--- a/store/src/server/api.rs
+++ b/store/src/server/api.rs
@@ -79,7 +79,7 @@ impl api_server::Api for StoreApi {
 
         let account_ids: Vec<u64> = request.account_ids.iter().map(|e| e.id).collect();
 
-        let (state, delta, path) = self
+        let (state, delta) = self
             .state
             .sync_state(request.block_num, &account_ids, &request.note_tags, &request.nullifiers)
             .await
@@ -89,7 +89,6 @@ impl api_server::Api for StoreApi {
             chain_tip: state.chain_tip,
             block_header: Some(state.block_header),
             mmr_delta: Some(delta.into()),
-            block_path: Some(path.into()),
             accounts: state.account_updates,
             notes: convert(state.notes),
             nullifiers: state.nullifiers,

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -341,7 +341,7 @@ impl State {
         account_ids: &[AccountId],
         note_tag_prefixes: &[u32],
         nullifier_prefixes: &[u32],
-    ) -> Result<(StateSyncUpdate, MmrDelta, MerklePath), anyhow::Error> {
+    ) -> Result<(StateSyncUpdate, MmrDelta), anyhow::Error> {
         let inner = self.inner.read().await;
 
         let state_sync = self
@@ -349,19 +349,27 @@ impl State {
             .get_state_sync(block_num, account_ids, note_tag_prefixes, nullifier_prefixes)
             .await?;
 
-        let (delta, path) = {
-            let delta = inner
-                .chain_mmr
-                .get_delta(block_num as usize, state_sync.block_header.block_num as usize)?;
-
-            let proof = inner
-                .chain_mmr
-                .open(block_num as usize, state_sync.block_header.block_num as usize)?;
-
-            (delta, proof.merkle_path)
+        let delta = if block_num == state_sync.block_header.block_num {
+            // The client is in sync with the chain tip.
+            MmrDelta {
+                forest: block_num as usize,
+                data: vec![],
+            }
+        } else {
+            // Important notes about the boundary conditions:
+            //
+            // - The Mmr forest is 1-indexed whereas the block number is 0-indexed. The Mmr root
+            // contained in the block header always lag behind by one block, this is because the Mmr
+            // leaves are hashes of block headers, and we can't have self-referential hashes. These two
+            // points cancel out and don't require adjusting.
+            // - Mmr::get_delta is inclusive, whereas the sync_state request block_num is defined to be
+            // exclusive, so the from_forest has to be adjusted with a +1
+            let from_forest = (block_num + 1) as usize;
+            let to_forest = state_sync.block_header.block_num as usize;
+            inner.chain_mmr.get_delta(from_forest, to_forest)?
         };
 
-        Ok((state_sync, delta, path))
+        Ok((state_sync, delta))
     }
 
     /// Returns data needed by the block producer to construct and prove the next block.


### PR DESCRIPTION
as per the title, this removes `block_path` and fixes #164