### PR TITLE
proposal:  remove transaction queue trait

### DIFF
--- a/block-producer/src/server/api.rs
+++ b/block-producer/src/server/api.rs
@@ -11,28 +11,30 @@ use miden_objects::transaction::ProvenTransaction;
 use tonic::Status;
 use tracing::{debug, info, instrument};
 
-use crate::{txqueue::TransactionQueue, COMPONENT};
+use crate::{
+    batch_builder::BatchBuilder,
+    txqueue::{TransactionQueue, TransactionVerifier},
+    COMPONENT,
+};
 
 // BLOCK PRODUCER
 // ================================================================================================
 
-pub struct BlockProducerApi<T> {
-    queue: Arc<T>,
+pub struct BlockProducerApi<BB, TV> {
+    queue: Arc<TransactionQueue<BB, TV>>,
 }
 
-impl<T> BlockProducerApi<T>
-where
-    T: TransactionQueue,
-{
-    pub fn new(queue: Arc<T>) -> Self {
+impl<BB, TV> BlockProducerApi<BB, TV> {
+    pub fn new(queue: Arc<TransactionQueue<BB, TV>>) -> Self {
         Self { queue }
     }
 }
 
 #[tonic::async_trait]
-impl<T> api_server::Api for BlockProducerApi<T>
+impl<BB, TV> api_server::Api for BlockProducerApi<BB, TV>
 where
-    T: TransactionQueue,
+    TV: TransactionVerifier,
+    BB: BatchBuilder,
 {
     #[allow(clippy::blocks_in_conditions)] // Workaround of `instrument` issue
     #[instrument(

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     config::BlockProducerConfig,
     state_view::DefaultStateView,
     store::DefaultStore,
-    txqueue::{DefaultTransactionQueue, DefaultTransactionQueueOptions},
+    txqueue::{TransactionQueue, TransactionQueueOptions},
     COMPONENT, SERVER_BATCH_SIZE, SERVER_BLOCK_FREQUENCY, SERVER_BUILD_BATCH_FREQUENCY,
     SERVER_MAX_BATCHES_PER_BLOCK,
 };
@@ -40,11 +40,11 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
     let batch_builder =
         Arc::new(DefaultBatchBuilder::new(Arc::new(block_builder), batch_builder_options));
 
-    let transaction_queue_options = DefaultTransactionQueueOptions {
+    let transaction_queue_options = TransactionQueueOptions {
         build_batch_frequency: SERVER_BUILD_BATCH_FREQUENCY,
         batch_size: SERVER_BATCH_SIZE,
     };
-    let queue = Arc::new(DefaultTransactionQueue::new(
+    let queue = Arc::new(TransactionQueue::new(
         state_view,
         batch_builder.clone(),
         transaction_queue_options,

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -104,18 +104,7 @@ impl Display for AddTransactionError {
 // TRANSACTION QUEUE
 // ================================================================================================
 
-#[async_trait]
-pub trait TransactionQueue: Send + Sync + 'static {
-    async fn add_transaction(
-        &self,
-        tx: SharedProvenTx,
-    ) -> Result<(), AddTransactionError>;
-}
-
-// DEFAULT TRANSACTION QUEUE
-// ================================================================================================
-
-pub struct DefaultTransactionQueueOptions {
+pub struct TransactionQueueOptions {
     /// The frequency at which we try to build batches from transactions in the queue
     pub build_batch_frequency: Duration,
 
@@ -123,14 +112,14 @@ pub struct DefaultTransactionQueueOptions {
     pub batch_size: usize,
 }
 
-pub struct DefaultTransactionQueue<BB, TV> {
+pub struct TransactionQueue<BB, TV> {
     ready_queue: SharedRwVec<SharedProvenTx>,
     tx_verifier: Arc<TV>,
     batch_builder: Arc<BB>,
-    options: DefaultTransactionQueueOptions,
+    options: TransactionQueueOptions,
 }
 
-impl<BB, TV> DefaultTransactionQueue<BB, TV>
+impl<BB, TV> TransactionQueue<BB, TV>
 where
     TV: TransactionVerifier,
     BB: BatchBuilder,
@@ -138,7 +127,7 @@ where
     pub fn new(
         tx_verifier: Arc<TV>,
         batch_builder: Arc<BB>,
-        options: DefaultTransactionQueueOptions,
+        options: TransactionQueueOptions,
     ) -> Self {
         Self {
             ready_queue: Arc::new(RwLock::new(Vec::new())),
@@ -188,17 +177,14 @@ where
             });
         }
     }
-}
 
-#[async_trait]
-impl<BB, TV> TransactionQueue for DefaultTransactionQueue<BB, TV>
-where
-    TV: TransactionVerifier,
-    BB: BatchBuilder,
-{
+    /// Queues `tx` to be added in a batch and subsequently into a block.
+    ///
+    /// This method will validate the `tx` and ensure it is valid w.r.t. the rollup state, and the
+    /// current in-flight transactions.
     #[allow(clippy::blocks_in_conditions)] // Workaround of `instrument` issue
     #[instrument(target = "miden-block-producer", skip_all, err)]
-    async fn add_transaction(
+    pub async fn add_transaction(
         &self,
         tx: SharedProvenTx,
     ) -> Result<(), AddTransactionError> {

--- a/block-producer/src/txqueue/tests/mod.rs
+++ b/block-producer/src/txqueue/tests/mod.rs
@@ -81,10 +81,10 @@ async fn test_build_batch_success() {
 
     let batch_builder = Arc::new(BatchBuilderSuccess::default());
 
-    let tx_queue = DefaultTransactionQueue::new(
+    let tx_queue = TransactionQueue::new(
         Arc::new(TransactionVerifierSuccess),
         batch_builder.clone(),
-        DefaultTransactionQueueOptions {
+        TransactionQueueOptions {
             build_batch_frequency,
             batch_size,
         },
@@ -117,10 +117,10 @@ async fn test_tx_verify_failure() {
 
     let batch_builder = Arc::new(BatchBuilderSuccess::default());
 
-    let tx_queue = DefaultTransactionQueue::new(
+    let tx_queue = TransactionQueue::new(
         Arc::new(TransactionVerifierFailure),
         batch_builder.clone(),
-        DefaultTransactionQueueOptions {
+        TransactionQueueOptions {
             build_batch_frequency,
             batch_size,
         },
@@ -155,10 +155,10 @@ async fn test_build_batch_failure() {
 
     let batch_builder = Arc::new(BatchBuilderFailure);
 
-    let tx_queue = DefaultTransactionQueue::new(
+    let tx_queue = TransactionQueue::new(
         Arc::new(TransactionVerifierSuccess),
         batch_builder.clone(),
-        DefaultTransactionQueueOptions {
+        TransactionQueueOptions {
             build_batch_frequency,
             batch_size,
         },


### PR DESCRIPTION
# why?

1. This trait is currently not used for testing.
2. As it currently stands, the block producer itself is the queue. Meaning I think it is unlikely this queue will need an additional implementation to support a remote queue.
3. This change makes `BlockProducerApi` depend on a concrete struct, making it easier to follow the code, e.g.:
    - jump to definition goes to the implementation instead of the trait definition
    - the mental model is more direct, removing one indirection level