### PR TITLE
block_builder: using borrows instead of refcount

### DIFF
--- a/block-producer/src/batch_builder/errors.rs
+++ b/block-producer/src/batch_builder/errors.rs
@@ -1,15 +1,31 @@
+use miden_objects::transaction::ProvenTransaction;
 use miden_vm::crypto::MerkleError;
 use thiserror::Error;
 
 use crate::MAX_NUM_CREATED_NOTES_PER_BATCH;
 
-#[derive(Error, Debug, PartialEq)]
+/// Error that may happen while building a transaction batch.
+///
+/// These errors are returned from the batch builder to the transaction queue, instead of
+/// dropping the transactions, they are included into the error values, so that the transaction
+/// queue can re-queue them.
+#[derive(Error, Debug)]
 pub enum BuildBatchError {
     #[error(
         "Too many notes in the batch. Got: {0}, max: {}",
         MAX_NUM_CREATED_NOTES_PER_BATCH
     )]
-    TooManyNotesCreated(usize),
+    TooManyNotesCreated(usize, Vec<ProvenTransaction>),
+
     #[error("failed to create notes SMT: {0}")]
-    NotesSmtError(#[from] MerkleError),
+    NotesSmtError(MerkleError, Vec<ProvenTransaction>),
+}
+
+impl BuildBatchError {
+    pub fn into_transactions(self) -> Vec<ProvenTransaction> {
+        match self {
+            BuildBatchError::TooManyNotesCreated(_, txs) => txs,
+            BuildBatchError::NotesSmtError(_, txs) => txs,
+        }
+    }
 }

--- a/block-producer/src/block_builder/mod.rs
+++ b/block-producer/src/block_builder/mod.rs
@@ -5,9 +5,10 @@ use miden_objects::{accounts::AccountId, Digest};
 use tracing::info;
 
 use crate::{
+    batch_builder::batch::TransactionBatch,
     block::Block,
     store::{ApplyBlock, Store},
-    SharedTxBatch, COMPONENT, MAX_NUM_CREATED_NOTES_PER_BATCH,
+    COMPONENT, MAX_NUM_CREATED_NOTES_PER_BATCH,
 };
 
 pub mod errors;
@@ -33,7 +34,7 @@ pub trait BlockBuilder: Send + Sync + 'static {
     /// block. In other words, if `build_block()` is never called, then no blocks are produced.
     async fn build_block(
         &self,
-        batches: Vec<SharedTxBatch>,
+        batches: &[TransactionBatch],
     ) -> Result<(), BuildBlockError>;
 }
 
@@ -69,7 +70,7 @@ where
 {
     async fn build_block(
         &self,
-        batches: Vec<SharedTxBatch>,
+        batches: &[TransactionBatch],
     ) -> Result<(), BuildBlockError> {
         let account_updates: Vec<(AccountId, Digest)> =
             batches.iter().flat_map(|batch| batch.updated_accounts()).collect();

--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -5,8 +5,8 @@ use miden_objects::transaction::{InputNotes, OutputNotes};
 // 1. `apply_block()` is called
 use super::*;
 use crate::{
-    batch_builder::TransactionBatch,
     test_utils::{DummyProvenTxGenerator, MockStoreFailure, MockStoreSuccessBuilder},
+    TransactionBatch,
 };
 
 /// Tests that `build_block()` succeeds when the transaction batches are not empty
@@ -24,22 +24,22 @@ async fn test_apply_block_called_nonempty_batches() {
 
     let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());
 
-    let batches: Vec<SharedTxBatch> = {
+    let batches: Vec<TransactionBatch> = {
         let batch_1 = {
-            let tx = Arc::new(tx_gen.dummy_proven_tx_with_params(
+            let tx = tx_gen.dummy_proven_tx_with_params(
                 account_id,
                 account_initial_hash,
                 [Felt::from(2u64), Felt::from(2u64), Felt::from(2u64), Felt::from(2u64)].into(),
                 InputNotes::new(Vec::new()).unwrap(),
                 OutputNotes::new(Vec::new()).unwrap(),
-            ));
+            );
 
-            Arc::new(TransactionBatch::new(vec![tx]).unwrap())
+            TransactionBatch::new(vec![tx]).unwrap()
         };
 
         vec![batch_1]
     };
-    block_builder.build_block(batches).await.unwrap();
+    block_builder.build_block(&batches).await.unwrap();
 
     // Ensure that the store's `apply_block()` was called
     assert_eq!(*store.num_apply_block_called.read().await, 1);
@@ -59,7 +59,7 @@ async fn test_apply_block_called_empty_batches() {
 
     let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());
 
-    block_builder.build_block(Vec::new()).await.unwrap();
+    block_builder.build_block(&Vec::new()).await.unwrap();
 
     // Ensure that the store's `apply_block()` was called
     assert_eq!(*store.num_apply_block_called.read().await, 1);
@@ -72,7 +72,7 @@ async fn test_build_block_failure() {
 
     let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());
 
-    let result = block_builder.build_block(Vec::new()).await;
+    let result = block_builder.build_block(&Vec::new()).await;
 
     // Ensure that the store's `apply_block()` was called
     assert!(matches!(result, Err(BuildBlockError::GetBlockInputsFailed(_))));

--- a/block-producer/src/lib.rs
+++ b/block-producer/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use batch_builder::TransactionBatch;
+use batch_builder::batch::TransactionBatch;
 use miden_objects::transaction::ProvenTransaction;
 use tokio::sync::RwLock;
 
@@ -22,8 +22,6 @@ pub mod server;
 // =================================================================================================
 
 /// A proven transaction that can be shared across threads
-pub(crate) type SharedProvenTx = Arc<ProvenTransaction>;
-pub(crate) type SharedTxBatch = Arc<TransactionBatch>;
 pub(crate) type SharedRwVec<T> = Arc<RwLock<Vec<T>>>;
 
 // CONSTANTS

--- a/block-producer/src/server/api.rs
+++ b/block-producer/src/server/api.rs
@@ -68,7 +68,7 @@ where
         debug!(target: COMPONENT, proof = ?tx.proof());
 
         self.queue
-            .add_transaction(Arc::new(tx))
+            .add_transaction(tx)
             .await
             .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?;
 

--- a/block-producer/src/state_view/tests/apply_block.rs
+++ b/block-producer/src/state_view/tests/apply_block.rs
@@ -34,7 +34,7 @@ async fn test_apply_block_ab1() {
     let state_view = DefaultStateView::new(store.clone());
 
     // Verify transaction so it can be tracked in state view
-    let verify_tx_res = state_view.verify_tx(tx.into()).await;
+    let verify_tx_res = state_view.verify_tx(&tx).await;
     assert!(verify_tx_res.is_ok());
 
     let block = MockBlockBuilder::new(&store)
@@ -74,7 +74,7 @@ async fn test_apply_block_ab2() {
 
     // Verify transactions so it can be tracked in state view
     for tx in txs {
-        let verify_tx_res = state_view.verify_tx(tx).await;
+        let verify_tx_res = state_view.verify_tx(&tx).await;
         assert!(verify_tx_res.is_ok());
     }
 
@@ -123,7 +123,7 @@ async fn test_apply_block_ab3() {
 
     // Verify transactions so it can be tracked in state view
     for tx in txs.clone() {
-        let verify_tx_res = state_view.verify_tx(tx).await;
+        let verify_tx_res = state_view.verify_tx(&tx).await;
         assert!(verify_tx_res.is_ok());
     }
 
@@ -151,7 +151,7 @@ async fn test_apply_block_ab3() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let verify_tx_res = state_view.verify_tx(tx_new.into()).await;
+    let verify_tx_res = state_view.verify_tx(&tx_new).await;
     assert_eq!(
         verify_tx_res,
         Err(VerifyTxError::InputNotesAlreadyConsumed(txs[0].input_notes().clone()))

--- a/block-producer/src/state_view/tests/mod.rs
+++ b/block-producer/src/state_view/tests/mod.rs
@@ -29,7 +29,7 @@ pub fn nullifier_by_index(index: u32) -> Nullifier {
 pub fn get_txs_and_accounts(
     tx_gen: &DummyProvenTxGenerator,
     num: u32,
-) -> impl Iterator<Item = (SharedProvenTx, MockPrivateAccount)> + '_ {
+) -> impl Iterator<Item = (ProvenTransaction, MockPrivateAccount)> + '_ {
     (0..num).map(|index| {
         let account = MockPrivateAccount::from(index);
         let tx = tx_gen.dummy_proven_tx_with_params(
@@ -40,6 +40,6 @@ pub fn get_txs_and_accounts(
             OutputNotes::new(Vec::new()).unwrap(),
         );
 
-        (Arc::new(tx), account)
+        (tx, account)
     })
 }

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -23,7 +23,7 @@ use crate::test_utils::MockStoreSuccessBuilder;
 #[tokio::test]
 async fn test_verify_tx_happy_path() {
     let tx_gen = DummyProvenTxGenerator::new();
-    let (txs, accounts): (Vec<SharedProvenTx>, Vec<MockPrivateAccount>) =
+    let (txs, accounts): (Vec<ProvenTransaction>, Vec<MockPrivateAccount>) =
         get_txs_and_accounts(&tx_gen, 3).unzip();
 
     let store = Arc::new(
@@ -39,7 +39,7 @@ async fn test_verify_tx_happy_path() {
     let state_view = DefaultStateView::new(store);
 
     for tx in txs {
-        state_view.verify_tx(tx).await.unwrap();
+        state_view.verify_tx(&tx).await.unwrap();
     }
 }
 
@@ -50,7 +50,7 @@ async fn test_verify_tx_happy_path() {
 #[tokio::test]
 async fn test_verify_tx_happy_path_concurrent() {
     let tx_gen = DummyProvenTxGenerator::new();
-    let (txs, accounts): (Vec<SharedProvenTx>, Vec<MockPrivateAccount>) =
+    let (txs, accounts): (Vec<ProvenTransaction>, Vec<MockPrivateAccount>) =
         get_txs_and_accounts(&tx_gen, 3).unzip();
 
     let store = Arc::new(
@@ -69,7 +69,7 @@ async fn test_verify_tx_happy_path_concurrent() {
 
     for tx in txs {
         let state_view = state_view.clone();
-        set.spawn(async move { state_view.verify_tx(tx).await });
+        set.spawn(async move { state_view.verify_tx(&tx).await });
     }
 
     while let Some(res) = set.join_next().await {
@@ -102,7 +102,7 @@ async fn test_verify_tx_vt1() {
 
     let state_view = DefaultStateView::new(store);
 
-    let verify_tx_result = state_view.verify_tx(tx.into()).await;
+    let verify_tx_result = state_view.verify_tx(&tx).await;
 
     assert_eq!(
         verify_tx_result,
@@ -133,7 +133,7 @@ async fn test_verify_tx_vt2() {
 
     let state_view = DefaultStateView::new(store);
 
-    let verify_tx_result = state_view.verify_tx(tx.into()).await;
+    let verify_tx_result = state_view.verify_tx(&tx).await;
 
     assert_eq!(
         verify_tx_result,
@@ -171,7 +171,7 @@ async fn test_verify_tx_vt3() {
 
     let state_view = DefaultStateView::new(store);
 
-    let verify_tx_result = state_view.verify_tx(tx.into()).await;
+    let verify_tx_result = state_view.verify_tx(&tx).await;
 
     assert_eq!(
         verify_tx_result,
@@ -214,10 +214,10 @@ async fn test_verify_tx_vt4() {
 
     let state_view = DefaultStateView::new(store);
 
-    let verify_tx1_result = state_view.verify_tx(tx1.into()).await;
+    let verify_tx1_result = state_view.verify_tx(&tx1).await;
     assert!(verify_tx1_result.is_ok());
 
-    let verify_tx2_result = state_view.verify_tx(tx2.into()).await;
+    let verify_tx2_result = state_view.verify_tx(&tx2).await;
     assert_eq!(
         verify_tx2_result,
         Err(VerifyTxError::AccountAlreadyModifiedByOtherTx(account.id))
@@ -264,10 +264,10 @@ async fn test_verify_tx_vt5() {
 
     let state_view = DefaultStateView::new(store);
 
-    let verify_tx1_result = state_view.verify_tx(tx1.into()).await;
+    let verify_tx1_result = state_view.verify_tx(&tx1).await;
     assert!(verify_tx1_result.is_ok());
 
-    let verify_tx2_result = state_view.verify_tx(tx2.into()).await;
+    let verify_tx2_result = state_view.verify_tx(&tx2).await;
     assert_eq!(
         verify_tx2_result,
         Err(VerifyTxError::InputNotesAlreadyConsumed(

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -16,7 +16,7 @@ use miden_objects::{accounts::AccountId, Digest};
 use tonic::transport::Channel;
 use tracing::{debug, info, instrument};
 
-use crate::{block::Block, SharedProvenTx, COMPONENT};
+use crate::{block::Block, ProvenTransaction, COMPONENT};
 
 mod errors;
 pub use errors::{ApplyBlockError, BlockInputsError, TxInputsError};
@@ -30,7 +30,7 @@ pub trait Store: ApplyBlock {
     /// TODO: add comments
     async fn get_tx_inputs(
         &self,
-        proven_tx: SharedProvenTx,
+        proven_tx: &ProvenTransaction,
     ) -> Result<TxInputs, TxInputsError>;
 
     /// TODO: add comments
@@ -116,7 +116,7 @@ impl Store for DefaultStore {
     #[instrument(target = "miden-block-producer", skip_all, err)]
     async fn get_tx_inputs(
         &self,
-        proven_tx: SharedProvenTx,
+        proven_tx: &ProvenTransaction,
     ) -> Result<TxInputs, TxInputsError> {
         let message = GetTransactionInputsRequest {
             account_id: Some(proven_tx.account_id().into()),

--- a/block-producer/src/test_utils/batch.rs
+++ b/block-producer/src/test_utils/batch.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use crate::{batch_builder::TransactionBatch, test_utils::MockProvenTxBuilder};
+use crate::{test_utils::MockProvenTxBuilder, TransactionBatch};
 
 pub trait TransactionBatchConstructor {
     /// Returns a `TransactionBatch` with `notes_per_tx.len()` transactions, where the i'th
@@ -16,17 +14,14 @@ impl TransactionBatchConstructor for TransactionBatch {
         let txs: Vec<_> = notes_per_tx
             .iter()
             .map(|&num_notes| MockProvenTxBuilder::new().num_notes_created(num_notes).build())
-            .map(Arc::new)
             .collect();
 
         Self::new(txs).unwrap()
     }
 
     fn from_txs(num_txs_in_batch: u64) -> Self {
-        let txs: Vec<_> = (0..num_txs_in_batch)
-            .map(|_| MockProvenTxBuilder::new().build())
-            .map(Arc::new)
-            .collect();
+        let txs: Vec<_> =
+            (0..num_txs_in_batch).map(|_| MockProvenTxBuilder::new().build()).collect();
 
         Self::new(txs).unwrap()
     }

--- a/block-producer/src/test_utils/block.rs
+++ b/block-producer/src/test_utils/block.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 use miden_node_proto::domain::BlockInputs;
 use miden_objects::{
@@ -9,10 +9,10 @@ use miden_vm::crypto::SimpleSmt;
 
 use super::MockStoreSuccess;
 use crate::{
-    batch_builder::TransactionBatch,
     block::Block,
     block_builder::prover::{block_witness::BlockWitness, BlockProver},
     store::Store,
+    TransactionBatch,
 };
 
 /// Constructs the block we expect to be built given the store state, and a set of transaction
@@ -85,9 +85,7 @@ pub async fn build_actual_block_header(
         .await
         .unwrap();
 
-    let block_witness =
-        BlockWitness::new(block_inputs_from_store, batches.into_iter().map(Arc::new).collect())
-            .unwrap();
+    let block_witness = BlockWitness::new(block_inputs_from_store, &batches).unwrap();
 
     BlockProver::new().prove(block_witness).unwrap()
 }

--- a/block-producer/src/test_utils/store.rs
+++ b/block-producer/src/test_utils/store.rs
@@ -8,7 +8,7 @@ use super::*;
 use crate::{
     block::Block,
     store::{ApplyBlock, ApplyBlockError, BlockInputsError, Store, TxInputs, TxInputsError},
-    SharedProvenTx,
+    ProvenTransaction,
 };
 
 /// Builds a [`MockStoreSuccess`]
@@ -157,7 +157,7 @@ impl ApplyBlock for MockStoreSuccess {
 impl Store for MockStoreSuccess {
     async fn get_tx_inputs(
         &self,
-        proven_tx: SharedProvenTx,
+        proven_tx: &ProvenTransaction,
     ) -> Result<TxInputs, TxInputsError> {
         let locked_accounts = self.accounts.read().await;
         let locked_consumed_nullifiers = self.consumed_nullifiers.read().await;
@@ -242,7 +242,7 @@ impl ApplyBlock for MockStoreFailure {
 impl Store for MockStoreFailure {
     async fn get_tx_inputs(
         &self,
-        _proven_tx: SharedProvenTx,
+        _proven_tx: &ProvenTransaction,
     ) -> Result<TxInputs, TxInputsError> {
         Err(TxInputsError::Dummy)
     }


### PR DESCRIPTION
The main code base didn't need the reference counting, and could be implemented with slices only. So this PR removes the `Arc<T>`s in favor of borrowing. The idea is that the types are a bit more straight forward (less wrappers), and we save a bit in atomic counting (not that important, most likely negligible).