### PR TITLE
(Logs) Build transactions batch

### DIFF
--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -132,14 +132,12 @@ impl TransactionBatch {
     // --------------------------------------------------------------------------------------------
 
     fn compute_id(txs: &[SharedProvenTx]) -> BatchId {
-        let mut result = BatchId::default();
-
+        let mut buf = Vec::with_capacity(32 * txs.len());
         for tx in txs {
-            let tx_hash = Blake3_256::hash(&tx.id().as_bytes());
-            result = Blake3_256::merge(&[result, tx_hash]);
+            let mut tx_id = tx.id().as_bytes().to_vec();
+            buf.append(&mut tx_id);
         }
-
-        result
+        Blake3_256::hash(&buf)
     }
 }
 

--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -78,7 +78,7 @@ impl TransactionBatch {
             )
         };
 
-        let id = Self::calc_id(&txs);
+        let id = Self::compute_id(&txs);
 
         Ok(Self {
             id,
@@ -128,11 +128,14 @@ impl TransactionBatch {
         self.created_notes_smt.root()
     }
 
-    fn calc_id(txs: &[SharedProvenTx]) -> BatchId {
+    // HELPER FUNCTIONS
+    // --------------------------------------------------------------------------------------------
+
+    fn compute_id(txs: &[SharedProvenTx]) -> BatchId {
         let mut result = BatchId::default();
 
         for tx in txs {
-            let tx_hash = Blake3_256::hash_elements(tx.id().inner().as_elements());
+            let tx_hash = Blake3_256::hash(&tx.id().as_bytes());
             result = Blake3_256::merge(&[result, tx_hash]);
         }
 

--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use miden_objects::{accounts::AccountId, notes::NoteEnvelope, Digest};
 use miden_vm::crypto::SimpleSmt;
+use tracing::instrument;
 
 use super::errors::BuildBatchError;
 use crate::{SharedProvenTx, CREATED_NOTES_SMT_DEPTH, MAX_NUM_CREATED_NOTES_PER_BATCH};
@@ -33,6 +34,7 @@ impl TransactionBatch {
     /// - The number of created notes across all transactions exceeds 4096.
     ///
     /// TODO: enforce limit on the number of created nullifiers.
+    #[instrument(target = "miden-block-producer", skip_all, err)]
     pub fn new(txs: Vec<SharedProvenTx>) -> Result<Self, BuildBatchError> {
         let updated_accounts = txs
             .iter()

--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -134,8 +134,7 @@ impl TransactionBatch {
     fn compute_id(txs: &[SharedProvenTx]) -> BatchId {
         let mut buf = Vec::with_capacity(32 * txs.len());
         for tx in txs {
-            let mut tx_id = tx.id().as_bytes().to_vec();
-            buf.append(&mut tx_id);
+            buf.extend_from_slice(&tx.id().as_bytes());
         }
         Blake3_256::hash(&buf)
     }

--- a/block-producer/src/batch_builder/mod.rs
+++ b/block-producer/src/batch_builder/mod.rs
@@ -128,7 +128,13 @@ where
         info!(target: COMPONENT, "Transaction batch built");
         Span::current().record("batch_id", format_blake3_digest(batch.id()));
 
-        self.ready_batches.write().await.push(batch);
+        let num_batches = {
+            let mut write_guard = self.ready_batches.write().await;
+            write_guard.push(batch);
+            write_guard.len()
+        };
+
+        info!(target: COMPONENT, num_batches, "Transaction batch added to the batch queue");
 
         Ok(())
     }

--- a/block-producer/src/batch_builder/mod.rs
+++ b/block-producer/src/batch_builder/mod.rs
@@ -74,6 +74,8 @@ where
     pub async fn run(self: Arc<Self>) {
         let mut interval = time::interval(self.options.block_frequency);
 
+        info!(target: COMPONENT, period_ms = interval.period().as_millis(), "Batch builder started");
+
         loop {
             interval.tick().await;
             self.try_build_block().await;

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -52,9 +52,15 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
 
     let block_producer = api_server::ApiServer::new(api::BlockProducerApi::new(queue.clone()));
 
-    tokio::spawn(async move { queue.run().await });
+    tokio::spawn(async move {
+        info!(target: COMPONENT, "Transaction queue started");
+        queue.run().await
+    });
 
-    tokio::spawn(async move { batch_builder.run().await });
+    tokio::spawn(async move {
+        info!(target: COMPONENT, "Batch builder started");
+        batch_builder.run().await
+    });
 
     info!(target: COMPONENT, "Server initialized");
 

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::{net::ToSocketAddrs, sync::Arc};
 use anyhow::{anyhow, Result};
 use miden_node_proto::{block_producer::api_server, store::api_client as store_client};
 use tonic::transport::Server;
-use tracing::{info, info_span, instrument, Instrument};
+use tracing::{info, instrument};
 
 use crate::{
     batch_builder::{DefaultBatchBuilder, DefaultBatchBuilderOptions},
@@ -23,7 +23,7 @@ pub mod api;
 // ================================================================================================
 
 /// TODO: add comments
-#[instrument(target = "miden-block-producer", name = "block_producer::serve", skip_all)]
+#[instrument(target = "miden-block-producer", name = "block_producer", skip_all)]
 pub async fn serve(config: BlockProducerConfig) -> Result<()> {
     info!(target: COMPONENT, %config, "Initializing server");
 
@@ -52,15 +52,9 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
 
     let block_producer = api_server::ApiServer::new(api::BlockProducerApi::new(queue.clone()));
 
-    tokio::spawn(
-        async move { queue.run().await }
-            .instrument(info_span!(target: COMPONENT, "transaction_queue")),
-    );
+    tokio::spawn(async move { queue.run().await });
 
-    tokio::spawn(
-        async move { batch_builder.run().await }
-            .instrument(info_span!(target: COMPONENT, "batch_builder")),
-    );
+    tokio::spawn(async move { batch_builder.run().await });
 
     info!(target: COMPONENT, "Server initialized");
 

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -52,15 +52,9 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
 
     let block_producer = api_server::ApiServer::new(api::BlockProducerApi::new(queue.clone()));
 
-    tokio::spawn(async move {
-        info!(target: COMPONENT, "Transaction queue started");
-        queue.run().await
-    });
+    tokio::spawn(async move { queue.run().await });
 
-    tokio::spawn(async move {
-        info!(target: COMPONENT, "Batch builder started");
-        batch_builder.run().await
-    });
+    tokio::spawn(async move { batch_builder.run().await });
 
     info!(target: COMPONENT, "Server initialized");
 

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -189,7 +189,7 @@ where
                         },
                     }
                 }
-                .instrument(info_span!(target: COMPONENT, "block_producer")),
+                .instrument(info_span!(target: COMPONENT, "batch_builder")),
             );
         }
     }

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -9,7 +9,7 @@ use miden_objects::{
     accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest, TransactionInputError,
 };
 use tokio::{sync::RwLock, time};
-use tracing::{info, instrument};
+use tracing::{info, info_span, instrument, Instrument};
 
 use crate::{
     batch_builder::BatchBuilder, store::TxInputsError, SharedProvenTx, SharedRwVec, COMPONENT,
@@ -148,6 +148,7 @@ where
         }
     }
 
+    #[instrument(target = "miden-block-producer", name = "block_producer" skip_all)]
     pub async fn run(self: Arc<Self>) {
         let mut interval = time::interval(self.options.build_batch_frequency);
 
@@ -176,17 +177,20 @@ where
             let ready_queue = self.ready_queue.clone();
             let batch_builder = self.batch_builder.clone();
 
-            tokio::spawn(async move {
-                match batch_builder.build_batch(txs.clone()).await {
-                    Ok(_) => {
-                        // batch was successfully built, do nothing
-                    },
-                    Err(_) => {
-                        // batch building failed, add txs back at the end of the queue
-                        ready_queue.write().await.append(&mut txs);
-                    },
+            tokio::spawn(
+                async move {
+                    match batch_builder.build_batch(txs.clone()).await {
+                        Ok(_) => {
+                            // batch was successfully built, do nothing
+                        },
+                        Err(_) => {
+                            // batch building failed, add txs back at the end of the queue
+                            ready_queue.write().await.append(&mut txs);
+                        },
+                    }
                 }
-            });
+                .instrument(info_span!(target: COMPONENT, "block_producer")),
+            );
         }
     }
 }

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -9,7 +9,7 @@ use miden_objects::{
     accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest, TransactionInputError,
 };
 use tokio::{sync::RwLock, time};
-use tracing::{info, info_span, instrument, Instrument};
+use tracing::{info, instrument};
 
 use crate::{
     batch_builder::BatchBuilder, store::TxInputsError, SharedProvenTx, SharedRwVec, COMPONENT,
@@ -148,7 +148,6 @@ where
         }
     }
 
-    #[instrument(target = "miden-block-producer", skip_all)]
     pub async fn run(self: Arc<Self>) {
         let mut interval = time::interval(self.options.build_batch_frequency);
 
@@ -177,22 +176,17 @@ where
             let ready_queue = self.ready_queue.clone();
             let batch_builder = self.batch_builder.clone();
 
-            tokio::spawn(
-                async move {
-                    match batch_builder.build_batch(txs.clone()).await {
-                        Ok(_) => {
-                            // batch was successfully built, do nothing
-                        },
-                        Err(_) => {
-                            // batch building failed, add txs back at the end of the queue
-                            ready_queue.write().await.append(&mut txs);
-                        },
-                    }
+            tokio::spawn(async move {
+                match batch_builder.build_batch(txs.clone()).await {
+                    Ok(_) => {
+                        // batch was successfully built, do nothing
+                    },
+                    Err(_) => {
+                        // batch building failed, add txs back at the end of the queue
+                        ready_queue.write().await.append(&mut txs);
+                    },
                 }
-                .instrument(
-                    info_span!(target: COMPONENT, "block_producer::batch_builder::build_batch"),
-                ),
-            );
+            });
         }
     }
 }

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -152,6 +152,8 @@ where
     pub async fn run(self: Arc<Self>) {
         let mut interval = time::interval(self.options.build_batch_frequency);
 
+        info!(target: COMPONENT, period_ms = interval.period().as_millis(), "Transaction queue started");
+
         loop {
             interval.tick().await;
             self.try_build_batches().await;

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -11,7 +11,7 @@ mod api;
 
 // RPC INITIALIZER
 // ================================================================================================
-#[instrument(target = "miden-rpc", skip_all)]
+#[instrument(target = "miden-rpc", name = "rpc::serve", skip_all)]
 pub async fn serve(config: RpcConfig) -> Result<()> {
     info!(target: COMPONENT, %config, "Initializing server");
 

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -11,7 +11,7 @@ mod api;
 
 // RPC INITIALIZER
 // ================================================================================================
-#[instrument(target = "miden-rpc", name = "rpc::serve", skip_all)]
+#[instrument(target = "miden-rpc", name = "rpc", skip_all)]
 pub async fn serve(config: RpcConfig) -> Result<()> {
     info!(target: COMPONENT, %config, "Initializing server");
 

--- a/store/src/db/mod.rs
+++ b/store/src/db/mod.rs
@@ -45,7 +45,7 @@ pub struct StateSyncUpdate {
 impl Db {
     /// Open a connection to the DB, apply any pending migrations, and ensure that the genesis block
     /// is as expected and present in the database.
-    #[instrument(target = "miden-store", skip_all)]
+    #[instrument(target = "miden-store", name = "store::setup", skip_all)]
     pub async fn setup(config: StoreConfig) -> Result<Self, anyhow::Error> {
         info!(target: COMPONENT, %config, "Connecting to the database");
 

--- a/store/src/server/mod.rs
+++ b/store/src/server/mod.rs
@@ -12,7 +12,7 @@ mod api;
 // STORE INITIALIZER
 // ================================================================================================
 
-#[instrument(target = "miden-store", skip_all)]
+#[instrument(target = "miden-store", name = "store::serve", skip_all)]
 pub async fn serve(
     config: StoreConfig,
     db: Db,

--- a/store/src/server/mod.rs
+++ b/store/src/server/mod.rs
@@ -12,7 +12,7 @@ mod api;
 // STORE INITIALIZER
 // ================================================================================================
 
-#[instrument(target = "miden-store", name = "store::serve", skip_all)]
+#[instrument(target = "miden-store", name = "store", skip_all)]
 pub async fn serve(
     config: StoreConfig,
     db: Db,

--- a/utils/src/logging.rs
+++ b/utils/src/logging.rs
@@ -2,6 +2,10 @@ use std::fmt::Display;
 
 use anyhow::Result;
 use itertools::Itertools;
+use miden_crypto::{
+    hash::{blake::Blake3Digest, Digest},
+    utils::bytes_to_hex_string,
+};
 use miden_objects::{
     notes::{NoteEnvelope, Nullifier},
     transaction::{InputNotes, OutputNotes},
@@ -71,4 +75,8 @@ pub fn format_array(list: impl IntoIterator<Item = impl Display>) -> String {
     } else {
         format!("[{}]", comma_separated)
     }
+}
+
+pub fn format_blake3_digest(digest: Blake3Digest<32>) -> String {
+    bytes_to_hex_string(digest.as_bytes())
 }


### PR DESCRIPTION
Added logs for transaction batch building flow.

Sample output:

```
2024-01-29T09:01:42.062953Z  INFO block_producer:try_build_batches: miden-block-producer: block-producer/src/txqueue/mod.rs:162: new
2024-01-29T09:01:42.063159Z  INFO block_producer:try_build_batches:batch_builder: miden-block-producer: block-producer/src/txqueue/mod.rs:192: new
2024-01-29T09:01:42.063304Z  INFO block_producer:try_build_batches:batch_builder:build_batch: miden-block-producer: block-producer/src/batch_builder/mod.rs:116: new
2024-01-29T09:01:42.063354Z  INFO block_producer:try_build_batches:batch_builder:build_batch: miden-block-producer: block-producer/src/batch_builder/mod.rs:123: Building a transaction batch, num_txs: 1
2024-01-29T09:01:42.063412Z  INFO block_producer:try_build_batches:batch_builder:build_batch:new_batch: miden-block-producer: block-producer/src/batch_builder/batch.rs:41: new
2024-01-29T09:01:42.072082Z  INFO block_producer:try_build_batches:batch_builder:build_batch:new_batch: miden-block-producer: block-producer/src/batch_builder/batch.rs:41: close, time.busy: 8.14ms, time.idle: 526µs
2024-01-29T09:01:42.072189Z  INFO block_producer:try_build_batches:batch_builder:build_batch: miden-block-producer: block-producer/src/batch_builder/mod.rs:128: Transaction batch built
2024-01-29T09:01:42.072302Z  INFO block_producer:try_build_batches:batch_builder:build_batch: miden-block-producer: block-producer/src/batch_builder/mod.rs:116: close, time.busy: 8.95ms, time.idle: 50.4µs batch_id: "0x8a73a469f0af54c4c32588af08f7fd840f80a25e690a3247f252500fddc6f534"
2024-01-29T09:01:42.092294Z  INFO block_producer:try_build_batches:batch_builder: miden-block-producer: block-producer/src/txqueue/mod.rs:192: close, time.busy: 29.0ms, time.idle: 141µs
2024-01-29T09:01:42.092359Z  INFO block_producer:try_build_batches: miden-block-producer: block-producer/src/txqueue/mod.rs:162: close, time.busy: 174µs, time.idle: 29.3ms
```