### PR TITLE
txqueue: document where empty blocks come from

### DIFF
--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -155,6 +155,8 @@ where
         let txs: Vec<ProvenTransaction> = {
             let mut locked_ready_queue = self.ready_queue.write().await;
 
+            // If there are no transactions in the queue, this call is a no-op. The [BatchBuilder]
+            // will produce empty blocks if necessary.
             if locked_ready_queue.is_empty() {
                 return;
             }


### PR DESCRIPTION
this behavior is a bit surprising, i think it deserves a small comment.