### PR TITLE
Fix failed verification for new accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ Cargo.lock
 # VS Code
 .vscode/
 
+# Genesis files
+/accounts
+genesis.dat
+
 # Sqlite db files
 *.sqlite3
 *.sqlite3-shm

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -179,7 +179,9 @@ fn ensure_tx_inputs_constraints(
 
     match tx_inputs.account_hash {
         Some(store_account_hash) => {
-            if candidate_tx.initial_account_hash() != store_account_hash {
+            if candidate_tx.initial_account_hash() != store_account_hash
+                && store_account_hash != Digest::default()
+            {
                 return Err(VerifyTxError::IncorrectAccountInitialHash {
                     tx_initial_account_hash: candidate_tx.initial_account_hash(),
                     store_account_hash: Some(store_account_hash),

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -179,13 +179,17 @@ fn ensure_tx_inputs_constraints(
 
     match tx_inputs.account_hash {
         Some(store_account_hash) => {
-            if candidate_tx.initial_account_hash() != store_account_hash
-                && store_account_hash != Digest::default()
-            {
-                return Err(VerifyTxError::IncorrectAccountInitialHash {
-                    tx_initial_account_hash: candidate_tx.initial_account_hash(),
-                    store_account_hash: Some(store_account_hash),
-                });
+            if candidate_tx.initial_account_hash() != store_account_hash {
+                // Prevents this check from returning an Err() in case a new account
+                // that has not yet been stored in the DB submits a transaction. By default
+                // the `store_account_hash` of a new account would be `Digest::default()`
+                if store_account_hash == Digest::default() {
+                } else {
+                    return Err(VerifyTxError::IncorrectAccountInitialHash {
+                        tx_initial_account_hash: candidate_tx.initial_account_hash(),
+                        store_account_hash: Some(store_account_hash),
+                    });
+                }
             }
         },
         None => {

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -178,8 +178,8 @@ fn ensure_tx_inputs_constraints(
     debug!(target: COMPONENT, %tx_inputs);
 
     match tx_inputs.account_hash {
-        // Having `Some(store_account_hash)` here signifies that we are operating
-        // on the state of an existing account.
+        // if the account is present in the Store, make sure that the account state hash
+        // from the received transaction is the same as the one from the Store
         Some(store_account_hash) => {
             if candidate_tx.initial_account_hash() != store_account_hash {
                 return Err(VerifyTxError::IncorrectAccountInitialHash {
@@ -188,8 +188,7 @@ fn ensure_tx_inputs_constraints(
                 });
             }
         },
-        // Having `None` here signifies that we are operating
-        // on the state of a new account
+        // if the account is not present in the Store, it must be a new account
         None => {
             // TODO: check if the transaction was executed against new account
         },

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -178,25 +178,20 @@ fn ensure_tx_inputs_constraints(
     debug!(target: COMPONENT, %tx_inputs);
 
     match tx_inputs.account_hash {
+        // Having `Some(store_account_hash)` here signifies that we are operating
+        // on the state of an existing account.
         Some(store_account_hash) => {
             if candidate_tx.initial_account_hash() != store_account_hash {
-                // Prevents this check from returning an Err() in case a new account
-                // that has not yet been stored in the DB submits a transaction. By default
-                // the `store_account_hash` of a new account would be `Digest::default()`
-                if store_account_hash == Digest::default() {
-                } else {
-                    return Err(VerifyTxError::IncorrectAccountInitialHash {
-                        tx_initial_account_hash: candidate_tx.initial_account_hash(),
-                        store_account_hash: Some(store_account_hash),
-                    });
-                }
+                return Err(VerifyTxError::IncorrectAccountInitialHash {
+                    tx_initial_account_hash: candidate_tx.initial_account_hash(),
+                    store_account_hash: Some(store_account_hash),
+                });
             }
         },
+        // Having `None` here signifies that we are operating
+        // on the state of a new account
         None => {
-            return Err(VerifyTxError::IncorrectAccountInitialHash {
-                tx_initial_account_hash: candidate_tx.initial_account_hash(),
-                store_account_hash: None,
-            })
+            // TODO: check if the transaction was executed against new account
         },
     }
 

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -2,7 +2,7 @@
 //!
 //! Store-related requirements
 //! VT1: `tx.initial_account_hash` must match the account hash in store
-//! VT2: If store doesn't contain account, `verify_tx` must fail
+//! VT2: If store doesn't contain account, `verify_tx` should check that it is a new account ( TODO ) and succeed
 //! VT3: If `tx` consumes an already-consumed note in the store, `verify_tx` must fail
 //!
 //! in-flight related requirements
@@ -113,6 +113,7 @@ async fn test_verify_tx_vt1() {
     );
 }
 
+/// TODO: Add new_account checks from the ProvenTransaction
 /// Verifies requirement VT2
 #[tokio::test]
 async fn test_verify_tx_vt2() {
@@ -135,13 +136,7 @@ async fn test_verify_tx_vt2() {
 
     let verify_tx_result = state_view.verify_tx(&tx).await;
 
-    assert_eq!(
-        verify_tx_result,
-        Err(VerifyTxError::IncorrectAccountInitialHash {
-            tx_initial_account_hash: account_not_in_store.states[0],
-            store_account_hash: None
-        })
-    );
+    assert!(verify_tx_result.is_ok());
 }
 
 /// Verifies requirement VT3

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -181,9 +181,15 @@ impl Store for DefaultStore {
             nullifiers.into_iter().collect()
         };
 
-        let tx_inputs = TxInputs {
-            account_hash,
-            nullifiers,
+        let tx_inputs = match account_hash {
+            Some(hash) if hash == Digest::default() => TxInputs {
+                account_hash: None,
+                nullifiers,
+            },
+            _ => TxInputs {
+                account_hash,
+                nullifiers,
+            },
         };
 
         debug!(target: COMPONENT, %tx_inputs);

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -183,10 +183,14 @@ impl Store for DefaultStore {
             nullifiers.into_iter().collect()
         };
 
-        // We are matching the received account_hash from the Store here to check for different cases:
-        // 1. If the hash is equal to `Digest::default()`, it signifies that this is a new account that has not yet interacted with the Store.
-        // 2. If the hash is not equal to `Digest::default()`, it signifies that it is a known account.
-        // 3. If the hash is `None`, it means there has been an error in the processing of the account hash from the Store.
+        // We are matching the received account_hash from the Store here to check for different
+        // cases:
+        // 1. If the hash is equal to `Digest::default()`, it signifies that this is a new account
+        //    which is not yet present in the Store.
+        // 2. If the hash is not equal to `Digest::default()`, it signifies that it is an exiting
+        //    account (i.e., known to the Store).
+        // 3. If the hash is `None`, it means there has been an error in the processing of the
+        //    account hash from the Store.
         let account_hash = match account_hash {
             Some(hash) if hash == Digest::default() => None,
             Some(hash) => Some(hash),

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -186,9 +186,14 @@ impl Store for DefaultStore {
                 account_hash: None,
                 nullifiers,
             },
-            _ => TxInputs {
-                account_hash,
+            Some(hash) => TxInputs {
+                account_hash: Some(hash),
                 nullifiers,
+            },
+            None => {
+                return Err(TxInputsError::MalformedResponse(format!(
+                    "incorrect account hash returned from the store. Got None.",
+                )))
             },
         };
 

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -191,9 +191,9 @@ impl Store for DefaultStore {
                 nullifiers,
             },
             None => {
-                return Err(TxInputsError::MalformedResponse(format!(
-                    "incorrect account hash returned from the store. Got None.",
-                )))
+                return Err(TxInputsError::MalformedResponse(
+                    "incorrect account hash returned from the store. Got None.".to_string(),
+                ))
             },
         };
 


### PR DESCRIPTION
The checks that were performed on new txs received by the node were preventing new accounts to submit txs. 

Because the `account_hash` of the tx account did not match the `account_hash` contained in the DB for this specific tx account considering that it had never be added. 

By default it was `Digest::default()`

Closes: #176 