### PR TITLE
block_builder: fix flaky tests (fixes: #125)

### DIFF
--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -47,4 +47,5 @@ tracing-subscriber = { workspace = true }
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 once_cell = { version = "1.18" }
-winterfell = "0.7"
+tokio = { version = "1.29", features = ["test-util" ] }
+winterfell = { version = "0.7" }

--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -17,7 +17,7 @@ pub type BatchId = Blake3Digest<32>;
 /// in the batch must be addressing that account (issue: #186).
 ///
 /// Note: Until recursive proofs are available in the Miden VM, we don't include the common proof.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionBatch {
     id: BatchId,
     updated_accounts: BTreeMap<AccountId, AccountStates>,

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -9,7 +9,7 @@ use miden_objects::{
     accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest, TransactionInputError,
 };
 use tokio::{sync::RwLock, time};
-use tracing::{info, info_span, instrument, Instrument};
+use tracing::{debug, info, info_span, instrument, Instrument};
 
 use crate::{
     batch_builder::BatchBuilder, store::TxInputsError, ProvenTransaction, SharedRwVec, COMPONENT,
@@ -158,6 +158,7 @@ where
             // If there are no transactions in the queue, this call is a no-op. The [BatchBuilder]
             // will produce empty blocks if necessary.
             if locked_ready_queue.is_empty() {
+                debug!(target: COMPONENT, "Transaction queue empty");
                 return;
             }
 

--- a/block-producer/src/txqueue/tests/mod.rs
+++ b/block-producer/src/txqueue/tests/mod.rs
@@ -1,4 +1,7 @@
-use tokio::time;
+use tokio::{
+    sync::mpsc::{self, error::TryRecvError},
+    time,
+};
 
 use super::*;
 use crate::{
@@ -35,9 +38,14 @@ impl TransactionVerifier for TransactionVerifierFailure {
 }
 
 /// Records all batches built in `ready_batches`
-#[derive(Default)]
 struct BatchBuilderSuccess {
-    ready_batches: SharedRwVec<TransactionBatch>,
+    ready_batches: mpsc::UnboundedSender<TransactionBatch>,
+}
+
+impl BatchBuilderSuccess {
+    fn new(ready_batches: mpsc::UnboundedSender<TransactionBatch>) -> Self {
+        Self { ready_batches }
+    }
 }
 
 #[async_trait]
@@ -46,7 +54,10 @@ impl BatchBuilder for BatchBuilderSuccess {
         &self,
         txs: Vec<ProvenTransaction>,
     ) -> Result<(), BuildBatchError> {
-        self.ready_batches.write().await.push(TransactionBatch::new(txs).unwrap());
+        let batch = TransactionBatch::new(txs).expect("Tx batch building should have succeeded");
+        self.ready_batches
+            .send(batch)
+            .expect("Sending to channel should have succeeded");
 
         Ok(())
     }
@@ -71,74 +82,131 @@ impl BatchBuilder for BatchBuilderFailure {
 
 /// Tests that when the internal "build batch timer" hits, all transactions in the queue are sent to
 /// be built in some batch
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_build_batch_success() {
     let build_batch_frequency = Duration::from_millis(5);
     let batch_size = 3;
+    let (sender, mut receiver) = mpsc::unbounded_channel::<TransactionBatch>();
 
-    let batch_builder = Arc::new(BatchBuilderSuccess::default());
-
-    let tx_queue = TransactionQueue::new(
+    let tx_queue = Arc::new(TransactionQueue::new(
         Arc::new(TransactionVerifierSuccess),
-        batch_builder.clone(),
+        Arc::new(BatchBuilderSuccess::new(sender)),
         TransactionQueueOptions {
             build_batch_frequency,
             batch_size,
         },
+    ));
+
+    // Starts the transaction queue task.
+    tokio::spawn(tx_queue.clone().run());
+
+    // the queue start empty
+    assert_eq!(Err(TryRecvError::Empty), receiver.try_recv());
+
+    // if no transactions have been added to the queue in the batch build interval, the queue does
+    // nothing
+    tokio::time::advance(build_batch_frequency).await;
+    assert_eq!(Err(TryRecvError::Empty), receiver.try_recv(), "queue starts empty");
+
+    let tx_generator = DummyProvenTxGenerator::new();
+
+    // if there is a single transaction in the queue when it is time to build a batch, the batch is
+    // created with that single transaction
+    let tx = tx_generator.dummy_proven_tx();
+    tx_queue
+        .add_transaction(tx.clone())
+        .await
+        .expect("Transaction queue is running");
+
+    tokio::time::advance(build_batch_frequency).await;
+    let batch = receiver.try_recv().expect("Queue not empty");
+    assert_eq!(
+        Err(TryRecvError::Empty),
+        receiver.try_recv(),
+        "A single transaction produces a single batch"
     );
+    let expected = TransactionBatch::new(vec![tx]).expect("Valid transactions");
+    assert_eq!(expected, batch, "The batch should have the one transaction added to the queue");
 
-    let proven_tx_generator = DummyProvenTxGenerator::new();
+    // a batch will include up to `batch_size` transactions
+    let mut txs = Vec::new();
+    for _ in 0..batch_size {
+        let tx = tx_generator.dummy_proven_tx();
+        tx_queue
+            .add_transaction(tx.clone())
+            .await
+            .expect("Transaciton queue is running");
+        txs.push(tx)
+    }
+    tokio::time::advance(build_batch_frequency).await;
+    let batch = receiver.try_recv().expect("Queue not empty");
+    assert_eq!(
+        Err(TryRecvError::Empty),
+        receiver.try_recv(),
+        "{batch_size} transactions create a single batch"
+    );
+    let expected = TransactionBatch::new(txs).expect("Valid transactions");
+    assert_eq!(expected, batch, "The batch should the transactions to fill a batch");
 
-    // Add enough transactions so that we have 3 batches
-    for _i in 0..(2 * batch_size + 1) {
-        tx_queue.add_transaction(proven_tx_generator.dummy_proven_tx()).await.unwrap();
+    // the transaction queue eagerly produces batches
+    let mut txs = Vec::new();
+    for _ in 0..(2 * batch_size + 1) {
+        let tx = tx_generator.dummy_proven_tx();
+        tx_queue
+            .add_transaction(tx.clone())
+            .await
+            .expect("Transaciton queue is running");
+        txs.push(tx)
+    }
+    for expected_batch in txs.chunks(batch_size).map(|txs| txs.to_vec()) {
+        tokio::time::advance(build_batch_frequency).await;
+        let batch = receiver.try_recv().expect("Queue not empty");
+        let expected = TransactionBatch::new(expected_batch).expect("Valid transactions");
+        assert_eq!(expected, batch, "The batch should the transactions to fill a batch");
     }
 
-    // Start the queue
-    tokio::spawn(Arc::new(tx_queue).run());
-
-    // Wait for tx queue to build batches
-    time::sleep(build_batch_frequency * 2).await;
-
-    assert_eq!(batch_builder.ready_batches.read().await.len(), 3);
+    // ensure all transactions have been consumed
+    tokio::time::advance(build_batch_frequency * 2).await;
+    assert_eq!(
+        Err(TryRecvError::Empty),
+        receiver.try_recv(),
+        "If there are no transactions, no batches are produced"
+    );
 }
 
 /// Tests that when transactions fail to verify, they are not added to the queue
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_tx_verify_failure() {
     let build_batch_frequency = Duration::from_millis(5);
     let batch_size = 3;
 
-    let batch_builder = Arc::new(BatchBuilderSuccess::default());
+    let (sender, mut receiver) = mpsc::unbounded_channel::<TransactionBatch>();
+    let batch_builder = Arc::new(BatchBuilderSuccess::new(sender));
 
-    let tx_queue = TransactionQueue::new(
+    let tx_queue = Arc::new(TransactionQueue::new(
         Arc::new(TransactionVerifierFailure),
         batch_builder.clone(),
         TransactionQueueOptions {
             build_batch_frequency,
             batch_size,
         },
-    );
+    ));
 
-    let internal_ready_queue = tx_queue.ready_queue.clone();
-
-    let proven_tx_generator = DummyProvenTxGenerator::new();
+    // Start the queue
+    tokio::spawn(tx_queue.clone().run());
 
     // Add a bunch of transactions that will all fail tx verification
-    for _i in 0..(3 * batch_size) {
+    let proven_tx_generator = DummyProvenTxGenerator::new();
+    for _ in 0..(3 * batch_size) {
         let r = tx_queue.add_transaction(proven_tx_generator.dummy_proven_tx()).await;
 
         assert!(matches!(r, Err(AddTransactionError::VerificationFailed(_))));
+        assert_eq!(
+            Err(TryRecvError::Empty),
+            receiver.try_recv(),
+            "If there are no transactions, no batches are produced"
+        );
     }
-
-    // Start the queue
-    tokio::spawn(Arc::new(tx_queue).run());
-
-    // Wait for tx queue to build batches
-    time::sleep(build_batch_frequency * 2).await;
-
-    assert!(internal_ready_queue.read().await.is_empty());
-    assert_eq!(batch_builder.ready_batches.read().await.len(), 0);
 }
 
 /// Tests that when batch building fails, transactions are added back to the ready queue


### PR DESCRIPTION
The test `test_build_batch_success` was flaky on the CI because of lack of coordination among the test and the code. This commit fixes the issue by using tokio's paused time loop, with explicity time advances, and a channel to synchronize the batch builder task with the test.

additional details on https://github.com/0xPolygonMiden/miden-node/pull/201 and https://github.com/0xPolygonMiden/miden-node/pull/202