### PR TITLE
Add tx proof verification in `RPC` and `Block Producer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
-miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
-miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-add-constant" }
+miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-add-constant" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "phklive-add-constant" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
 miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
 miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-add-constant" }
-miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-add-constant" }
-miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "phklive-add-constant" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -28,6 +28,7 @@ miden-node-store = { path = "../store" }
 miden-node-utils = { path = "../utils" }
 miden-objects = { workspace = true }
 miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-tx = { workspace = true }
 miden_vm = { package = "miden-vm", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
@@ -47,5 +48,5 @@ tracing-subscriber = { workspace = true }
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 once_cell = { version = "1.18" }
-tokio = { version = "1.29", features = ["test-util" ] }
+tokio = { version = "1.29", features = ["test-util"] }
 winterfell = { version = "0.7" }

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-add-constant", default-features = false }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }
 winterfell = { version = "0.7" }

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-add-constant", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }
 winterfell = { version = "0.7" }

--- a/block-producer/block-producer-example.toml
+++ b/block-producer/block-producer-example.toml
@@ -1,3 +1,4 @@
 [block_producer]
 endpoint = { host = "localhost", port = 48046 }
 store_url = "http://localhost:28943"
+check_tx_proofs = true

--- a/block-producer/block-producer-example.toml
+++ b/block-producer/block-producer-example.toml
@@ -1,4 +1,4 @@
 [block_producer]
 endpoint = { host = "localhost", port = 48046 }
 store_url = "http://localhost:28943"
-check_tx_proofs = true
+verify_tx_proofs = true

--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -2,7 +2,7 @@ use miden_air::Felt;
 use miden_objects::transaction::{InputNotes, OutputNotes};
 
 // block builder tests (higher level)
-// 1. `apply_block()` is called
+// `apply_block()` is called
 use super::*;
 use crate::{
     test_utils::{DummyProvenTxGenerator, MockStoreFailure, MockStoreSuccessBuilder},

--- a/block-producer/src/config.rs
+++ b/block-producer/src/config.rs
@@ -16,11 +16,12 @@ pub struct BlockProducerConfig {
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_url: String,
 
-    /// Enables or Disables the verification of proofs in the Block Producer
-    /// We could want to disable proof verification for the following reasons:
-    /// - Proofs take non-negligible time to verify
-    /// - Proof verification is already made at the RPC level
-    /// - Batch Builder will verify tx proofs before batch proof generation
+    /// Enable or disable the verification of transaction proofs before they are accepted into the
+    /// transaction queue.
+    ///
+    /// Disabling transaction proof verification will speed up transaction processing as proof
+    /// verification may take ~15ms/proof. This is OK when all transactions are forwarded to the
+    /// block producer from the RPC component as transaction proofs are also verified there.
     pub verify_tx_proofs: bool,
 }
 

--- a/block-producer/src/config.rs
+++ b/block-producer/src/config.rs
@@ -15,6 +15,8 @@ pub struct BlockProducerConfig {
 
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_url: String,
+
+    pub check_tx_proofs: bool,
 }
 
 impl BlockProducerConfig {
@@ -62,6 +64,7 @@ mod tests {
                 r#"
                     [block_producer]
                     store_url = "http://store:8000"
+                    check_tx_proofs = true
 
                     [block_producer.endpoint]
                     host = "127.0.0.1"
@@ -81,6 +84,7 @@ mod tests {
                             port: 8080,
                         },
                         store_url: "http://store:8000".to_string(),
+                        check_tx_proofs: true
                     }
                 }
             );

--- a/block-producer/src/config.rs
+++ b/block-producer/src/config.rs
@@ -16,6 +16,11 @@ pub struct BlockProducerConfig {
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_url: String,
 
+    /// Enables or Disables the verification of proofs in the Block Producer
+    /// We could want to disable proof verification for the following reasons:
+    /// - Proofs take non-negligible time to verify
+    /// - Proof verification is already made at the RPC level
+    /// - Batch Builder will verify tx proofs before batch proof generation
     pub verify_tx_proofs: bool,
 }
 

--- a/block-producer/src/config.rs
+++ b/block-producer/src/config.rs
@@ -16,7 +16,7 @@ pub struct BlockProducerConfig {
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_url: String,
 
-    pub check_tx_proofs: bool,
+    pub verify_tx_proofs: bool,
 }
 
 impl BlockProducerConfig {
@@ -64,7 +64,7 @@ mod tests {
                 r#"
                     [block_producer]
                     store_url = "http://store:8000"
-                    check_tx_proofs = true
+                    verify_tx_proofs = true
 
                     [block_producer.endpoint]
                     host = "127.0.0.1"
@@ -84,7 +84,7 @@ mod tests {
                             port: 8080,
                         },
                         store_url: "http://store:8000".to_string(),
-                        check_tx_proofs: true
+                        verify_tx_proofs: true
                     }
                 }
             );

--- a/block-producer/src/errors.rs
+++ b/block-producer/src/errors.rs
@@ -44,8 +44,7 @@ pub enum VerifyTxError {
     TransactionInputError(#[from] TransactionInputError),
 
     /// Failed to verify the transaction execution proof
-    /// TODO: Add transaction id in error message
-    #[error("Invalid transaction proof error")]
+    #[error("Invalid transaction proof error for transaction: {0}")]
     InvalidTransactionProof(TransactionId),
 }
 

--- a/block-producer/src/errors.rs
+++ b/block-producer/src/errors.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     accounts::AccountId,
     crypto::merkle::MerkleError,
     notes::Nullifier,
-    transaction::{InputNotes, ProvenTransaction},
+    transaction::{InputNotes, ProvenTransaction, TransactionId},
     Digest, TransactionInputError,
 };
 use miden_vm::ExecutionError;
@@ -42,6 +42,11 @@ pub enum VerifyTxError {
 
     #[error("Transaction input error: {0}")]
     TransactionInputError(#[from] TransactionInputError),
+
+    /// Failed to verify the transaction execution proof
+    /// TODO: Add transaction id in error message
+    #[error("Invalid transaction proof error")]
+    InvalidTransactionProof(TransactionId),
 }
 
 // Transaction adding errors

--- a/block-producer/src/server/api.rs
+++ b/block-producer/src/server/api.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, instrument};
 
 use crate::{
     batch_builder::BatchBuilder,
-    txqueue::{TransactionQueue, TransactionVerifier},
+    txqueue::{TransactionQueue, TransactionValidator},
     COMPONENT,
 };
 
@@ -32,7 +32,7 @@ impl<BB, TV> BlockProducerApi<BB, TV> {
 #[tonic::async_trait]
 impl<BB, TV> api_server::Api for BlockProducerApi<BB, TV>
 where
-    TV: TransactionVerifier,
+    TV: TransactionValidator,
     BB: BatchBuilder,
 {
     #[allow(clippy::blocks_in_conditions)] // Workaround of `instrument` issue

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -30,7 +30,7 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
     let store = Arc::new(DefaultStore::new(
         store_client::ApiClient::connect(config.store_url.to_string()).await?,
     ));
-    let state_view = Arc::new(DefaultStateView::new(store.clone()));
+    let state_view = Arc::new(DefaultStateView::new(store.clone(), config.check_tx_proofs));
 
     let block_builder = DefaultBlockBuilder::new(store.clone(), state_view.clone());
     let batch_builder_options = DefaultBatchBuilderOptions {

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -30,7 +30,7 @@ pub async fn serve(config: BlockProducerConfig) -> Result<()> {
     let store = Arc::new(DefaultStore::new(
         store_client::ApiClient::connect(config.store_url.to_string()).await?,
     ));
-    let state_view = Arc::new(DefaultStateView::new(store.clone(), config.check_tx_proofs));
+    let state_view = Arc::new(DefaultStateView::new(store.clone(), config.verify_tx_proofs));
 
     let block_builder = DefaultBlockBuilder::new(store.clone(), state_view.clone());
     let batch_builder_options = DefaultBatchBuilderOptions {

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -3,10 +3,13 @@ use std::{collections::BTreeSet, sync::Arc};
 use async_trait::async_trait;
 use miden_node_proto::TransactionInputs;
 use miden_node_utils::formatting::format_array;
-use miden_objects::{accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest};
+use miden_objects::{
+    accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest,
+    MIN_PROOF_SECURITY_LEVEL,
+};
+use miden_tx::TransactionVerifier;
 use tokio::sync::RwLock;
 use tracing::{debug, instrument};
-use {miden_objects::MIN_PROOF_SECURITY_LEVEL, miden_tx::TransactionVerifier};
 
 use crate::{
     block::Block,

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -4,12 +4,10 @@ use async_trait::async_trait;
 use miden_node_proto::TransactionInputs;
 use miden_node_utils::formatting::format_array;
 use miden_objects::{accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest};
-
-#[cfg(not(test))]
-use {miden_objects::MIN_PROOF_SECURITY_LEVEL, miden_tx::TransactionVerifier};
-
 use tokio::sync::RwLock;
 use tracing::{debug, instrument};
+#[cfg(not(test))]
+use {miden_objects::MIN_PROOF_SECURITY_LEVEL, miden_tx::TransactionVerifier};
 
 use crate::{
     block::Block,

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -4,11 +4,10 @@ use async_trait::async_trait;
 use miden_node_proto::TransactionInputs;
 use miden_node_utils::formatting::format_array;
 use miden_objects::{accounts::AccountId, notes::Nullifier, transaction::InputNotes, Digest};
-use tokio::sync::RwLock;
-use tracing::{debug, instrument};
-
 #[cfg(not(test))]
 use miden_tx::TransactionVerifier;
+use tokio::sync::RwLock;
+use tracing::{debug, instrument};
 
 use crate::{
     block::Block,

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -23,7 +23,7 @@ pub struct DefaultStateView<S> {
     store: Arc<S>,
 
     /// Enables or disables the verification of transaction proofs in `verify_tx`
-    check_tx_proofs: bool,
+    verify_tx_proofs: bool,
 
     /// The account ID of accounts being modified by transactions currently in the block production
     /// pipeline. We currently ensure that only 1 tx/block modifies any given account (issue: #186).
@@ -39,11 +39,11 @@ where
 {
     pub fn new(
         store: Arc<S>,
-        check_tx_proofs: bool,
+        verify_tx_proofs: bool,
     ) -> Self {
         Self {
             store,
-            check_tx_proofs,
+            verify_tx_proofs,
             accounts_in_flight: Arc::new(RwLock::new(BTreeSet::new())),
             nullifiers_in_flight: Arc::new(RwLock::new(BTreeSet::new())),
         }
@@ -61,7 +61,7 @@ where
         &self,
         candidate_tx: &ProvenTransaction,
     ) -> Result<(), VerifyTxError> {
-        if self.check_tx_proofs {
+        if self.verify_tx_proofs {
             // Verify transaction proof
             //
             // This check makes sure that the transaction proof that has been attached to the transaction

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -65,10 +65,7 @@ where
         candidate_tx: &ProvenTransaction,
     ) -> Result<(), VerifyTxError> {
         if self.verify_tx_proofs {
-            // Verify transaction proof
-            //
-            // This check makes sure that the transaction proof that has been attached to the transaction
-            // is valid, errors out if the proof is invalid.
+            // Make sure that the transaction proof is valid and meets the required security level
             let tx_verifier = TransactionVerifier::new(MIN_PROOF_SECURITY_LEVEL);
             tx_verifier
                 .verify(candidate_tx.clone())
@@ -90,7 +87,7 @@ where
         ensure_tx_inputs_constraints(candidate_tx, tx_inputs)?;
 
         // Re-check in-flight transaction constraints, and if verification passes, register
-        //    transaction
+        // transaction
         //
         // Note: We need to re-check these constraints because we dropped the locks since we last
         // checked
@@ -156,10 +153,10 @@ where
 // HELPERS
 // -------------------------------------------------------------------------------------------------
 
-/// Ensures the constraints related to in-flight transactions:  
-/// - the candidate transaction doesn't modify the same account as an existing in-flight  
-///   transaction (issue: #186)  
-/// - no consumed note's nullifier in candidate tx's consumed notes is already contained in  
+/// Ensures the constraints related to in-flight transactions:
+/// - the candidate transaction doesn't modify the same account as an existing in-flight
+///   transaction (issue: #186)
+/// - no consumed note's nullifier in candidate tx's consumed notes is already contained in
 ///   `already_consumed_nullifiers`
 #[instrument(target = "miden-block-producer", skip_all, err)]
 fn ensure_in_flight_constraints(

--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -156,11 +156,11 @@ where
 // HELPERS
 // -------------------------------------------------------------------------------------------------
 
-/// Ensures the constraints related to in-flight transactions:
-/// - the candidate transaction doesn't modify the same account as an existing in-flight
-///    transaction (issue: #186)
-/// - no consumed note's nullifier in candidate tx's consumed notes is already contained in
-///    `already_consumed_nullifiers`
+/// Ensures the constraints related to in-flight transactions:  
+/// - the candidate transaction doesn't modify the same account as an existing in-flight  
+///   transaction (issue: #186)  
+/// - no consumed note's nullifier in candidate tx's consumed notes is already contained in  
+///   `already_consumed_nullifiers`
 #[instrument(target = "miden-block-producer", skip_all, err)]
 fn ensure_in_flight_constraints(
     candidate_tx: &ProvenTransaction,

--- a/block-producer/src/state_view/tests/apply_block.rs
+++ b/block-producer/src/state_view/tests/apply_block.rs
@@ -31,7 +31,7 @@ async fn test_apply_block_ab1() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let state_view = DefaultStateView::new(store.clone());
+    let state_view = DefaultStateView::new(store.clone(), false);
 
     // Verify transaction so it can be tracked in state view
     let verify_tx_res = state_view.verify_tx(&tx).await;
@@ -70,7 +70,7 @@ async fn test_apply_block_ab2() {
             .build(),
     );
 
-    let state_view = DefaultStateView::new(store.clone());
+    let state_view = DefaultStateView::new(store.clone(), false);
 
     // Verify transactions so it can be tracked in state view
     for tx in txs {
@@ -119,7 +119,7 @@ async fn test_apply_block_ab3() {
             .build(),
     );
 
-    let state_view = DefaultStateView::new(store.clone());
+    let state_view = DefaultStateView::new(store.clone(), false);
 
     // Verify transactions so it can be tracked in state view
     for tx in txs.clone() {

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -36,7 +36,7 @@ async fn test_verify_tx_happy_path() {
             .build(),
     );
 
-    let state_view = DefaultStateView::new(store);
+    let state_view = DefaultStateView::new(store, false);
 
     for tx in txs {
         state_view.verify_tx(&tx).await.unwrap();
@@ -63,7 +63,7 @@ async fn test_verify_tx_happy_path_concurrent() {
             .build(),
     );
 
-    let state_view = Arc::new(DefaultStateView::new(store));
+    let state_view = Arc::new(DefaultStateView::new(store, false));
 
     let mut set = JoinSet::new();
 
@@ -100,7 +100,7 @@ async fn test_verify_tx_vt1() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let state_view = DefaultStateView::new(store);
+    let state_view = DefaultStateView::new(store, false);
 
     let verify_tx_result = state_view.verify_tx(&tx).await;
 
@@ -132,7 +132,7 @@ async fn test_verify_tx_vt2() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let state_view = DefaultStateView::new(store);
+    let state_view = DefaultStateView::new(store, false);
 
     let verify_tx_result = state_view.verify_tx(&tx).await;
 
@@ -164,7 +164,7 @@ async fn test_verify_tx_vt3() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let state_view = DefaultStateView::new(store);
+    let state_view = DefaultStateView::new(store, false);
 
     let verify_tx_result = state_view.verify_tx(&tx).await;
 
@@ -207,7 +207,7 @@ async fn test_verify_tx_vt4() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let state_view = DefaultStateView::new(store);
+    let state_view = DefaultStateView::new(store, false);
 
     let verify_tx1_result = state_view.verify_tx(&tx1).await;
     assert!(verify_tx1_result.is_ok());
@@ -257,7 +257,7 @@ async fn test_verify_tx_vt5() {
         OutputNotes::new(Vec::new()).unwrap(),
     );
 
-    let state_view = DefaultStateView::new(store);
+    let state_view = DefaultStateView::new(store, false);
 
     let verify_tx1_result = state_view.verify_tx(&tx1).await;
     assert!(verify_tx1_result.is_ok());

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-// TRANSACTION VERIFIER
+// TRANSACTION VALIDATOR
 // ================================================================================================
 
 /// Implementations are responsible to track in-flight transactions and verify that new transactions
@@ -22,7 +22,7 @@ mod tests;
 /// See [crate::store::ApplyBlock], that trait's `apply_block` is called when a block is sealed, and
 /// it can determine when transactions are no longer in-flight.
 #[async_trait]
-pub trait TransactionVerifier: Send + Sync + 'static {
+pub trait TransactionValidator: Send + Sync + 'static {
     /// Method to receive a `tx` for processing.
     ///
     /// This method should:
@@ -57,7 +57,7 @@ pub struct TransactionQueue<BB, TV> {
 
 impl<BB, TV> TransactionQueue<BB, TV>
 where
-    TV: TransactionVerifier,
+    TV: TransactionValidator,
     BB: BatchBuilder,
 {
     pub fn new(

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -27,9 +27,9 @@ pub trait TransactionValidator: Send + Sync + 'static {
     ///
     /// This method should:
     ///
-    /// 1. Verify the transaction is valid, against the current's rollup state, and also against
+    /// Verify the transaction is valid, against the current's rollup state, and also against
     ///    in-flight transactions.
-    /// 2. Track the necessary state of the transaction until it is commited to the `store`, to
+    /// Track the necessary state of the transaction until it is commited to the `store`, to
     ///    perform the check above.
     async fn verify_tx(
         &self,

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -26,11 +26,10 @@ pub trait TransactionValidator: Send + Sync + 'static {
     /// Method to receive a `tx` for processing.
     ///
     /// This method should:
-    ///
-    /// Verify the transaction is valid, against the current's rollup state, and also against
-    ///    in-flight transactions.
-    /// Track the necessary state of the transaction until it is commited to the `store`, to
-    ///    perform the check above.
+    /// - Verify the transaction is valid, against the current's rollup state, and also against
+    ///   in-flight transactions.
+    /// - Track the necessary state of the transaction until it is commited to the `store`, to
+    ///   perform the check above.
     async fn verify_tx(
         &self,
         tx: &ProvenTransaction,

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -50,7 +50,7 @@ pub struct TransactionQueueOptions {
 
 pub struct TransactionQueue<BB, TV> {
     ready_queue: SharedRwVec<ProvenTransaction>,
-    tx_verifier: Arc<TV>,
+    tx_validator: Arc<TV>,
     batch_builder: Arc<BB>,
     options: TransactionQueueOptions,
 }
@@ -61,13 +61,13 @@ where
     BB: BatchBuilder,
 {
     pub fn new(
-        tx_verifier: Arc<TV>,
+        tx_validator: Arc<TV>,
         batch_builder: Arc<BB>,
         options: TransactionQueueOptions,
     ) -> Self {
         Self {
             ready_queue: Arc::new(RwLock::new(Vec::new())),
-            tx_verifier,
+            tx_validator,
             batch_builder,
             options,
         }
@@ -136,7 +136,7 @@ where
     ) -> Result<(), AddTransactionError> {
         info!(target: COMPONENT, tx_id = %tx.id().to_hex(), account_id = %tx.account_id().to_hex());
 
-        self.tx_verifier
+        self.tx_validator
             .verify_tx(&tx)
             .await
             .map_err(AddTransactionError::VerificationFailed)?;

--- a/block-producer/src/txqueue/tests/mod.rs
+++ b/block-producer/src/txqueue/tests/mod.rs
@@ -10,10 +10,10 @@ use crate::{errors::BuildBatchError, test_utils::DummyProvenTxGenerator, Transac
 // ================================================================================================
 
 /// All transactions verify successfully
-struct TransactionVerifierSuccess;
+struct TransactionValidatorSuccess;
 
 #[async_trait]
-impl TransactionVerifier for TransactionVerifierSuccess {
+impl TransactionValidator for TransactionValidatorSuccess {
     async fn verify_tx(
         &self,
         _tx: &ProvenTransaction,
@@ -23,10 +23,10 @@ impl TransactionVerifier for TransactionVerifierSuccess {
 }
 
 /// All transactions fail to verify
-struct TransactionVerifierFailure;
+struct TransactionValidatorFailure;
 
 #[async_trait]
-impl TransactionVerifier for TransactionVerifierFailure {
+impl TransactionValidator for TransactionValidatorFailure {
     async fn verify_tx(
         &self,
         tx: &ProvenTransaction,
@@ -87,7 +87,7 @@ async fn test_build_batch_success() {
     let (sender, mut receiver) = mpsc::unbounded_channel::<TransactionBatch>();
 
     let tx_queue = Arc::new(TransactionQueue::new(
-        Arc::new(TransactionVerifierSuccess),
+        Arc::new(TransactionValidatorSuccess),
         Arc::new(BatchBuilderSuccess::new(sender)),
         TransactionQueueOptions {
             build_batch_frequency,
@@ -182,7 +182,7 @@ async fn test_tx_verify_failure() {
     let batch_builder = Arc::new(BatchBuilderSuccess::new(sender));
 
     let tx_queue = Arc::new(TransactionQueue::new(
-        Arc::new(TransactionVerifierFailure),
+        Arc::new(TransactionValidatorFailure),
         batch_builder.clone(),
         TransactionQueueOptions {
             build_batch_frequency,
@@ -216,7 +216,7 @@ async fn test_build_batch_failure() {
     let batch_builder = Arc::new(BatchBuilderFailure);
 
     let tx_queue = TransactionQueue::new(
-        Arc::new(TransactionVerifierSuccess),
+        Arc::new(TransactionValidatorSuccess),
         batch_builder.clone(),
         TransactionQueueOptions {
             build_batch_frequency,

--- a/node/miden-node.toml
+++ b/node/miden-node.toml
@@ -4,7 +4,8 @@
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
 endpoint = { host = "localhost", port = 48046 }
 store_url = "http://localhost:28943"
-# enables or disables the verification of transaction proofs in the block producer
+# enables or disables the verification of transaction proofs before they are accepted into the
+# transaction queue.
 verify_tx_proofs = true
 
 [rpc]

--- a/node/miden-node.toml
+++ b/node/miden-node.toml
@@ -4,6 +4,7 @@
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
 endpoint = { host = "localhost", port = 48046 }
 store_url = "http://localhost:28943"
+check_tx_proofs = true
 
 [rpc]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16

--- a/node/miden-node.toml
+++ b/node/miden-node.toml
@@ -4,6 +4,7 @@
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
 endpoint = { host = "localhost", port = 48046 }
 store_url = "http://localhost:28943"
+# enables or disables the verification of transaction proofs in the block producer
 verify_tx_proofs = true
 
 [rpc]

--- a/node/miden-node.toml
+++ b/node/miden-node.toml
@@ -4,7 +4,7 @@
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
 endpoint = { host = "localhost", port = 48046 }
 store_url = "http://localhost:28943"
-check_tx_proofs = true
+verify_tx_proofs = true
 
 [rpc]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16

--- a/node/src/commands/start.rs
+++ b/node/src/commands/start.rs
@@ -69,6 +69,7 @@ mod tests {
                 r#"
                     [block_producer]
                     store_url = "http://store:8000"
+                    check_tx_proofs = true
 
                     [block_producer.endpoint]
                     host = "127.0.0.1"
@@ -101,6 +102,7 @@ mod tests {
                             port: 8080,
                         },
                         store_url: "http://store:8000".to_string(),
+                        check_tx_proofs: true
                     },
                     rpc: RpcConfig {
                         endpoint: Endpoint {

--- a/node/src/commands/start.rs
+++ b/node/src/commands/start.rs
@@ -69,7 +69,7 @@ mod tests {
                 r#"
                     [block_producer]
                     store_url = "http://store:8000"
-                    check_tx_proofs = true
+                    verify_tx_proofs = true
 
                     [block_producer.endpoint]
                     host = "127.0.0.1"
@@ -102,7 +102,7 @@ mod tests {
                             port: 8080,
                         },
                         store_url: "http://store:8000".to_string(),
-                        check_tx_proofs: true
+                        verify_tx_proofs: true
                     },
                     rpc: RpcConfig {
                         endpoint: Endpoint {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,17 +11,18 @@ rust-version = "1.73"
 
 [dependencies]
 anyhow = { version = "1.0" }
-clap = { version = "4.3" , features = ["derive"] }
+clap = { version = "4.3", features = ["derive"] }
 directories = { version = "5.0" }
 figment = { version = "0.10", features = ["toml", "env"] }
 hex = { version = "0.4" }
 miden-objects = { workspace = true }
+miden-tx = { workspace = true }
 miden-node-proto = { path = "../proto" }
 miden-node-store = { path = "../store" }
 miden-node-utils = { path = "../utils" }
 miden-node-block-producer = { path = "../block-producer" }
 prost = { version = "0.12" }
-serde = { version = "1.0" , features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
 toml = { version = "0.8" }
 tonic = { version = "0.10" }

--- a/rpc/src/server/api.rs
+++ b/rpc/src/server/api.rs
@@ -12,7 +12,9 @@ use miden_node_proto::generated::{
     rpc::api_server,
     store::api_client as store_client,
 };
-use miden_objects::{transaction::ProvenTransaction, utils::serde::Deserializable, Digest};
+use miden_objects::{
+    transaction::ProvenTransaction, utils::serde::Deserializable, Digest, MIN_PROOF_SECURITY_LEVEL,
+};
 use miden_tx::TransactionVerifier;
 use tonic::{
     transport::{Channel, Error},
@@ -123,12 +125,12 @@ impl api_server::Api for RpcApi {
         let tx = ProvenTransaction::read_from_bytes(&request.transaction)
             .map_err(|_| Status::invalid_argument("Invalid transaction"))?;
 
-        let tx_verifier = TransactionVerifier::new(96);
+        let tx_verifier = TransactionVerifier::new(MIN_PROOF_SECURITY_LEVEL);
 
         tx_verifier.verify(tx.clone()).map_err(|_| {
             Status::invalid_argument(format!(
                 "Invalid transaction proof for transaction: {}",
-                tx.id().to_hex()
+                tx.id()
             ))
         })?;
 

--- a/rpc/src/server/api.rs
+++ b/rpc/src/server/api.rs
@@ -125,9 +125,12 @@ impl api_server::Api for RpcApi {
 
         let tx_verifier = TransactionVerifier::new(96);
 
-        tx_verifier
-            .verify(tx)
-            .map_err(|_| Status::invalid_argument("Invalid transaction proof"))?;
+        tx_verifier.verify(tx.clone()).map_err(|_| {
+            Status::invalid_argument(format!(
+                "Invalid transaction proof for transaction: {}",
+                tx.id().to_hex()
+            ))
+        })?;
 
         self.block_producer.clone().submit_proven_transaction(request).await
     }


### PR DESCRIPTION
In this PR I propose the addition of the verification of tx proofs on the `RPC` and `Block Producer` of the Miden node.

This will make sure that the locally proven tx's have a valid proof of execution.

Closing: #106 

Would be better to merge after: https://github.com/0xPolygonMiden/miden-base/pull/460