### PR TITLE
Update code to be compatible with Winterfell 0.8

### DIFF
--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -51,4 +51,4 @@ miden-node-utils = { path = "../utils", features = ["tracing-forest"] }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }
-winterfell = { version = "0.7" }
+winterfell = { version = "0.8" }

--- a/block-producer/src/block_builder/prover/mod.rs
+++ b/block-producer/src/block_builder/prover/mod.rs
@@ -226,7 +226,8 @@ impl BlockProver {
             .duration_since(UNIX_EPOCH)
             .expect("today is expected to be before 1970")
             .as_millis()
-            .into();
+            .try_into()
+            .expect("timestamp is greater than or equal to the field modulus");
 
         Ok(BlockHeader::new(
             prev_hash,

--- a/block-producer/src/block_builder/prover/tests.rs
+++ b/block-producer/src/block_builder/prover/tests.rs
@@ -108,9 +108,9 @@ fn test_block_witness_validation_inconsistent_account_hashes() {
     let account_id_2 = AccountId::new_unchecked(ONE);
 
     let account_1_hash_store =
-        Digest::new([Felt::from(1u64), Felt::from(2u64), Felt::from(3u64), Felt::from(4u64)]);
+        Digest::new([Felt::new(1u64), Felt::new(2u64), Felt::new(3u64), Felt::new(4u64)]);
     let account_1_hash_batches =
-        Digest::new([Felt::from(4u64), Felt::from(3u64), Felt::from(2u64), Felt::from(1u64)]);
+        Digest::new([Felt::new(4u64), Felt::new(3u64), Felt::new(2u64), Felt::new(1u64)]);
 
     let block_inputs_from_store: BlockInputs = {
         let block_header = mock_block_header(0, None, None, &[]);
@@ -187,27 +187,27 @@ async fn test_compute_account_root_success() {
     // Set up account states
     // ---------------------------------------------------------------------------------------------
     let account_ids = [
-        AccountId::new_unchecked(Felt::from(0b0000_0000_0000_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_0000_0000_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_1111_0000_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_1111_1111_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_1111_1111_1111u64)),
+        AccountId::new_unchecked(Felt::new(0b0000_0000_0000_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_0000_0000_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_1111_0000_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_1111_1111_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_1111_1111_1111u64)),
     ];
 
     let account_initial_states = [
-        [Felt::from(1u64), Felt::from(1u64), Felt::from(1u64), Felt::from(1u64)],
-        [Felt::from(2u64), Felt::from(2u64), Felt::from(2u64), Felt::from(2u64)],
-        [Felt::from(3u64), Felt::from(3u64), Felt::from(3u64), Felt::from(3u64)],
-        [Felt::from(4u64), Felt::from(4u64), Felt::from(4u64), Felt::from(4u64)],
-        [Felt::from(5u64), Felt::from(5u64), Felt::from(5u64), Felt::from(5u64)],
+        [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)],
+        [Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)],
+        [Felt::new(3u64), Felt::new(3u64), Felt::new(3u64), Felt::new(3u64)],
+        [Felt::new(4u64), Felt::new(4u64), Felt::new(4u64), Felt::new(4u64)],
+        [Felt::new(5u64), Felt::new(5u64), Felt::new(5u64), Felt::new(5u64)],
     ];
 
     let account_final_states = [
-        [Felt::from(2u64), Felt::from(2u64), Felt::from(2u64), Felt::from(2u64)],
-        [Felt::from(3u64), Felt::from(3u64), Felt::from(3u64), Felt::from(3u64)],
-        [Felt::from(4u64), Felt::from(4u64), Felt::from(4u64), Felt::from(4u64)],
-        [Felt::from(5u64), Felt::from(5u64), Felt::from(5u64), Felt::from(5u64)],
-        [Felt::from(1u64), Felt::from(1u64), Felt::from(1u64), Felt::from(1u64)],
+        [Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)],
+        [Felt::new(3u64), Felt::new(3u64), Felt::new(3u64), Felt::new(3u64)],
+        [Felt::new(4u64), Felt::new(4u64), Felt::new(4u64), Felt::new(4u64)],
+        [Felt::new(5u64), Felt::new(5u64), Felt::new(5u64), Felt::new(5u64)],
+        [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)],
     ];
 
     // Set up store's account SMT
@@ -280,19 +280,19 @@ async fn test_compute_account_root_empty_batches() {
     // Set up account states
     // ---------------------------------------------------------------------------------------------
     let account_ids = [
-        AccountId::new_unchecked(Felt::from(0b0000_0000_0000_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_0000_0000_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_1111_0000_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_1111_1111_0000u64)),
-        AccountId::new_unchecked(Felt::from(0b1111_1111_1111_1111u64)),
+        AccountId::new_unchecked(Felt::new(0b0000_0000_0000_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_0000_0000_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_1111_0000_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_1111_1111_0000u64)),
+        AccountId::new_unchecked(Felt::new(0b1111_1111_1111_1111u64)),
     ];
 
     let account_initial_states = [
-        [Felt::from(1u64), Felt::from(1u64), Felt::from(1u64), Felt::from(1u64)],
-        [Felt::from(2u64), Felt::from(2u64), Felt::from(2u64), Felt::from(2u64)],
-        [Felt::from(3u64), Felt::from(3u64), Felt::from(3u64), Felt::from(3u64)],
-        [Felt::from(4u64), Felt::from(4u64), Felt::from(4u64), Felt::from(4u64)],
-        [Felt::from(5u64), Felt::from(5u64), Felt::from(5u64), Felt::from(5u64)],
+        [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)],
+        [Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)],
+        [Felt::new(3u64), Felt::new(3u64), Felt::new(3u64), Felt::new(3u64)],
+        [Felt::new(4u64), Felt::new(4u64), Felt::new(4u64), Felt::new(4u64)],
+        [Felt::new(5u64), Felt::new(5u64), Felt::new(5u64), Felt::new(5u64)],
     ];
 
     // Set up store's account SMT
@@ -399,20 +399,20 @@ async fn test_compute_note_root_success() {
     let tx_gen = DummyProvenTxGenerator::new();
 
     let account_ids = [
-        AccountId::new_unchecked(Felt::from(0u64)),
-        AccountId::new_unchecked(Felt::from(1u64)),
-        AccountId::new_unchecked(Felt::from(2u64)),
+        AccountId::new_unchecked(Felt::new(0u64)),
+        AccountId::new_unchecked(Felt::new(1u64)),
+        AccountId::new_unchecked(Felt::new(2u64)),
     ];
 
     let notes_created: Vec<NoteEnvelope> = [
-        Digest::from([Felt::from(1u64), Felt::from(1u64), Felt::from(1u64), Felt::from(1u64)]),
-        Digest::from([Felt::from(2u64), Felt::from(2u64), Felt::from(2u64), Felt::from(2u64)]),
-        Digest::from([Felt::from(3u64), Felt::from(3u64), Felt::from(3u64), Felt::from(3u64)]),
+        Digest::from([Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)]),
+        Digest::from([Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)]),
+        Digest::from([Felt::new(3u64), Felt::new(3u64), Felt::new(3u64), Felt::new(3u64)]),
     ]
     .into_iter()
     .zip(account_ids.iter())
     .map(|(note_digest, &account_id)| {
-        NoteEnvelope::new(note_digest.into(), NoteMetadata::new(account_id, Felt::from(1u64)))
+        NoteEnvelope::new(note_digest.into(), NoteMetadata::new(account_id, Felt::new(1u64)))
     })
     .collect();
 
@@ -507,7 +507,7 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
     let nullifier_1 = batches[0].produced_nullifiers().next().unwrap();
     let nullifier_2 = batches[1].produced_nullifiers().next().unwrap();
     let nullifier_3 =
-        Digest::from([101_u64.into(), 102_u64.into(), 103_u64.into(), 104_u64.into()]).into();
+        Digest::from([101_u32.into(), 102_u32.into(), 103_u32.into(), 104_u32.into()]).into();
 
     let block_inputs_from_store: BlockInputs = {
         let block_header = mock_block_header(0, None, None, &[]);

--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -14,9 +14,9 @@ use crate::{
 #[miden_node_test_macro::enable_logging]
 async fn test_apply_block_called_nonempty_batches() {
     let tx_gen = DummyProvenTxGenerator::new();
-    let account_id = AccountId::new_unchecked(42u64.into());
+    let account_id = AccountId::new_unchecked(42u32.into());
     let account_initial_hash: Digest =
-        [Felt::from(1u64), Felt::from(1u64), Felt::from(1u64), Felt::from(1u64)].into();
+        [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)].into();
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
             .initial_accounts(std::iter::once((account_id, account_initial_hash)))
@@ -30,7 +30,7 @@ async fn test_apply_block_called_nonempty_batches() {
             let tx = tx_gen.dummy_proven_tx_with_params(
                 account_id,
                 account_initial_hash,
-                [Felt::from(2u64), Felt::from(2u64), Felt::from(2u64), Felt::from(2u64)].into(),
+                [Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)].into(),
                 InputNotes::new(Vec::new()).unwrap(),
                 OutputNotes::new(Vec::new()).unwrap(),
             );
@@ -50,9 +50,9 @@ async fn test_apply_block_called_nonempty_batches() {
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn test_apply_block_called_empty_batches() {
-    let account_id = AccountId::new_unchecked(42u64.into());
+    let account_id = AccountId::new_unchecked(42u32.into());
     let account_hash: Digest =
-        [Felt::from(1u64), Felt::from(1u64), Felt::from(1u64), Felt::from(1u64)].into();
+        [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)].into();
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
             .initial_accounts(std::iter::once((account_id, account_hash)))

--- a/node/src/commands/genesis/mod.rs
+++ b/node/src/commands/genesis/mod.rs
@@ -148,7 +148,8 @@ fn create_accounts(
                     init_seed,
                     TokenSymbol::try_from(inputs.token_symbol.as_str())?,
                     inputs.decimals,
-                    Felt::from(inputs.max_supply),
+                    Felt::try_from(inputs.max_supply)
+                        .expect("max supply value is greater than or equal to the field modulus"),
                     auth_scheme,
                 )?;
 

--- a/proto/src/domain/blocks.rs
+++ b/proto/src/domain/blocks.rs
@@ -72,7 +72,10 @@ impl TryFrom<block_header::BlockHeader> for BlockHeader {
                 .ok_or(block_header::BlockHeader::missing_field(stringify!(proof_hash)))?
                 .try_into()?,
             value.version.into(),
-            value.timestamp.into(),
+            value
+                .timestamp
+                .try_into()
+                .expect("timestamp value is greater than or equal to the field modulus"),
         ))
     }
 }

--- a/proto/src/domain/mod.rs
+++ b/proto/src/domain/mod.rs
@@ -1,4 +1,4 @@
-use miden_objects::{StarkField, Word};
+use miden_objects::Word;
 
 pub mod accounts;
 pub mod blocks;

--- a/store/src/db/sql.rs
+++ b/store/src/db/sql.rs
@@ -12,12 +12,9 @@ use miden_node_proto::{
         responses::{AccountHashUpdate, NullifierUpdate},
     },
 };
-use miden_objects::{
-    crypto::{
-        hash::rpo::RpoDigest,
-        utils::{Deserializable, SliceReader},
-    },
-    StarkField,
+use miden_objects::crypto::{
+    hash::rpo::RpoDigest,
+    utils::{Deserializable, SliceReader},
 };
 use prost::Message;
 use rusqlite::{params, types::Value, Connection, Transaction};

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -486,7 +486,12 @@ pub fn build_notes_tree(
             .ok_or(NoteCreated::missing_field(stringify!(sender)))?
             .try_into()
             .or(Err(ApplyBlockError::InvalidAccountId))?;
-        let note_metadata = NoteMetadata::new(account_id, note.tag.into());
+        let note_metadata = NoteMetadata::new(
+            account_id,
+            note.tag
+                .try_into()
+                .expect("tag value is greater than or equal to the field modulus"),
+        );
         let index = note.note_index as u64;
         entries.push((index, note_id.try_into()?));
         entries.push((index + 1, note_metadata.into()));


### PR DESCRIPTION
This PR updates the code to be compatible with new 0.8 version of the Winterfell.

This update mostly contains changes in `Felt` creation, since casting of `u64` to `FieldElement` was removed. It also updates the serialization and deserialization of the structs, which contain vectors of `Felt`s or `RpoDigest`s.