### PR TITLE
Fix `TODO` for new accounts

### DIFF
--- a/block-producer/src/state_view/mod.rs
+++ b/block-producer/src/state_view/mod.rs
@@ -194,7 +194,14 @@ fn ensure_tx_inputs_constraints(
         },
         // if the account is not present in the Store, it must be a new account
         None => {
-            // TODO: check if the transaction was executed against new account
+            // if the initial account hash is not equal to `Digest::default()` it
+            // signifies that the account is not new but is also not recorded in the Store
+            if candidate_tx.initial_account_hash() != Digest::default() {
+                return Err(VerifyTxError::IncorrectAccountInitialHash {
+                    tx_initial_account_hash: candidate_tx.initial_account_hash(),
+                    store_account_hash: None,
+                });
+            }
         },
     }
 

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -82,7 +82,7 @@ async fn test_verify_tx_happy_path_concurrent() {
 async fn test_verify_tx_vt1() {
     let tx_gen = DummyProvenTxGenerator::new();
 
-    let account = MockPrivateAccount::<3>::from(0);
+    let account = MockPrivateAccount::<3>::from(1);
 
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
@@ -113,7 +113,6 @@ async fn test_verify_tx_vt1() {
     );
 }
 
-/// TODO: Add new_account checks from the ProvenTransaction
 /// Verifies requirement VT2
 #[tokio::test]
 async fn test_verify_tx_vt2() {
@@ -144,7 +143,7 @@ async fn test_verify_tx_vt2() {
 async fn test_verify_tx_vt3() {
     let tx_gen = DummyProvenTxGenerator::new();
 
-    let account: MockPrivateAccount<3> = MockPrivateAccount::from(0);
+    let account: MockPrivateAccount<3> = MockPrivateAccount::from(1);
 
     let nullifier_in_store = nullifier_by_index(0);
 
@@ -181,7 +180,7 @@ async fn test_verify_tx_vt3() {
 async fn test_verify_tx_vt4() {
     let tx_gen = DummyProvenTxGenerator::new();
 
-    let account: MockPrivateAccount<3> = MockPrivateAccount::from(0);
+    let account: MockPrivateAccount<3> = MockPrivateAccount::from(1);
 
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
@@ -224,8 +223,8 @@ async fn test_verify_tx_vt4() {
 async fn test_verify_tx_vt5() {
     let tx_gen = DummyProvenTxGenerator::new();
 
-    let account_1: MockPrivateAccount<3> = MockPrivateAccount::from(0);
-    let account_2: MockPrivateAccount<3> = MockPrivateAccount::from(1);
+    let account_1: MockPrivateAccount<3> = MockPrivateAccount::from(1);
+    let account_2: MockPrivateAccount<3> = MockPrivateAccount::from(2);
     let nullifier_in_both_txs = nullifier_by_index(0);
 
     // Notice: `consumed_note_in_both_txs` is NOT in the store

--- a/block-producer/src/test_utils/account.rs
+++ b/block-producer/src/test_utils/account.rs
@@ -13,7 +13,10 @@ pub struct MockPrivateAccount<const NUM_STATES: usize = 3> {
 }
 
 impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
-    fn new(init_seed: [u8; 32]) -> Self {
+    fn new(
+        init_seed: [u8; 32],
+        new_account: bool,
+    ) -> Self {
         let account_seed = get_account_seed(
             init_seed,
             miden_objects::accounts::AccountType::RegularAccountUpdatableCode,
@@ -25,7 +28,10 @@ impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
 
         let mut states = [Digest::default(); NUM_STATES];
 
-        states[0] = Hasher::hash(&init_seed);
+        if !new_account {
+            states[0] = Hasher::hash(&init_seed);
+        }
+
         for idx in 1..NUM_STATES {
             states[idx] = Hasher::hash(&states[idx - 1].as_bytes());
         }
@@ -39,9 +45,15 @@ impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
 
 impl<const NUM_STATES: usize> From<u32> for MockPrivateAccount<NUM_STATES> {
     /// Each index gives rise to a different account ID
+    /// Passing index 0 signifies that it's a new account
     fn from(index: u32) -> Self {
         let init_seed: Vec<_> = index.to_be_bytes().into_iter().chain([0u8; 28]).collect();
 
-        Self::new(init_seed.try_into().unwrap())
+        // using index 0 signifies that it's a new account
+        if index == 0 {
+            Self::new(init_seed.try_into().unwrap(), true)
+        } else {
+            Self::new(init_seed.try_into().unwrap(), false)
+        }
     }
 }


### PR DESCRIPTION
In this PR I propose to remove the TODO that checks if the transaction was executed against a new account.

I made sure that the transactions initial account hash is indeed equal to `Digest::default()` considering that we received `None` back from the store, meaning that this is a new account. 