### PR TITLE
Set nonce of accounts to 1 at genesis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,20 @@
 [workspace]
-members = ["block-producer", "node", "proto", "rpc", "store", "utils", "test-macro"]
+members = [
+  "block-producer",
+  "node",
+  "proto",
+  "rpc",
+  "store",
+  "utils",
+  "test-macro",
+]
 resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
-miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
-miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "main" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce" }
+miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce" }
-miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce" }
-miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 miden-node-utils = { path = "../utils", features = ["tracing-forest"] }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "phklive-set-nonce", default-features = false }
 miden-node-utils = { path = "../utils", features = ["tracing-forest"] }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }

--- a/node/src/commands/genesis/mod.rs
+++ b/node/src/commands/genesis/mod.rs
@@ -18,7 +18,7 @@ use miden_node_utils::config::load_config;
 use miden_objects::{
     accounts::{Account, AccountData, AccountType, AuthData},
     assets::TokenSymbol,
-    Felt,
+    Felt, ONE,
 };
 
 mod inputs;
@@ -166,7 +166,7 @@ fn create_accounts(
             }
         }
 
-        account_data.account.set_nonce(Felt::new(1))?;
+        account_data.account.set_nonce(ONE)?;
 
         account_data.write(path)?;
 

--- a/node/src/commands/genesis/mod.rs
+++ b/node/src/commands/genesis/mod.rs
@@ -121,7 +121,7 @@ fn create_accounts(
 
     for account in accounts {
         // build account data from account inputs
-        let account_data = match account {
+        let mut account_data = match account {
             AccountInput::BasicWallet(inputs) => {
                 print!("Creating basic wallet account...");
                 let init_seed = hex_to_bytes(&inputs.init_seed)?;
@@ -165,6 +165,8 @@ fn create_accounts(
                 return Err(anyhow!("Failed to generate account file {} because it already exists. Use the --force flag to overwrite.", path.display()));
             }
         }
+
+        account_data.account.set_nonce(Felt::new(1))?;
 
         account_data.write(path)?;
 


### PR DESCRIPTION
In this PR I propose to set the nonce of Miden-Accounts imported at genesis to 1. 

This will prevent errors that we had on checks because of accounts imported at genesis breaking the node constraints.

Closes: #223