### PR TITLE
Using `Nullifier` instead of `Digest` for nullifiers

### DIFF
--- a/block-producer/src/block.rs
+++ b/block-producer/src/block.rs
@@ -1,13 +1,17 @@
 use std::collections::BTreeMap;
 
-use miden_objects::{accounts::AccountId, notes::NoteEnvelope, BlockHeader, Digest};
+use miden_objects::{
+    accounts::AccountId,
+    notes::{NoteEnvelope, Nullifier},
+    BlockHeader, Digest,
+};
 
 #[derive(Debug, Clone)]
 pub struct Block {
     pub header: BlockHeader,
     pub updated_accounts: Vec<(AccountId, Digest)>,
     pub created_notes: BTreeMap<u64, NoteEnvelope>,
-    pub produced_nullifiers: Vec<Digest>,
+    pub produced_nullifiers: Vec<Nullifier>,
     // TODO:
     // - full states for updated public accounts
     // - full states for created public notes

--- a/block-producer/src/block_builder/mod.rs
+++ b/block-producer/src/block_builder/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use miden_node_utils::formatting::{format_array, format_blake3_digest};
-use miden_objects::{accounts::AccountId, Digest};
+use miden_objects::{accounts::AccountId, notes::Nullifier, Digest};
 use tracing::{debug, info, instrument};
 
 use crate::{
@@ -90,7 +90,7 @@ where
                 })
             })
             .collect();
-        let produced_nullifiers: Vec<Digest> =
+        let produced_nullifiers: Vec<Nullifier> =
             batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();
 
         let block_inputs = self

--- a/block-producer/src/block_builder/prover/block_witness.rs
+++ b/block-producer/src/block_builder/prover/block_witness.rs
@@ -4,6 +4,7 @@ use miden_node_proto::domain::blocks::BlockInputs;
 use miden_objects::{
     accounts::AccountId,
     crypto::merkle::{EmptySubtreeRoots, MerklePath, MerkleStore, MmrPeaks, SmtProof},
+    notes::Nullifier,
     vm::{AdviceInputs, StackInputs},
     BlockHeader, Digest, Felt, ZERO,
 };
@@ -32,7 +33,7 @@ pub struct BlockWitness {
     pub(super) updated_accounts: BTreeMap<AccountId, AccountUpdate>,
     /// (batch_index, created_notes_root) for batches that contain notes
     pub(super) batch_created_notes_roots: BTreeMap<usize, Digest>,
-    pub(super) produced_nullifiers: BTreeMap<Digest, SmtProof>,
+    pub(super) produced_nullifiers: BTreeMap<Nullifier, SmtProof>,
     pub(super) chain_peaks: MmrPeaks,
     pub(super) prev_header: BlockHeader,
 }
@@ -191,19 +192,19 @@ impl BlockWitness {
         block_inputs: &BlockInputs,
         batches: &[TransactionBatch],
     ) -> Result<(), BuildBlockError> {
-        let produced_nullifiers_from_store: BTreeSet<Digest> = block_inputs
+        let produced_nullifiers_from_store: BTreeSet<Nullifier> = block_inputs
             .nullifiers
             .iter()
             .map(|nullifier_record| nullifier_record.nullifier)
             .collect();
 
-        let produced_nullifiers_from_batches: BTreeSet<Digest> =
+        let produced_nullifiers_from_batches: BTreeSet<Nullifier> =
             batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();
 
         if produced_nullifiers_from_store == produced_nullifiers_from_batches {
             Ok(())
         } else {
-            let differing_nullifiers: Vec<Digest> = produced_nullifiers_from_store
+            let differing_nullifiers: Vec<Nullifier> = produced_nullifiers_from_store
                 .symmetric_difference(&produced_nullifiers_from_batches)
                 .copied()
                 .collect();
@@ -233,7 +234,7 @@ impl BlockWitness {
                 .expect("can't be more than 2^64 - 1 nullifiers");
 
             for nullifier in self.produced_nullifiers.keys() {
-                stack_inputs.extend(*nullifier);
+                stack_inputs.extend(nullifier.inner());
             }
 
             // append nullifier value (`[block_num, 0, 0, 0]`)
@@ -308,7 +309,7 @@ impl BlockWitness {
             merkle_store
                 .add_merkle_paths(self.produced_nullifiers.iter().map(|(nullifier, proof)| {
                     // Note: the initial value for all nullifiers in the tree is `[0, 0, 0, 0]`
-                    (u64::from(nullifier[3]), Digest::default(), proof.path().clone())
+                    (u64::from(nullifier.inner()[3]), Digest::default(), proof.path().clone())
                 }))
                 .map_err(BlockProverError::InvalidMerklePaths)?;
 

--- a/block-producer/src/block_builder/prover/tests.rs
+++ b/block-producer/src/block_builder/prover/tests.rs
@@ -507,7 +507,7 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
     let nullifier_1 = batches[0].produced_nullifiers().next().unwrap();
     let nullifier_2 = batches[1].produced_nullifiers().next().unwrap();
     let nullifier_3 =
-        Digest::from([101_u64.into(), 102_u64.into(), 103_u64.into(), 104_u64.into()]);
+        Digest::from([101_u64.into(), 102_u64.into(), 103_u64.into(), 104_u64.into()]).into();
 
     let block_inputs_from_store: BlockInputs = {
         let block_header = mock_block_header(0, None, None, &[]);
@@ -518,7 +518,7 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
                 nullifier: nullifier_2,
                 proof: SmtProof::new(
                     MerklePath::new(vec![Digest::default(); SMT_DEPTH as usize]),
-                    SmtLeaf::new_empty(LeafIndex::new_max_depth(nullifier_2[3].into())),
+                    SmtLeaf::new_empty(LeafIndex::new_max_depth(nullifier_2.inner()[3].into())),
                 )
                 .unwrap(),
             },
@@ -526,7 +526,7 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
                 nullifier: nullifier_3,
                 proof: SmtProof::new(
                     MerklePath::new(vec![Digest::default(); SMT_DEPTH as usize]),
-                    SmtLeaf::new_empty(LeafIndex::new_max_depth(nullifier_3[3].into())),
+                    SmtLeaf::new_empty(LeafIndex::new_max_depth(nullifier_3.inner()[3].into())),
                 )
                 .unwrap(),
             },
@@ -666,12 +666,11 @@ async fn test_compute_nullifier_root_success() {
     // ---------------------------------------------------------------------------------------------
 
     // Note that the block number in store is 42; the nullifiers get added to the next block (i.e. block number 43)
-    let nullifier_smt = Smt::with_entries(
-        nullifiers
-            .into_iter()
-            .map(|nullifier| (nullifier, [(initial_block_num + 1).into(), ZERO, ZERO, ZERO])),
-    )
-    .unwrap();
+    let nullifier_smt =
+        Smt::with_entries(nullifiers.into_iter().map(|nullifier| {
+            (nullifier.inner(), [(initial_block_num + 1).into(), ZERO, ZERO, ZERO])
+        }))
+        .unwrap();
 
     // Compare roots
     // ---------------------------------------------------------------------------------------------

--- a/block-producer/src/errors.rs
+++ b/block-producer/src/errors.rs
@@ -135,7 +135,7 @@ pub enum BuildBlockError {
     #[error("transaction batches and store contain different hashes for some accounts. Offending accounts: {0:?}")]
     InconsistentAccountStates(Vec<AccountId>),
     #[error("transaction batches and store don't produce the same nullifiers. Offending nullifiers: {0:?}")]
-    InconsistentNullifiers(Vec<Digest>),
+    InconsistentNullifiers(Vec<Nullifier>),
     #[error(
         "too many batches in block. Got: {0}, max: 2^{}",
         CREATED_NOTES_TREE_INSERTION_DEPTH

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -9,7 +9,7 @@ use miden_node_proto::{
     },
     TransactionInputs,
 };
-use miden_objects::{accounts::AccountId, Digest};
+use miden_objects::{accounts::AccountId, notes::Nullifier};
 use tonic::transport::Channel;
 use tracing::{debug, info, instrument};
 
@@ -31,7 +31,7 @@ pub trait Store: ApplyBlock {
     async fn get_block_inputs(
         &self,
         updated_accounts: impl Iterator<Item = &AccountId> + Send,
-        produced_nullifiers: impl Iterator<Item = &Digest> + Send,
+        produced_nullifiers: impl Iterator<Item = &Nullifier> + Send,
     ) -> Result<BlockInputs, BlockInputsError>;
 }
 
@@ -128,7 +128,7 @@ impl Store for DefaultStore {
     async fn get_block_inputs(
         &self,
         updated_accounts: impl Iterator<Item = &AccountId> + Send,
-        produced_nullifiers: impl Iterator<Item = &Digest> + Send,
+        produced_nullifiers: impl Iterator<Item = &Nullifier> + Send,
     ) -> Result<BlockInputs, BlockInputsError> {
         let request = tonic::Request::new(GetBlockInputsRequest {
             account_ids: updated_accounts

--- a/block-producer/src/test_utils/block.rs
+++ b/block-producer/src/test_utils/block.rs
@@ -2,8 +2,10 @@ use std::collections::BTreeMap;
 
 use miden_node_proto::domain::blocks::BlockInputs;
 use miden_objects::{
-    accounts::AccountId, crypto::merkle::Mmr, notes::NoteEnvelope, BlockHeader, Digest,
-    ACCOUNT_TREE_DEPTH, ONE, ZERO,
+    accounts::AccountId,
+    crypto::merkle::Mmr,
+    notes::{NoteEnvelope, Nullifier},
+    BlockHeader, Digest, ACCOUNT_TREE_DEPTH, ONE, ZERO,
 };
 use miden_vm::crypto::SimpleSmt;
 
@@ -74,7 +76,7 @@ pub async fn build_actual_block_header(
 ) -> BlockHeader {
     let updated_accounts: Vec<(AccountId, Digest)> =
         batches.iter().flat_map(|batch| batch.updated_accounts()).collect();
-    let produced_nullifiers: Vec<Digest> =
+    let produced_nullifiers: Vec<Nullifier> =
         batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();
 
     let block_inputs_from_store: BlockInputs = store
@@ -98,7 +100,7 @@ pub struct MockBlockBuilder {
 
     updated_accounts: Option<Vec<(AccountId, Digest)>>,
     created_notes: Option<BTreeMap<u64, NoteEnvelope>>,
-    produced_nullifiers: Option<Vec<Digest>>,
+    produced_nullifiers: Option<Vec<Nullifier>>,
 }
 
 impl MockBlockBuilder {
@@ -138,7 +140,7 @@ impl MockBlockBuilder {
 
     pub fn produced_nullifiers(
         mut self,
-        produced_nullifiers: Vec<Digest>,
+        produced_nullifiers: Vec<Nullifier>,
     ) -> Self {
         self.produced_nullifiers = Some(produced_nullifiers);
 

--- a/proto/src/domain/digest.rs
+++ b/proto/src/domain/digest.rs
@@ -1,10 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use hex::{FromHex, ToHex};
-use miden_objects::{
-    notes::{NoteId, Nullifier},
-    Digest, Felt, StarkField,
-};
+use miden_objects::{notes::NoteId, Digest, Felt, StarkField};
 
 use crate::{errors::ParseError, generated::digest};
 
@@ -142,18 +139,6 @@ impl From<Digest> for digest::Digest {
 impl From<&Digest> for digest::Digest {
     fn from(value: &Digest) -> Self {
         (*value).into()
-    }
-}
-
-impl From<&Nullifier> for digest::Digest {
-    fn from(value: &Nullifier) -> Self {
-        (*value).inner().into()
-    }
-}
-
-impl From<Nullifier> for digest::Digest {
-    fn from(value: Nullifier) -> Self {
-        value.inner().into()
     }
 }
 

--- a/proto/src/domain/nullifiers.rs
+++ b/proto/src/domain/nullifiers.rs
@@ -1,16 +1,46 @@
-use miden_objects::{crypto::merkle::SmtProof, Digest};
+use miden_objects::{
+    crypto::{hash::rpo::RpoDigest, merkle::SmtProof},
+    notes::Nullifier,
+};
 
 use crate::{
     errors::{MissingFieldHelper, ParseError},
-    generated::responses::NullifierBlockInputRecord,
+    generated::{digest::Digest, responses::NullifierBlockInputRecord},
 };
+
+// FROM NULLIFIER
+// ================================================================================================
+
+impl From<&Nullifier> for Digest {
+    fn from(value: &Nullifier) -> Self {
+        (*value).inner().into()
+    }
+}
+
+impl From<Nullifier> for Digest {
+    fn from(value: Nullifier) -> Self {
+        value.inner().into()
+    }
+}
+
+// INTO NULLIFIER
+// ================================================================================================
+
+impl TryFrom<Digest> for Nullifier {
+    type Error = ParseError;
+
+    fn try_from(value: Digest) -> Result<Self, Self::Error> {
+        let digest: RpoDigest = value.try_into()?;
+        Ok(digest.into())
+    }
+}
 
 // NULLIFIER INPUT RECORD
 // ================================================================================================
 
 #[derive(Clone, Debug)]
 pub struct NullifierWitness {
-    pub nullifier: Digest,
+    pub nullifier: Nullifier,
     pub proof: SmtProof,
 }
 

--- a/proto/src/domain/transactions.rs
+++ b/proto/src/domain/transactions.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use miden_node_utils::formatting::{format_map, format_opt};
-use miden_objects::Digest;
+use miden_objects::notes::Nullifier;
 
 use crate::{
     domain::accounts::AccountState,
@@ -23,7 +23,7 @@ pub struct TransactionInputs {
 
     /// Maps each consumed notes' nullifier to block number, where the note is consumed
     /// (`zero` means, that note isn't consumed yet)
-    pub nullifiers: BTreeMap<Digest, u32>,
+    pub nullifiers: BTreeMap<Nullifier, u32>,
 }
 
 impl Display for TransactionInputs {

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -400,7 +400,7 @@ impl State {
                 let proof = inner.nullifier_tree.open(nullifier);
 
                 NullifierWitness {
-                    nullifier: *nullifier,
+                    nullifier: (*nullifier).into(),
                     proof,
                 }
             })
@@ -434,7 +434,7 @@ impl State {
                 let value = inner.nullifier_tree.get_value(&nullifier);
                 let block_num = nullifier_value_to_block_num(value);
 
-                (nullifier, block_num)
+                (nullifier.into(), block_num)
             })
             .collect();
 


### PR DESCRIPTION
This addresses the comment from [#208](https://github.com/0xPolygonMiden/miden-node/pull/208):

https://github.com/0xPolygonMiden/miden-node/pull/208#discussion_r1485563702