### PR TITLE
`BlockInputs` improvements

### DIFF
--- a/block-producer/src/block.rs
+++ b/block-producer/src/block.rs
@@ -1,7 +1,13 @@
 use std::collections::BTreeMap;
 
+use miden_node_proto::{
+    errors::{MissingFieldHelper, ParseError},
+    generated::responses::GetBlockInputsResponse,
+    try_convert, AccountInputRecord, NullifierWitness,
+};
 use miden_objects::{
     accounts::AccountId,
+    crypto::merkle::MmrPeaks,
     notes::{NoteEnvelope, Nullifier},
     BlockHeader, Digest,
 };
@@ -21,5 +27,60 @@ pub struct Block {
 impl Block {
     pub fn hash(&self) -> Digest {
         todo!()
+    }
+}
+
+// BLOCK INPUTS
+// ================================================================================================
+
+/// Information needed from the store to build a block
+#[derive(Clone, Debug)]
+pub struct BlockInputs {
+    /// Previous block header
+    pub block_header: BlockHeader,
+
+    /// MMR peaks for the current chain state
+    pub chain_peaks: MmrPeaks,
+
+    /// The hashes of the requested accounts and their authentication paths
+    pub account_states: Vec<AccountInputRecord>,
+
+    /// The requested nullifiers and their authentication paths
+    pub nullifiers: Vec<NullifierWitness>,
+}
+
+impl TryFrom<GetBlockInputsResponse> for BlockInputs {
+    type Error = ParseError;
+
+    fn try_from(get_block_inputs: GetBlockInputsResponse) -> Result<Self, Self::Error> {
+        let block_header: BlockHeader = get_block_inputs
+            .block_header
+            .ok_or(GetBlockInputsResponse::missing_field(stringify!(block_header)))?
+            .try_into()?;
+
+        let chain_peaks = {
+            // setting the number of leaves to the current block number gives us one leaf less than
+            // what is currently in the chain MMR (i.e., chain MMR with block_num = 1 has 2 leave);
+            // this is because GetBlockInputs returns the state of the chain MMR as of one block
+            // ago so that block_header.chain_root matches the hash of MMR peaks.
+            let num_leaves = block_header.block_num() as usize;
+
+            MmrPeaks::new(
+                num_leaves,
+                get_block_inputs
+                    .mmr_peaks
+                    .into_iter()
+                    .map(|peak| peak.try_into())
+                    .collect::<Result<_, Self::Error>>()?,
+            )
+            .map_err(Self::Error::MmrPeaksError)?
+        };
+
+        Ok(Self {
+            block_header,
+            chain_peaks,
+            account_states: try_convert(get_block_inputs.account_states)?,
+            nullifiers: try_convert(get_block_inputs.nullifiers)?,
+        })
     }
 }

--- a/block-producer/src/block.rs
+++ b/block-producer/src/block.rs
@@ -12,6 +12,8 @@ use miden_objects::{
     BlockHeader, Digest,
 };
 
+use crate::store::BlockInputsError;
+
 #[derive(Debug, Clone)]
 pub struct Block {
     pub header: BlockHeader,
@@ -56,7 +58,7 @@ pub struct AccountWitness {
 }
 
 impl TryFrom<GetBlockInputsResponse> for BlockInputs {
-    type Error = ParseError;
+    type Error = BlockInputsError;
 
     fn try_from(get_block_inputs: GetBlockInputsResponse) -> Result<Self, Self::Error> {
         let block_header: BlockHeader = get_block_inputs
@@ -76,10 +78,9 @@ impl TryFrom<GetBlockInputsResponse> for BlockInputs {
                 get_block_inputs
                     .mmr_peaks
                     .into_iter()
-                    .map(|peak| peak.try_into())
-                    .collect::<Result<_, Self::Error>>()?,
-            )
-            .map_err(Self::Error::MmrPeaksError)?
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()?,
+            )?
         };
 
         let accounts = get_block_inputs

--- a/block-producer/src/block_builder/prover/block_witness.rs
+++ b/block-producer/src/block_builder/prover/block_witness.rs
@@ -128,7 +128,7 @@ impl BlockWitness {
         let accounts_in_batches: BTreeSet<AccountId> =
             batches_initial_states.keys().cloned().collect();
         let accounts_in_store: BTreeSet<AccountId> =
-            block_inputs.accounts.iter().map(|(&account_id, _)| account_id).collect();
+            block_inputs.accounts.keys().copied().collect();
 
         if accounts_in_batches == accounts_in_store {
             let accounts_with_different_hashes: Vec<AccountId> = block_inputs
@@ -173,7 +173,7 @@ impl BlockWitness {
         batches: &[TransactionBatch],
     ) -> Result<(), BuildBlockError> {
         let produced_nullifiers_from_store: BTreeSet<Nullifier> =
-            block_inputs.nullifiers.iter().map(|(&nullifier, _)| nullifier).collect();
+            block_inputs.nullifiers.keys().copied().collect();
 
         let produced_nullifiers_from_batches: BTreeSet<Nullifier> =
             batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();

--- a/block-producer/src/block_builder/prover/block_witness.rs
+++ b/block-producer/src/block_builder/prover/block_witness.rs
@@ -50,9 +50,9 @@ impl BlockWitness {
                 batches.iter().flat_map(|batch| batch.account_initial_states()).collect();
 
             let mut account_merkle_proofs: BTreeMap<AccountId, MerklePath> = block_inputs
-                .account_states
+                .accounts
                 .into_iter()
-                .map(|record| (record.account_id, record.proof))
+                .map(|(account_id, witness)| (account_id, witness.proof))
                 .collect();
 
             batches
@@ -90,16 +90,10 @@ impl BlockWitness {
             })
             .collect();
 
-        let produced_nullifiers = block_inputs
-            .nullifiers
-            .into_iter()
-            .map(|nullifier_record| (nullifier_record.nullifier, nullifier_record.proof))
-            .collect();
-
         Ok(Self {
             updated_accounts,
             batch_created_notes_roots,
-            produced_nullifiers,
+            produced_nullifiers: block_inputs.nullifiers,
             chain_peaks: block_inputs.chain_peaks,
             prev_header: block_inputs.block_header,
         })
@@ -143,27 +137,23 @@ impl BlockWitness {
 
         let accounts_in_batches: BTreeSet<AccountId> =
             batches_initial_states.keys().cloned().collect();
-        let accounts_in_store: BTreeSet<AccountId> = block_inputs
-            .account_states
-            .iter()
-            .map(|record| &record.account_id)
-            .cloned()
-            .collect();
+        let accounts_in_store: BTreeSet<AccountId> =
+            block_inputs.accounts.iter().map(|(&account_id, _)| account_id).collect();
 
         if accounts_in_batches == accounts_in_store {
             let accounts_with_different_hashes: Vec<AccountId> = block_inputs
-                .account_states
+                .accounts
                 .iter()
-                .filter_map(|record| {
-                    let hash_in_store = record.account_hash;
+                .filter_map(|(account_id, witness)| {
+                    let hash_in_store = witness.hash;
                     let hash_in_batches = batches_initial_states
-                        .get(&record.account_id)
+                        .get(account_id)
                         .expect("we already verified that account id is contained in batches");
 
                     if hash_in_store == *hash_in_batches {
                         None
                     } else {
-                        Some(record.account_id)
+                        Some(*account_id)
                     }
                 })
                 .collect();
@@ -192,11 +182,8 @@ impl BlockWitness {
         block_inputs: &BlockInputs,
         batches: &[TransactionBatch],
     ) -> Result<(), BuildBlockError> {
-        let produced_nullifiers_from_store: BTreeSet<Nullifier> = block_inputs
-            .nullifiers
-            .iter()
-            .map(|nullifier_record| nullifier_record.nullifier)
-            .collect();
+        let produced_nullifiers_from_store: BTreeSet<Nullifier> =
+            block_inputs.nullifiers.iter().map(|(&nullifier, _)| nullifier).collect();
 
         let produced_nullifiers_from_batches: BTreeSet<Nullifier> =
             batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();

--- a/block-producer/src/block_builder/prover/block_witness.rs
+++ b/block-producer/src/block_builder/prover/block_witness.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use miden_node_proto::domain::blocks::BlockInputs;
 use miden_objects::{
     accounts::AccountId,
     crypto::merkle::{EmptySubtreeRoots, MerklePath, MerkleStore, MmrPeaks, SmtProof},
@@ -10,6 +9,7 @@ use miden_objects::{
 };
 
 use crate::{
+    block::BlockInputs,
     errors::{BlockProverError, BuildBlockError},
     TransactionBatch, CREATED_NOTES_SMT_DEPTH, CREATED_NOTES_TREE_INSERTION_DEPTH,
 };

--- a/block-producer/src/block_builder/prover/tests.rs
+++ b/block-producer/src/block_builder/prover/tests.rs
@@ -1,5 +1,5 @@
 use miden_mock::mock::block::mock_block_header;
-use miden_node_proto::{AccountInputRecord, BlockInputs, NullifierWitness};
+use miden_node_proto::{AccountInputRecord, NullifierWitness};
 use miden_objects::{
     accounts::AccountId,
     crypto::merkle::{
@@ -13,6 +13,7 @@ use miden_objects::{
 
 use super::*;
 use crate::{
+    block::BlockInputs,
     block_builder::prover::block_witness::CREATED_NOTES_TREE_DEPTH,
     store::Store,
     test_utils::{

--- a/block-producer/src/errors.rs
+++ b/block-producer/src/errors.rs
@@ -2,7 +2,7 @@ use miden_node_proto::errors::ParseError;
 use miden_node_utils::formatting::format_opt;
 use miden_objects::{
     accounts::AccountId,
-    crypto::merkle::MerkleError,
+    crypto::merkle::{MerkleError, MmrError},
     notes::Nullifier,
     transaction::{InputNotes, ProvenTransaction, TransactionId},
     Digest, TransactionInputError, BLOCK_OUTPUT_NOTES_BATCH_TREE_DEPTH, MAX_NOTES_PER_BATCH,
@@ -97,10 +97,13 @@ pub enum BlockProverError {
 // Block inputs errors
 // =================================================================================================
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Error)]
 pub enum BlockInputsError {
     #[error("failed to parse protobuf message: {0}")]
     ParseError(#[from] ParseError),
+    #[error("MmrPeaks error: {0}")]
+    MmrPeaksError(#[from] MmrError),
     #[error("gRPC client failed with error: {0}")]
     GrpcClientError(String),
 }

--- a/block-producer/src/store/mod.rs
+++ b/block-producer/src/store/mod.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use miden_node_proto::{
     convert,
-    domain::blocks::BlockInputs,
     generated::{
         account, digest,
         requests::{ApplyBlockRequest, GetBlockInputsRequest, GetTransactionInputsRequest},
@@ -14,7 +13,10 @@ use tonic::transport::Channel;
 use tracing::{debug, info, instrument};
 
 pub use crate::errors::{ApplyBlockError, BlockInputsError, TxInputsError};
-use crate::{block::Block, ProvenTransaction, COMPONENT};
+use crate::{
+    block::{Block, BlockInputs},
+    ProvenTransaction, COMPONENT,
+};
 
 // STORE TRAIT
 // ================================================================================================

--- a/block-producer/src/test_utils/block.rs
+++ b/block-producer/src/test_utils/block.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use miden_node_proto::domain::blocks::BlockInputs;
 use miden_objects::{
     accounts::AccountId,
     crypto::merkle::Mmr,
@@ -11,7 +10,7 @@ use miden_vm::crypto::SimpleSmt;
 
 use super::MockStoreSuccess;
 use crate::{
-    block::Block,
+    block::{Block, BlockInputs},
     block_builder::prover::{block_witness::BlockWitness, BlockProver},
     store::Store,
     TransactionBatch,

--- a/block-producer/src/test_utils/store.rs
+++ b/block-producer/src/test_utils/store.rs
@@ -1,9 +1,7 @@
 use std::collections::BTreeSet;
 
 use async_trait::async_trait;
-use miden_node_proto::{
-    AccountInputRecord, AccountState, BlockInputs, NullifierWitness, TransactionInputs,
-};
+use miden_node_proto::{AccountInputRecord, AccountState, NullifierWitness, TransactionInputs};
 use miden_objects::{
     crypto::merkle::{Mmr, SimpleSmt, Smt, ValuePath},
     notes::Nullifier,
@@ -12,7 +10,7 @@ use miden_objects::{
 
 use super::*;
 use crate::{
-    block::Block,
+    block::{Block, BlockInputs},
     store::{ApplyBlock, ApplyBlockError, BlockInputsError, Store, TxInputsError},
     ProvenTransaction,
 };

--- a/proto/src/domain/blocks.rs
+++ b/proto/src/domain/blocks.rs
@@ -1,10 +1,8 @@
-use miden_objects::{crypto::merkle::MmrPeaks, BlockHeader};
+use miden_objects::BlockHeader;
 
-use super::try_convert;
 use crate::{
     errors::{MissingFieldHelper, ParseError},
-    generated::{block_header, responses, responses::GetBlockInputsResponse},
-    AccountInputRecord, NullifierWitness,
+    generated::block_header,
 };
 
 // BLOCK HEADER
@@ -77,60 +75,5 @@ impl TryFrom<block_header::BlockHeader> for BlockHeader {
                 .try_into()
                 .expect("timestamp value is greater than or equal to the field modulus"),
         ))
-    }
-}
-
-// BLOCK INPUTS
-// ================================================================================================
-
-/// Information needed from the store to build a block
-#[derive(Clone, Debug)]
-pub struct BlockInputs {
-    /// Previous block header
-    pub block_header: BlockHeader,
-
-    /// MMR peaks for the current chain state
-    pub chain_peaks: MmrPeaks,
-
-    /// The hashes of the requested accounts and their authentication paths
-    pub account_states: Vec<AccountInputRecord>,
-
-    /// The requested nullifiers and their authentication paths
-    pub nullifiers: Vec<NullifierWitness>,
-}
-
-impl TryFrom<responses::GetBlockInputsResponse> for BlockInputs {
-    type Error = ParseError;
-
-    fn try_from(get_block_inputs: responses::GetBlockInputsResponse) -> Result<Self, Self::Error> {
-        let block_header: BlockHeader = get_block_inputs
-            .block_header
-            .ok_or(GetBlockInputsResponse::missing_field(stringify!(block_header)))?
-            .try_into()?;
-
-        let chain_peaks = {
-            // setting the number of leaves to the current block number gives us one leaf less than
-            // what is currently in the chain MMR (i.e., chain MMR with block_num = 1 has 2 leave);
-            // this is because GetBlockInputs returns the state of the chain MMR as of one block
-            // ago so that block_header.chain_root matches the hash of MMR peaks.
-            let num_leaves = block_header.block_num() as usize;
-
-            MmrPeaks::new(
-                num_leaves,
-                get_block_inputs
-                    .mmr_peaks
-                    .into_iter()
-                    .map(|peak| peak.try_into())
-                    .collect::<Result<_, Self::Error>>()?,
-            )
-            .map_err(Self::Error::MmrPeaksError)?
-        };
-
-        Ok(Self {
-            block_header,
-            chain_peaks,
-            account_states: try_convert(get_block_inputs.account_states)?,
-            nullifiers: try_convert(get_block_inputs.nullifiers)?,
-        })
     }
 }

--- a/proto/src/errors.rs
+++ b/proto/src/errors.rs
@@ -1,6 +1,6 @@
 use std::any::type_name;
 
-use miden_objects::crypto::merkle::{MmrError, SmtLeafError, SmtProofError};
+use miden_objects::crypto::merkle::{SmtLeafError, SmtProofError};
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone, PartialEq)]
@@ -15,8 +15,6 @@ pub enum ParseError {
     TooMuchData { expected: usize, got: usize },
     #[error("Not enough data, expected {expected}, got {got}")]
     InsufficientData { expected: usize, got: usize },
-    #[error("MmrPeaks error: {0}")]
-    MmrPeaksError(MmrError),
     #[error("Number of MmrPeaks doesn't fit into memory")]
     TooManyMmrPeaks,
     #[error("Value is not in the range 0..MODULUS")]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -9,7 +9,6 @@ pub mod generated;
 
 pub use domain::{
     accounts::{AccountInputRecord, AccountState},
-    blocks::BlockInputs,
     convert, nullifier_value_to_block_num,
     nullifiers::NullifierWitness,
     transactions::TransactionInputs,


### PR DESCRIPTION
This PR addresses comment: https://github.com/0xPolygonMiden/miden-node/pull/208#discussion_r1485563945
Moved `BlockInputs` to block-producer, converted accounts and nullifiers to binary-tree maps. 