### PR TITLE
tracing_forest: fixed issues to use logging with dev envs

### DIFF
--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/main.rs"
 bench = false
 doctest = false
 
+[features]
+tracing-forest = ["miden-node-utils/tracing-forest"]
+
 [dependencies]
 anyhow = { version = "1.0" }
 async-trait = { version = "0.1" }
@@ -22,23 +25,16 @@ clap = { version = "4.3", features = ["derive"] }
 figment = { version = "0.10", features = ["toml", "env"] }
 itertools = { version = "0.12" }
 miden-air = { package = "miden-air", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-
 miden-node-proto = { path = "../proto" }
 miden-node-store = { path = "../store" }
 miden-node-utils = { path = "../utils" }
 miden-objects = { workspace = true }
-miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-tx = { workspace = true }
+miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden_vm = { package = "miden-vm", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { version = "1.29", features = [
-    "rt-multi-thread",
-    "net",
-    "macros",
-    "sync",
-    "time",
-] }
+tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
 toml = { version = "0.8" }
 tonic = { version = "0.11" }
 tracing = { workspace = true }
@@ -47,7 +43,6 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
-miden-node-utils = { path = "../utils", features = ["tracing-forest"] }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }

--- a/block-producer/src/batch_builder/mod.rs
+++ b/block-producer/src/batch_builder/mod.rs
@@ -78,9 +78,6 @@ where
 
     // BATCH BUILDER STARTER
     // --------------------------------------------------------------------------------------------
-
-    /// TODO: add comments
-    #[instrument(target = "miden-block-producer", name = "block_producer" skip_all)]
     pub async fn run(self: Arc<Self>) {
         let mut interval = time::interval(self.options.block_frequency);
 

--- a/block-producer/src/server/mod.rs
+++ b/block-producer/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::{net::ToSocketAddrs, sync::Arc};
 use anyhow::{anyhow, Result};
 use miden_node_proto::generated::{block_producer::api_server, store::api_client as store_client};
 use tonic::transport::Server;
-use tracing::{info, instrument};
+use tracing::info;
 
 use crate::{
     batch_builder::{DefaultBatchBuilder, DefaultBatchBuilderOptions},
@@ -16,14 +16,11 @@ use crate::{
     SERVER_MAX_BATCHES_PER_BLOCK,
 };
 
-// TODO: does this need to be public?
 pub mod api;
 
 // BLOCK PRODUCER INITIALIZER
 // ================================================================================================
 
-/// TODO: add comments
-#[instrument(target = "miden-block-producer", name = "block_producer", skip_all)]
 pub async fn serve(config: BlockProducerConfig) -> Result<()> {
     info!(target: COMPONENT, %config, "Initializing server");
 

--- a/block-producer/src/txqueue/mod.rs
+++ b/block-producer/src/txqueue/mod.rs
@@ -73,7 +73,6 @@ where
         }
     }
 
-    #[instrument(target = "miden-block-producer", name = "block_producer" skip_all)]
     pub async fn run(self: Arc<Self>) {
         let mut interval = time::interval(self.options.build_batch_frequency);
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.73"
 [features]
 # Makes `make-genesis` subcommand run faster. Is only suitable for testing.
 testing = ["miden-lib/testing"]
+tracing-forest = ["miden-node-block-producer/tracing-forest"]
 
 [dependencies]
 anyhow = { version = "1.0" }

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::net::ToSocketAddrs;
 use anyhow::{anyhow, Result};
 use miden_node_proto::generated::rpc::api_server;
 use tonic::transport::Server;
-use tracing::{info, instrument};
+use tracing::info;
 
 use crate::{config::RpcConfig, COMPONENT};
 
@@ -11,7 +11,7 @@ mod api;
 
 // RPC INITIALIZER
 // ================================================================================================
-#[instrument(target = "miden-rpc", name = "rpc", skip_all)]
+
 pub async fn serve(config: RpcConfig) -> Result<()> {
     info!(target: COMPONENT, %config, "Initializing server");
 

--- a/store/src/server/mod.rs
+++ b/store/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::{net::ToSocketAddrs, sync::Arc};
 use anyhow::{anyhow, Result};
 use miden_node_proto::generated::store::api_server;
 use tonic::transport::Server;
-use tracing::{info, instrument};
+use tracing::info;
 
 use crate::{config::StoreConfig, db::Db, state::State, COMPONENT};
 
@@ -12,7 +12,6 @@ mod api;
 // STORE INITIALIZER
 // ================================================================================================
 
-#[instrument(target = "miden-store", name = "store", skip_all)]
 pub async fn serve(
     config: StoreConfig,
     db: Db,

--- a/utils/src/logging.rs
+++ b/utils/src/logging.rs
@@ -1,5 +1,9 @@
 use anyhow::Result;
-use tracing::subscriber::{self, Subscriber};
+use tracing::{
+    level_filters::LevelFilter,
+    subscriber::{self, Subscriber},
+};
+use tracing_subscriber::EnvFilter;
 
 pub fn setup_logging() -> Result<()> {
     subscriber::set_global_default(subscriber())?;
@@ -9,8 +13,7 @@ pub fn setup_logging() -> Result<()> {
 
 #[cfg(not(feature = "tracing-forest"))]
 pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
-    use tracing::level_filters::LevelFilter;
-    use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+    use tracing_subscriber::fmt::format::FmtSpan;
 
     tracing_subscriber::fmt()
         .pretty()
@@ -33,5 +36,9 @@ pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
     pub use tracing_forest::ForestLayer;
     pub use tracing_subscriber::{layer::SubscriberExt, Registry};
 
-    Registry::default().with(ForestLayer::default())
+    Registry::default().with(ForestLayer::default()).with(
+        EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .from_env_lossy(),
+    )
 }


### PR DESCRIPTION
Fixed a few issues I found with the logging and also fixes #231 while I was at it.

- Remove the spans that would swallow all the logs when using tracing forest. These were the spans around main and tasks' entry points.
- Added feature flags to enable tracing_forest. The previous approach did not work, since the compilation profile doesn't change the dependencies.
- Added support for `RUST_LOG` and changed the default from `TRACE` to `INFO`.