### PR TITLE
Mock proven TX improvements

### DIFF
--- a/block-producer/src/batch_builder/tests/mod.rs
+++ b/block-producer/src/batch_builder/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{errors::BuildBlockError, test_utils::DummyProvenTxGenerator};
+use crate::{errors::BuildBlockError, test_utils::MockProvenTxBuilder};
 
 // STRUCTS
 // ================================================================================================
@@ -61,13 +61,7 @@ async fn test_block_size_doesnt_exceed_limit() {
 
     // Add 3 batches in internal queue (remember: 2 batches/block)
     {
-        let tx_gen = DummyProvenTxGenerator::new();
-
-        let mut batch_group = vec![
-            dummy_tx_batch(&tx_gen, 2),
-            dummy_tx_batch(&tx_gen, 2),
-            dummy_tx_batch(&tx_gen, 2),
-        ];
+        let mut batch_group = vec![dummy_tx_batch(2), dummy_tx_batch(2), dummy_tx_batch(2)];
 
         batch_builder.ready_batches.write().await.append(&mut batch_group);
     }
@@ -137,13 +131,7 @@ async fn test_batches_added_back_to_queue_on_block_build_failure() {
 
     // Add 3 batches in internal queue
     {
-        let tx_gen = DummyProvenTxGenerator::new();
-
-        let mut batch_group = vec![
-            dummy_tx_batch(&tx_gen, 2),
-            dummy_tx_batch(&tx_gen, 2),
-            dummy_tx_batch(&tx_gen, 2),
-        ];
+        let mut batch_group = vec![dummy_tx_batch(2), dummy_tx_batch(2), dummy_tx_batch(2)];
 
         batch_builder.ready_batches.write().await.append(&mut batch_group);
     }
@@ -161,10 +149,7 @@ async fn test_batches_added_back_to_queue_on_block_build_failure() {
 // HELPERS
 // ================================================================================================
 
-fn dummy_tx_batch(
-    tx_gen: &DummyProvenTxGenerator,
-    num_txs_in_batch: usize,
-) -> TransactionBatch {
-    let txs: Vec<_> = (0..num_txs_in_batch).map(|_| tx_gen.dummy_proven_tx()).collect();
+fn dummy_tx_batch(num_txs_in_batch: usize) -> TransactionBatch {
+    let txs: Vec<_> = (0..num_txs_in_batch).map(|_| MockProvenTxBuilder::new().build()).collect();
     TransactionBatch::new(txs).unwrap()
 }

--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -27,7 +27,7 @@ async fn test_apply_block_called_nonempty_batches() {
                 account_initial_hash,
                 [Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)].into(),
             )
-                .build();
+            .build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };

--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -1,16 +1,14 @@
 use miden_air::Felt;
-use miden_objects::transaction::{InputNotes, OutputNotes};
 
 // block builder tests (higher level)
 // `apply_block()` is called
 use super::*;
-use crate::test_utils::{DummyProvenTxGenerator, MockStoreFailure, MockStoreSuccessBuilder};
+use crate::test_utils::{MockProvenTxBuilder, MockStoreFailure, MockStoreSuccessBuilder};
 
 /// Tests that `build_block()` succeeds when the transaction batches are not empty
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn test_apply_block_called_nonempty_batches() {
-    let tx_gen = DummyProvenTxGenerator::new();
     let account_id = AccountId::new_unchecked(42u32.into());
     let account_initial_hash: Digest =
         [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)].into();
@@ -24,13 +22,12 @@ async fn test_apply_block_called_nonempty_batches() {
 
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
-            let tx = tx_gen.dummy_proven_tx_with_params(
+            let tx = MockProvenTxBuilder::with_account(
                 account_id,
                 account_initial_hash,
                 [Felt::new(2u64), Felt::new(2u64), Felt::new(2u64), Felt::new(2u64)].into(),
-                InputNotes::new(Vec::new()).unwrap(),
-                OutputNotes::new(Vec::new()).unwrap(),
-            );
+            )
+                .build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };

--- a/block-producer/src/state_view/tests/mod.rs
+++ b/block-producer/src/state_view/tests/mod.rs
@@ -27,7 +27,7 @@ pub fn nullifier_by_index(index: u32) -> Nullifier {
 /// The transactions each consume a single different note
 pub fn get_txs_and_accounts(
     num: u32
-) -> impl Iterator<Item=(ProvenTransaction, MockPrivateAccount)> {
+) -> impl Iterator<Item = (ProvenTransaction, MockPrivateAccount)> {
     (0..num).map(|index| {
         let account = MockPrivateAccount::from(index);
         let tx =

--- a/block-producer/src/state_view/tests/mod.rs
+++ b/block-producer/src/state_view/tests/mod.rs
@@ -1,7 +1,7 @@
-use miden_objects::{transaction::OutputNotes, Hasher, EMPTY_WORD, ZERO};
+use miden_objects::{Hasher, EMPTY_WORD, ZERO};
 
 use super::*;
-use crate::test_utils::{DummyProvenTxGenerator, MockPrivateAccount};
+use crate::test_utils::{MockPrivateAccount, MockProvenTxBuilder};
 
 mod apply_block;
 mod verify_tx;
@@ -26,18 +26,14 @@ pub fn nullifier_by_index(index: u32) -> Nullifier {
 /// Returns `num` transactions, and the corresponding account they modify.
 /// The transactions each consume a single different note
 pub fn get_txs_and_accounts(
-    tx_gen: &DummyProvenTxGenerator,
-    num: u32,
-) -> impl Iterator<Item = (ProvenTransaction, MockPrivateAccount)> + '_ {
+    num: u32
+) -> impl Iterator<Item=(ProvenTransaction, MockPrivateAccount)> {
     (0..num).map(|index| {
         let account = MockPrivateAccount::from(index);
-        let tx = tx_gen.dummy_proven_tx_with_params(
-            account.id,
-            account.states[0],
-            account.states[1],
-            InputNotes::new(vec![nullifier_by_index(index)]).unwrap(),
-            OutputNotes::new(Vec::new()).unwrap(),
-        );
+        let tx =
+            MockProvenTxBuilder::with_account(account.id, account.states[0], account.states[1])
+                .num_nullifiers(1)
+                .build();
 
         (tx, account)
     })

--- a/block-producer/src/test_utils/mod.rs
+++ b/block-producer/src/test_utils/mod.rs
@@ -4,12 +4,15 @@ use miden_objects::{accounts::AccountId, Digest};
 use tokio::sync::RwLock;
 
 mod proven_tx;
-pub use proven_tx::{DummyProvenTxGenerator, MockProvenTxBuilder};
+
+pub use proven_tx::MockProvenTxBuilder;
 
 mod store;
+
 pub use store::{MockStoreFailure, MockStoreSuccess, MockStoreSuccessBuilder};
 
 mod account;
+
 pub use account::MockPrivateAccount;
 
 pub mod block;

--- a/block-producer/src/test_utils/proven_tx.rs
+++ b/block-producer/src/test_utils/proven_tx.rs
@@ -3,7 +3,6 @@
 use std::sync::{Arc, Mutex};
 
 use miden_air::{ExecutionProof, HashFunction};
-use miden_mock::constants::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN;
 use miden_objects::{
     accounts::AccountId,
     notes::{NoteEnvelope, NoteMetadata, Nullifier},
@@ -11,15 +10,7 @@ use miden_objects::{
     Digest, Felt, Hasher, ONE,
 };
 use once_cell::sync::Lazy;
-use winterfell::{
-    crypto::{hashers::Blake3_192, DefaultRandomCoin},
-    math::{fields::f64::BaseElement, FieldElement},
-    matrix::ColMatrix,
-    Air, AirContext, Assertion, AuxTraceRandElements, ConstraintCompositionCoefficients,
-    DefaultConstraintEvaluator, DefaultTraceLde, EvaluationFrame, FieldExtension, ProofOptions,
-    Prover, StarkDomain, StarkProof, Trace, TraceInfo, TracePolyTable, TraceTable,
-    TransitionConstraintDegree,
-};
+use winterfell::StarkProof;
 
 use super::MockPrivateAccount;
 
@@ -33,27 +24,56 @@ static NUM_NOTES_CREATED: Lazy<Arc<Mutex<u64>>> = Lazy::new(|| Arc::new(Mutex::n
 static NUM_INPUT_NOTES: Lazy<Arc<Mutex<u64>>> = Lazy::new(|| Arc::new(Mutex::new(0)));
 
 pub struct MockProvenTxBuilder {
-    mock_account: MockPrivateAccount,
+    account_id: AccountId,
+    initial_account_hash: Digest,
+    final_account_hash: Digest,
     notes_created: Option<Vec<NoteEnvelope>>,
     nullifiers: Option<Vec<Nullifier>>,
 }
 
 impl MockProvenTxBuilder {
     pub fn new() -> Self {
-        let account_index: u32 = {
+        let mock_account: MockPrivateAccount = {
             let mut locked_num_accounts_created = NUM_ACCOUNTS_CREATED.lock().unwrap();
 
             let account_index = *locked_num_accounts_created;
 
             *locked_num_accounts_created += 1;
 
-            account_index
+            account_index.into()
         };
+
+        Self::with_account(mock_account.id, mock_account.states[0], mock_account.states[1])
+    }
+
+    pub fn with_account(
+        account_id: AccountId,
+        initial_account_hash: Digest,
+        final_account_hash: Digest,
+    ) -> Self {
         Self {
-            mock_account: account_index.into(),
+            account_id,
+            initial_account_hash,
+            final_account_hash,
             notes_created: None,
             nullifiers: None,
         }
+    }
+
+    pub fn nullifiers(
+        mut self,
+        nullifiers: Vec<Nullifier>,
+    ) -> Self {
+        self.nullifiers = Some(nullifiers);
+        self
+    }
+
+    pub fn notes_created(
+        mut self,
+        notes: Vec<NoteEnvelope>,
+    ) -> Self {
+        self.notes_created = Some(notes);
+        self
     }
 
     pub fn num_notes_created(
@@ -67,7 +87,7 @@ impl MockProvenTxBuilder {
             .map(|note_index| {
                 let note_hash = Hasher::hash(&note_index.to_be_bytes());
 
-                NoteEnvelope::new(note_hash.into(), NoteMetadata::new(self.mock_account.id, ONE))
+                NoteEnvelope::new(note_hash.into(), NoteMetadata::new(self.account_id, ONE))
             })
             .collect();
 
@@ -106,9 +126,9 @@ impl MockProvenTxBuilder {
 
     pub fn build(self) -> ProvenTransaction {
         ProvenTransaction::new(
-            self.mock_account.id,
-            self.mock_account.states[0],
-            self.mock_account.states[1],
+            self.account_id,
+            self.initial_account_hash,
+            self.final_account_hash,
             InputNotes::new(self.nullifiers.unwrap_or_default()).unwrap(),
             OutputNotes::new(self.notes_created.unwrap_or_default()).unwrap(),
             None,
@@ -121,205 +141,5 @@ impl MockProvenTxBuilder {
 impl Default for MockProvenTxBuilder {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// We need to generate a new `ProvenTransaction` every time because it doesn't
-/// derive `Clone`. Doing it this way allows us to compute the `StarkProof`
-/// once, and clone it for each new `ProvenTransaction`.
-#[derive(Clone)]
-pub struct DummyProvenTxGenerator {
-    stark_proof: StarkProof,
-}
-
-impl DummyProvenTxGenerator {
-    pub fn new() -> Self {
-        let prover = DummyProver::new();
-        let stark_proof = prover.prove(prover.build_trace(16)).unwrap();
-        Self { stark_proof }
-    }
-
-    pub fn dummy_proven_tx(&self) -> ProvenTransaction {
-        ProvenTransaction::new(
-            AccountId::try_from(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN).unwrap(),
-            Digest::default(),
-            Digest::default(),
-            InputNotes::new(Vec::new()).unwrap(),
-            OutputNotes::new(Vec::new()).unwrap(),
-            None,
-            Digest::default(),
-            ExecutionProof::new(self.stark_proof.clone(), HashFunction::Blake3_192),
-        )
-    }
-
-    pub fn dummy_proven_tx_with_params(
-        &self,
-        account_id: AccountId,
-        initial_account_hash: Digest,
-        final_account_hash: Digest,
-        input_notes: InputNotes<Nullifier>,
-        output_notes: OutputNotes<NoteEnvelope>,
-    ) -> ProvenTransaction {
-        ProvenTransaction::new(
-            account_id,
-            initial_account_hash,
-            final_account_hash,
-            input_notes,
-            output_notes,
-            None,
-            Digest::default(),
-            ExecutionProof::new(self.stark_proof.clone(), HashFunction::Blake3_192),
-        )
-    }
-}
-
-impl Default for DummyProvenTxGenerator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-const TRACE_WIDTH: usize = 2;
-
-pub fn are_equal<E: FieldElement>(
-    a: E,
-    b: E,
-) -> E {
-    a - b
-}
-
-pub struct FibSmall {
-    context: AirContext<BaseElement>,
-    result: BaseElement,
-}
-
-impl Air for FibSmall {
-    type BaseField = BaseElement;
-    type PublicInputs = BaseElement;
-
-    // CONSTRUCTOR
-    // --------------------------------------------------------------------------------------------
-    fn new(
-        trace_info: TraceInfo,
-        pub_inputs: Self::BaseField,
-        options: ProofOptions,
-    ) -> Self {
-        let degrees = vec![TransitionConstraintDegree::new(1), TransitionConstraintDegree::new(1)];
-        assert_eq!(TRACE_WIDTH, trace_info.width());
-        FibSmall {
-            context: AirContext::new(trace_info, degrees, 3, options),
-            result: pub_inputs,
-        }
-    }
-
-    fn context(&self) -> &AirContext<Self::BaseField> {
-        &self.context
-    }
-
-    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
-        &self,
-        frame: &EvaluationFrame<E>,
-        _periodic_values: &[E],
-        result: &mut [E],
-    ) {
-        let current = frame.current();
-        let next = frame.next();
-        // expected state width is 2 field elements
-        debug_assert_eq!(TRACE_WIDTH, current.len());
-        debug_assert_eq!(TRACE_WIDTH, next.len());
-
-        // constraints of Fibonacci sequence (2 terms per step):
-        // s_{0, i+1} = s_{0, i} + s_{1, i}
-        // s_{1, i+1} = s_{1, i} + s_{0, i+1}
-        result[0] = are_equal(next[0], current[0] + current[1]);
-        result[1] = are_equal(next[1], current[1] + next[0]);
-    }
-
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
-        // a valid Fibonacci sequence should start with two ones and terminate with
-        // the expected result
-        let last_step = self.trace_length() - 1;
-        vec![
-            Assertion::single(0, 0, Self::BaseField::ONE),
-            Assertion::single(1, 0, Self::BaseField::ONE),
-            Assertion::single(1, last_step, self.result),
-        ]
-    }
-}
-
-pub struct DummyProver {
-    options: ProofOptions,
-}
-
-impl DummyProver {
-    pub fn new() -> Self {
-        Self {
-            options: ProofOptions::new(1, 2, 1, FieldExtension::None, 2, 127),
-        }
-    }
-
-    /// Builds an execution trace for computing a Fibonacci sequence of the specified length such
-    /// that each row advances the sequence by 2 terms.
-    pub fn build_trace(
-        &self,
-        sequence_length: usize,
-    ) -> TraceTable<BaseElement> {
-        assert!(sequence_length.is_power_of_two(), "sequence length must be a power of 2");
-
-        let mut trace = TraceTable::new(TRACE_WIDTH, sequence_length / 2);
-        trace.fill(
-            |state| {
-                state[0] = BaseElement::ONE;
-                state[1] = BaseElement::ONE;
-            },
-            |_, state| {
-                state[0] += state[1];
-                state[1] += state[0];
-            },
-        );
-
-        trace
-    }
-}
-
-impl Prover for DummyProver {
-    type BaseField = BaseElement;
-    type Air = FibSmall;
-    type Trace = TraceTable<BaseElement>;
-    type HashFn = Blake3_192<BaseElement>;
-    type RandomCoin = DefaultRandomCoin<Self::HashFn>;
-    type TraceLde<E: FieldElement<BaseField = BaseElement>> =
-        DefaultTraceLde<E, Blake3_192<BaseElement>>;
-    type ConstraintEvaluator<'a, E: FieldElement<BaseField = BaseElement>> =
-        DefaultConstraintEvaluator<'a, FibSmall, E>;
-
-    fn get_pub_inputs(
-        &self,
-        trace: &Self::Trace,
-    ) -> BaseElement {
-        let last_step = trace.length() - 1;
-        trace.get(1, last_step)
-    }
-
-    fn options(&self) -> &ProofOptions {
-        &self.options
-    }
-
-    fn new_trace_lde<E: FieldElement<BaseField = BaseElement>>(
-        &self,
-        trace_info: &TraceInfo,
-        main_trace: &ColMatrix<BaseElement>,
-        domain: &StarkDomain<BaseElement>,
-    ) -> (Self::TraceLde<E>, TracePolyTable<E>) {
-        DefaultTraceLde::new(trace_info, main_trace, domain)
-    }
-
-    fn new_evaluator<'a, E: FieldElement<BaseField = BaseElement>>(
-        &self,
-        air: &'a FibSmall,
-        aux_rand_elements: AuxTraceRandElements<E>,
-        composition_coefficients: ConstraintCompositionCoefficients<E>,
-    ) -> Self::ConstraintEvaluator<'a, E> {
-        DefaultConstraintEvaluator::new(air, aux_rand_elements, composition_coefficients)
     }
 }

--- a/block-producer/src/txqueue/tests/mod.rs
+++ b/block-producer/src/txqueue/tests/mod.rs
@@ -1,7 +1,7 @@
 use tokio::sync::mpsc::{self, error::TryRecvError};
 
 use super::*;
-use crate::{errors::BuildBatchError, test_utils::DummyProvenTxGenerator, TransactionBatch};
+use crate::{errors::BuildBatchError, test_utils::MockProvenTxBuilder, TransactionBatch};
 
 // STRUCTS
 // ================================================================================================
@@ -104,11 +104,9 @@ async fn test_build_batch_success() {
     tokio::time::advance(build_batch_frequency).await;
     assert_eq!(Err(TryRecvError::Empty), receiver.try_recv(), "queue starts empty");
 
-    let tx_generator = DummyProvenTxGenerator::new();
-
     // if there is a single transaction in the queue when it is time to build a batch, the batch is
     // created with that single transaction
-    let tx = tx_generator.dummy_proven_tx();
+    let tx = MockProvenTxBuilder::new().build();
     tx_queue
         .add_transaction(tx.clone())
         .await
@@ -121,18 +119,17 @@ async fn test_build_batch_success() {
         receiver.try_recv(),
         "A single transaction produces a single batch"
     );
-    let expected = TransactionBatch::new(vec![tx]).expect("Valid transactions");
+    let expected = TransactionBatch::new(vec![tx.clone()]).expect("Valid transactions");
     assert_eq!(expected, batch, "The batch should have the one transaction added to the queue");
 
     // a batch will include up to `batch_size` transactions
     let mut txs = Vec::new();
     for _ in 0..batch_size {
-        let tx = tx_generator.dummy_proven_tx();
         tx_queue
             .add_transaction(tx.clone())
             .await
             .expect("Transaciton queue is running");
-        txs.push(tx)
+        txs.push(tx.clone())
     }
     tokio::time::advance(build_batch_frequency).await;
     let batch = receiver.try_recv().expect("Queue not empty");
@@ -147,12 +144,11 @@ async fn test_build_batch_success() {
     // the transaction queue eagerly produces batches
     let mut txs = Vec::new();
     for _ in 0..(2 * batch_size + 1) {
-        let tx = tx_generator.dummy_proven_tx();
         tx_queue
             .add_transaction(tx.clone())
             .await
             .expect("Transaciton queue is running");
-        txs.push(tx)
+        txs.push(tx.clone())
     }
     for expected_batch in txs.chunks(batch_size).map(|txs| txs.to_vec()) {
         tokio::time::advance(build_batch_frequency).await;
@@ -193,9 +189,8 @@ async fn test_tx_verify_failure() {
     tokio::spawn(tx_queue.clone().run());
 
     // Add a bunch of transactions that will all fail tx verification
-    let proven_tx_generator = DummyProvenTxGenerator::new();
     for _ in 0..(3 * batch_size) {
-        let r = tx_queue.add_transaction(proven_tx_generator.dummy_proven_tx()).await;
+        let r = tx_queue.add_transaction(MockProvenTxBuilder::new().build()).await;
 
         assert!(matches!(r, Err(AddTransactionError::VerificationFailed(_))));
         assert_eq!(
@@ -226,11 +221,9 @@ async fn test_build_batch_failure() {
 
     let internal_ready_queue = tx_queue.ready_queue.clone();
 
-    let proven_tx_generator = DummyProvenTxGenerator::new();
-
     // Add enough transactions so that we have 1 batch
     for _i in 0..batch_size {
-        tx_queue.add_transaction(proven_tx_generator.dummy_proven_tx()).await.unwrap();
+        tx_queue.add_transaction(MockProvenTxBuilder::new().build()).await.unwrap();
     }
 
     // Start the queue


### PR DESCRIPTION
In this PR we got rid of `DummyProvenTxGenerator` in favour of `MockProvenTxBuilder`. The latter was also improved in order to provide all needed features.

Look into https://github.com/0xPolygonMiden/miden-node/issues/79 for context.