### PR TITLE
Got rid of shared state in `MockProvenTxBuilder`

### DIFF
--- a/block-producer/src/batch_builder/tests/mod.rs
+++ b/block-producer/src/batch_builder/tests/mod.rs
@@ -61,7 +61,8 @@ async fn test_block_size_doesnt_exceed_limit() {
 
     // Add 3 batches in internal queue (remember: 2 batches/block)
     {
-        let mut batch_group = vec![dummy_tx_batch(2), dummy_tx_batch(2), dummy_tx_batch(2)];
+        let mut batch_group =
+            vec![dummy_tx_batch(0, 2), dummy_tx_batch(10, 2), dummy_tx_batch(20, 2)];
 
         batch_builder.ready_batches.write().await.append(&mut batch_group);
     }
@@ -131,7 +132,8 @@ async fn test_batches_added_back_to_queue_on_block_build_failure() {
 
     // Add 3 batches in internal queue
     {
-        let mut batch_group = vec![dummy_tx_batch(2), dummy_tx_batch(2), dummy_tx_batch(2)];
+        let mut batch_group =
+            vec![dummy_tx_batch(0, 2), dummy_tx_batch(10, 2), dummy_tx_batch(20, 2)];
 
         batch_builder.ready_batches.write().await.append(&mut batch_group);
     }
@@ -149,7 +151,14 @@ async fn test_batches_added_back_to_queue_on_block_build_failure() {
 // HELPERS
 // ================================================================================================
 
-fn dummy_tx_batch(num_txs_in_batch: usize) -> TransactionBatch {
-    let txs: Vec<_> = (0..num_txs_in_batch).map(|_| MockProvenTxBuilder::new().build()).collect();
+fn dummy_tx_batch(
+    starting_acccount_index: u32,
+    num_txs_in_batch: usize,
+) -> TransactionBatch {
+    let txs = (0..num_txs_in_batch)
+        .map(|index| {
+            MockProvenTxBuilder::with_account_index(starting_acccount_index + index as u32).build()
+        })
+        .collect();
     TransactionBatch::new(txs).unwrap()
 }

--- a/block-producer/src/block_builder/prover/tests.rs
+++ b/block-producer/src/block_builder/prover/tests.rs
@@ -458,13 +458,13 @@ async fn test_compute_note_root_success() {
 fn test_block_witness_validation_inconsistent_nullifiers() {
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
-            let tx = MockProvenTxBuilder::new().num_nullifiers(1).build();
+            let tx = MockProvenTxBuilder::with_account_index(0).nullifiers_range(0..1).build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };
 
         let batch_2 = {
-            let tx = MockProvenTxBuilder::new().num_nullifiers(1).build();
+            let tx = MockProvenTxBuilder::with_account_index(1).nullifiers_range(1..2).build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };
@@ -539,13 +539,13 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
 async fn test_compute_nullifier_root_empty_success() {
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
-            let tx = MockProvenTxBuilder::new().build();
+            let tx = MockProvenTxBuilder::with_account_index(0).build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };
 
         let batch_2 = {
-            let tx = MockProvenTxBuilder::new().build();
+            let tx = MockProvenTxBuilder::with_account_index(1).build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };
@@ -592,13 +592,13 @@ async fn test_compute_nullifier_root_empty_success() {
 async fn test_compute_nullifier_root_success() {
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
-            let tx = MockProvenTxBuilder::new().num_nullifiers(1).build();
+            let tx = MockProvenTxBuilder::with_account_index(0).nullifiers_range(0..1).build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };
 
         let batch_2 = {
-            let tx = MockProvenTxBuilder::new().num_nullifiers(1).build();
+            let tx = MockProvenTxBuilder::with_account_index(1).nullifiers_range(1..2).build();
 
             TransactionBatch::new(vec![tx]).unwrap()
         };

--- a/block-producer/src/state_view/tests/apply_block.rs
+++ b/block-producer/src/state_view/tests/apply_block.rs
@@ -49,7 +49,7 @@ async fn test_apply_block_ab1() {
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn test_apply_block_ab2() {
-    let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(3).unzip();
+    let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
@@ -67,7 +67,7 @@ async fn test_apply_block_ab2() {
     // Verify transactions so it can be tracked in state view
     for tx in txs {
         let verify_tx_res = state_view.verify_tx(&tx).await;
-        assert!(verify_tx_res.is_ok());
+        assert_eq!(verify_tx_res, Ok(()));
     }
 
     // All except the first account will go into the block.
@@ -97,7 +97,7 @@ async fn test_apply_block_ab2() {
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn test_apply_block_ab3() {
-    let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(3).unzip();
+    let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
@@ -115,7 +115,7 @@ async fn test_apply_block_ab3() {
     // Verify transactions so it can be tracked in state view
     for tx in txs.clone() {
         let verify_tx_res = state_view.verify_tx(&tx).await;
-        assert!(verify_tx_res.is_ok());
+        assert_eq!(verify_tx_res, Ok(()));
     }
 
     let block = MockBlockBuilder::new(&store)

--- a/block-producer/src/state_view/tests/mod.rs
+++ b/block-producer/src/state_view/tests/mod.rs
@@ -28,7 +28,7 @@ pub fn nullifier_by_index(index: u32) -> Nullifier {
 pub fn get_txs_and_accounts(
     starting_account_index: u32,
     num: u32,
-) -> impl Iterator<Item=(ProvenTransaction, MockPrivateAccount)> {
+) -> impl Iterator<Item = (ProvenTransaction, MockPrivateAccount)> {
     (0..num).map(move |index| {
         let account = MockPrivateAccount::from(starting_account_index + index);
         let nullifier_starting_index = (starting_account_index + index) as u64;

--- a/block-producer/src/state_view/tests/mod.rs
+++ b/block-producer/src/state_view/tests/mod.rs
@@ -26,13 +26,15 @@ pub fn nullifier_by_index(index: u32) -> Nullifier {
 /// Returns `num` transactions, and the corresponding account they modify.
 /// The transactions each consume a single different note
 pub fn get_txs_and_accounts(
-    num: u32
-) -> impl Iterator<Item = (ProvenTransaction, MockPrivateAccount)> {
-    (0..num).map(|index| {
-        let account = MockPrivateAccount::from(index);
+    starting_account_index: u32,
+    num: u32,
+) -> impl Iterator<Item=(ProvenTransaction, MockPrivateAccount)> {
+    (0..num).map(move |index| {
+        let account = MockPrivateAccount::from(starting_account_index + index);
+        let nullifier_starting_index = (starting_account_index + index) as u64;
         let tx =
             MockProvenTxBuilder::with_account(account.id, account.states[0], account.states[1])
-                .num_nullifiers(1)
+                .nullifiers_range(nullifier_starting_index..(nullifier_starting_index + 1))
                 .build();
 
         (tx, account)

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -121,8 +121,8 @@ async fn test_verify_tx_vt2() {
         account_not_in_store.states[0],
         account_not_in_store.states[1],
     )
-        .nullifiers_range(0..1)
-        .build();
+    .nullifiers_range(0..1)
+    .build();
 
     let state_view = DefaultStateView::new(store, false);
 

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -23,7 +23,7 @@ use crate::test_utils::MockStoreSuccessBuilder;
 #[miden_node_test_macro::enable_logging]
 async fn test_verify_tx_happy_path() {
     let (txs, accounts): (Vec<ProvenTransaction>, Vec<MockPrivateAccount>) =
-        get_txs_and_accounts(3).unzip();
+        get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
@@ -50,7 +50,7 @@ async fn test_verify_tx_happy_path() {
 #[miden_node_test_macro::enable_logging]
 async fn test_verify_tx_happy_path_concurrent() {
     let (txs, accounts): (Vec<ProvenTransaction>, Vec<MockPrivateAccount>) =
-        get_txs_and_accounts(3).unzip();
+        get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
         MockStoreSuccessBuilder::new()
@@ -91,7 +91,7 @@ async fn test_verify_tx_vt1() {
     // The transaction's initial account hash uses `account.states[1]`, where the store expects
     // `account.states[0]`
     let tx = MockProvenTxBuilder::with_account(account.id, account.states[1], account.states[2])
-        .num_nullifiers(1)
+        .nullifiers_range(0..1)
         .build();
 
     let state_view = DefaultStateView::new(store, false);
@@ -121,8 +121,8 @@ async fn test_verify_tx_vt2() {
         account_not_in_store.states[0],
         account_not_in_store.states[1],
     )
-    .num_nullifiers(1)
-    .build();
+        .nullifiers_range(0..1)
+        .build();
 
     let state_view = DefaultStateView::new(store, false);
 

--- a/block-producer/src/test_utils/batch.rs
+++ b/block-producer/src/test_utils/batch.rs
@@ -3,25 +3,48 @@ use crate::{test_utils::MockProvenTxBuilder, TransactionBatch};
 pub trait TransactionBatchConstructor {
     /// Returns a `TransactionBatch` with `notes_per_tx.len()` transactions, where the i'th
     /// transaction has `notes_per_tx[i]` notes created
-    fn from_notes_created(notes_per_tx: &[u64]) -> Self;
+    fn from_notes_created(
+        starting_account_index: u32,
+        notes_per_tx: &[u64],
+    ) -> Self;
 
     /// Returns a `TransactionBatch` which contains `num_txs_in_batch` transactions
-    fn from_txs(num_txs_in_batch: u64) -> Self;
+    fn from_txs(
+        starting_account_index: u32,
+        num_txs_in_batch: u64,
+    ) -> Self;
 }
 
 impl TransactionBatchConstructor for TransactionBatch {
-    fn from_notes_created(notes_per_tx: &[u64]) -> Self {
+    fn from_notes_created(
+        starting_account_index: u32,
+        notes_per_tx: &[u64],
+    ) -> Self {
         let txs: Vec<_> = notes_per_tx
             .iter()
-            .map(|&num_notes| MockProvenTxBuilder::new().num_notes_created(num_notes).build())
+            .enumerate()
+            .map(|(index, &num_notes)| {
+                let starting_note_index = starting_account_index as u64 + index as u64;
+                MockProvenTxBuilder::with_account_index(starting_account_index + index as u32)
+                    .notes_created_range(starting_note_index..(starting_note_index + num_notes))
+                    .build()
+            })
             .collect();
 
         Self::new(txs).unwrap()
     }
 
-    fn from_txs(num_txs_in_batch: u64) -> Self {
-        let txs: Vec<_> =
-            (0..num_txs_in_batch).map(|_| MockProvenTxBuilder::new().build()).collect();
+    fn from_txs(
+        starting_account_index: u32,
+        num_txs_in_batch: u64,
+    ) -> Self {
+        let txs: Vec<_> = (0..num_txs_in_batch)
+            .enumerate()
+            .map(|(index, _)| {
+                MockProvenTxBuilder::with_account_index(starting_account_index + index as u32)
+                    .build()
+            })
+            .collect();
 
         Self::new(txs).unwrap()
     }

--- a/block-producer/src/txqueue/tests/mod.rs
+++ b/block-producer/src/txqueue/tests/mod.rs
@@ -106,7 +106,7 @@ async fn test_build_batch_success() {
 
     // if there is a single transaction in the queue when it is time to build a batch, the batch is
     // created with that single transaction
-    let tx = MockProvenTxBuilder::new().build();
+    let tx = MockProvenTxBuilder::with_account_index(0).build();
     tx_queue
         .add_transaction(tx.clone())
         .await
@@ -189,8 +189,10 @@ async fn test_tx_verify_failure() {
     tokio::spawn(tx_queue.clone().run());
 
     // Add a bunch of transactions that will all fail tx verification
-    for _ in 0..(3 * batch_size) {
-        let r = tx_queue.add_transaction(MockProvenTxBuilder::new().build()).await;
+    for i in 0..(3 * batch_size as u32) {
+        let r = tx_queue
+            .add_transaction(MockProvenTxBuilder::with_account_index(i).build())
+            .await;
 
         assert!(matches!(r, Err(AddTransactionError::VerificationFailed(_))));
         assert_eq!(
@@ -222,8 +224,11 @@ async fn test_build_batch_failure() {
     let internal_ready_queue = tx_queue.ready_queue.clone();
 
     // Add enough transactions so that we have 1 batch
-    for _i in 0..batch_size {
-        tx_queue.add_transaction(MockProvenTxBuilder::new().build()).await.unwrap();
+    for i in 0..batch_size {
+        tx_queue
+            .add_transaction(MockProvenTxBuilder::with_account_index(i as u32).build())
+            .await
+            .unwrap();
     }
 
     // Start the queue


### PR DESCRIPTION
This addresses comment from here: https://github.com/0xPolygonMiden/miden-node/pull/248#discussion_r1502794786