### PR TITLE
Change git VM dependency to crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { version = "0.8" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
-miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
-miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies" }
+miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ resolver = "2"
 
 [workspace.dependencies]
 miden-crypto = { version = "0.8" }
-miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies" }
-miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies" }
-miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies" }
+miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
+miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
 thiserror = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -42,7 +42,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main" }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -24,14 +24,14 @@ async-trait = { version = "0.1" }
 clap = { version = "4.3", features = ["derive"] }
 figment = { version = "0.10", features = ["toml", "env"] }
 itertools = { version = "0.12" }
-miden-air = { package = "miden-air", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden-air = { package = "miden-air", version = "0.8", default-features = false }
 miden-node-proto = { path = "../proto" }
 miden-node-store = { path = "../store" }
 miden-node-utils = { path = "../utils" }
 miden-objects = { workspace = true }
 miden-tx = { workspace = true }
-miden_stdlib = { package = "miden-stdlib", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
-miden_vm = { package = "miden-vm", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
+miden_stdlib = { package = "miden-stdlib", version = "0.8", default-features = false }
+miden_vm = { package = "miden-vm", version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
@@ -42,7 +42,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies", default-features = false }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }

--- a/block-producer/Cargo.toml
+++ b/block-producer/Cargo.toml
@@ -42,7 +42,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "andrew-update-dependencies", default-features = false }
+miden-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 miden-node-test-macro = { path = "../test-macro" }
 once_cell = { version = "1.18" }
 tokio = { version = "1.29", features = ["test-util"] }


### PR DESCRIPTION
This small PR changes Miden VM crates dependencies from git link to crate version.
This PR should be merged after https://github.com/0xPolygonMiden/miden-base/pull/486.