### PR TITLE
Improvements in `MockStoreSuccessBuilder`

### DIFF
--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -116,17 +116,17 @@ impl TransactionBatch {
             .map(|(account_id, account_states)| (*account_id, account_states.final_state))
     }
 
-    /// Returns the nullifier of all consumed notes.
+    /// Returns an iterator over produced nullifiers for all consumed notes.
     pub fn produced_nullifiers(&self) -> impl Iterator<Item = Nullifier> + '_ {
         self.produced_nullifiers.iter().cloned()
     }
 
-    /// Returns the hash of created notes.
+    /// Returns an iterator over created notes.
     pub fn created_notes(&self) -> impl Iterator<Item = &NoteEnvelope> + '_ {
         self.created_notes.iter()
     }
 
-    /// Returns the root of the created notes SMT.
+    /// Returns the root hash of the created notes SMT.
     pub fn created_notes_root(&self) -> Digest {
         self.created_notes_smt.root()
     }

--- a/block-producer/src/block_builder/prover/block_witness.rs
+++ b/block-producer/src/block_builder/prover/block_witness.rs
@@ -225,7 +225,6 @@ impl BlockWitness {
 
         // Notes stack inputs
         {
-            let num_created_notes_roots = self.batch_created_notes_roots.len();
             for (batch_index, batch_created_notes_root) in self.batch_created_notes_roots.iter() {
                 stack_inputs.extend(batch_created_notes_root.iter());
 
@@ -237,7 +236,7 @@ impl BlockWitness {
             let empty_root = EmptySubtreeRoots::entry(BLOCK_OUTPUT_NOTES_TREE_DEPTH, 0);
             stack_inputs.extend(*empty_root);
             stack_inputs.push(
-                Felt::try_from(num_created_notes_roots as u64)
+                Felt::try_from(self.batch_created_notes_roots.len() as u64)
                     .expect("notes roots number is greater than or equal to the field modulus"),
             );
         }

--- a/block-producer/src/block_builder/prover/mod.rs
+++ b/block-producer/src/block_builder/prover/mod.rs
@@ -224,7 +224,7 @@ impl BlockProver {
         let proof_hash = Digest::default();
         let timestamp: Felt = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("today is expected to be before 1970")
+            .expect("today is expected to be after 1970")
             .as_millis()
             .try_into()
             .expect("timestamp is greater than or equal to the field modulus");

--- a/block-producer/src/block_builder/prover/tests.rs
+++ b/block-producer/src/block_builder/prover/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, iter};
 
 use miden_mock::mock::block::mock_block_header;
 use miden_objects::{
@@ -188,14 +188,13 @@ async fn test_compute_account_root_success() {
     // Set up store's account SMT
     // ---------------------------------------------------------------------------------------------
 
-    let store = MockStoreSuccessBuilder::new()
-        .initial_accounts(
-            account_ids
-                .iter()
-                .zip(account_initial_states.iter())
-                .map(|(&account_id, &account_hash)| (account_id, account_hash.into())),
-        )
-        .build();
+    let store = MockStoreSuccessBuilder::from_accounts(
+        account_ids
+            .iter()
+            .zip(account_initial_states.iter())
+            .map(|(&account_id, &account_hash)| (account_id, account_hash.into())),
+    )
+    .build();
 
     // Block prover
     // ---------------------------------------------------------------------------------------------
@@ -272,14 +271,13 @@ async fn test_compute_account_root_empty_batches() {
     // Set up store's account SMT
     // ---------------------------------------------------------------------------------------------
 
-    let store = MockStoreSuccessBuilder::new()
-        .initial_accounts(
-            account_ids
-                .iter()
-                .zip(account_initial_states.iter())
-                .map(|(&account_id, &account_hash)| (account_id, account_hash.into())),
-        )
-        .build();
+    let store = MockStoreSuccessBuilder::from_accounts(
+        account_ids
+            .iter()
+            .zip(account_initial_states.iter())
+            .map(|(&account_id, &account_hash)| (account_id, account_hash.into())),
+    )
+    .build();
 
     // Block prover
     // ---------------------------------------------------------------------------------------------
@@ -310,7 +308,7 @@ async fn test_compute_note_root_empty_batches_success() {
     // Set up store
     // ---------------------------------------------------------------------------------------------
 
-    let store = MockStoreSuccessBuilder::new().build();
+    let store = MockStoreSuccessBuilder::from_batches(iter::empty()).build();
 
     // Block prover
     // ---------------------------------------------------------------------------------------------
@@ -340,7 +338,7 @@ async fn test_compute_note_root_empty_notes_success() {
     // Set up store
     // ---------------------------------------------------------------------------------------------
 
-    let store = MockStoreSuccessBuilder::new().build();
+    let store = MockStoreSuccessBuilder::from_batches(iter::empty()).build();
 
     // Block prover
     // ---------------------------------------------------------------------------------------------
@@ -391,7 +389,7 @@ async fn test_compute_note_root_success() {
     // Set up store
     // ---------------------------------------------------------------------------------------------
 
-    let store = MockStoreSuccessBuilder::new().build();
+    let store = MockStoreSuccessBuilder::from_batches(iter::empty()).build();
 
     // Block prover
     // ---------------------------------------------------------------------------------------------
@@ -562,9 +560,7 @@ async fn test_compute_nullifier_root_empty_success() {
     // Set up store
     // ---------------------------------------------------------------------------------------------
 
-    let store = MockStoreSuccessBuilder::new()
-        .initial_accounts(batches.iter().flat_map(|batch| batch.account_initial_states()))
-        .build();
+    let store = MockStoreSuccessBuilder::from_batches(batches.iter()).build();
 
     // Block prover
     // ---------------------------------------------------------------------------------------------
@@ -621,8 +617,7 @@ async fn test_compute_nullifier_root_success() {
     // ---------------------------------------------------------------------------------------------
     let initial_block_num = 42;
 
-    let store = MockStoreSuccessBuilder::new()
-        .initial_accounts(batches.iter().flat_map(|batch| batch.account_initial_states()))
+    let store = MockStoreSuccessBuilder::from_batches(batches.iter())
         .initial_block_num(initial_block_num)
         .build();
 
@@ -660,7 +655,7 @@ async fn test_compute_nullifier_root_success() {
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn test_compute_chain_mmr_root_empty_mmr() {
-    let store = MockStoreSuccessBuilder::new().build();
+    let store = MockStoreSuccessBuilder::from_batches(iter::empty()).build();
 
     let expected_block_header = build_expected_block_header(&store, &[]).await;
     let actual_block_header = build_actual_block_header(&store, Vec::new()).await;
@@ -679,7 +674,9 @@ async fn test_compute_chain_mmr_root_mmr_1_peak() {
         mmr
     };
 
-    let store = MockStoreSuccessBuilder::new().initial_chain_mmr(initial_chain_mmr).build();
+    let store = MockStoreSuccessBuilder::from_batches(iter::empty())
+        .initial_chain_mmr(initial_chain_mmr)
+        .build();
 
     let expected_block_header = build_expected_block_header(&store, &[]).await;
     let actual_block_header = build_actual_block_header(&store, Vec::new()).await;
@@ -702,7 +699,9 @@ async fn test_compute_chain_mmr_root_mmr_17_peaks() {
         mmr
     };
 
-    let store = MockStoreSuccessBuilder::new().initial_chain_mmr(initial_chain_mmr).build();
+    let store = MockStoreSuccessBuilder::from_batches(iter::empty())
+        .initial_chain_mmr(initial_chain_mmr)
+        .build();
 
     let expected_block_header = build_expected_block_header(&store, &[]).await;
     let actual_block_header = build_actual_block_header(&store, Vec::new()).await;

--- a/block-producer/src/block_builder/tests.rs
+++ b/block-producer/src/block_builder/tests.rs
@@ -13,8 +13,7 @@ async fn test_apply_block_called_nonempty_batches() {
     let account_initial_hash: Digest =
         [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)].into();
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(std::iter::once((account_id, account_initial_hash)))
+        MockStoreSuccessBuilder::from_accounts(std::iter::once((account_id, account_initial_hash)))
             .build(),
     );
 
@@ -48,9 +47,7 @@ async fn test_apply_block_called_empty_batches() {
     let account_hash: Digest =
         [Felt::new(1u64), Felt::new(1u64), Felt::new(1u64), Felt::new(1u64)].into();
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(std::iter::once((account_id, account_hash)))
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(std::iter::once((account_id, account_hash))).build(),
     );
 
     let block_builder = DefaultBlockBuilder::new(store.clone(), store.clone());

--- a/block-producer/src/errors.rs
+++ b/block-producer/src/errors.rs
@@ -113,6 +113,8 @@ pub enum BlockInputsError {
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ApplyBlockError {
+    #[error("Merkle error: {0}")]
+    MerkleError(#[from] MerkleError),
     #[error("gRPC client failed with error: {0}")]
     GrpcClientError(String),
 }

--- a/block-producer/src/state_view/tests/apply_block.rs
+++ b/block-producer/src/state_view/tests/apply_block.rs
@@ -16,9 +16,7 @@ async fn test_apply_block_ab1() {
     let account: MockPrivateAccount<3> = MockPrivateAccount::from(0);
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(iter::once((account.id, account.states[0])))
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(iter::once((account.id, account.states[0]))).build(),
     );
 
     let tx =
@@ -52,14 +50,13 @@ async fn test_apply_block_ab2() {
     let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(
-                accounts
-                    .clone()
-                    .into_iter()
-                    .map(|mock_account| (mock_account.id, mock_account.states[0])),
-            )
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(
+            accounts
+                .clone()
+                .into_iter()
+                .map(|mock_account| (mock_account.id, mock_account.states[0])),
+        )
+        .build(),
     );
 
     let state_view = DefaultStateView::new(store.clone(), false);
@@ -100,14 +97,13 @@ async fn test_apply_block_ab3() {
     let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(
-                accounts
-                    .clone()
-                    .into_iter()
-                    .map(|mock_account| (mock_account.id, mock_account.states[0])),
-            )
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(
+            accounts
+                .clone()
+                .into_iter()
+                .map(|mock_account| (mock_account.id, mock_account.states[0])),
+        )
+        .build(),
     );
 
     let state_view = DefaultStateView::new(store.clone(), false);
@@ -132,7 +128,7 @@ async fn test_apply_block_ab3() {
     let apply_block_res = state_view.apply_block(block).await;
     assert!(apply_block_res.is_ok());
 
-    // Craft a new transaction which tries to consume the same note that was consumed in in the
+    // Craft a new transaction which tries to consume the same note that was consumed in the
     // first tx
     let tx_new = MockProvenTxBuilder::with_account(
         accounts[0].id,

--- a/block-producer/src/state_view/tests/verify_tx.rs
+++ b/block-producer/src/state_view/tests/verify_tx.rs
@@ -26,13 +26,12 @@ async fn test_verify_tx_happy_path() {
         get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(
-                accounts
-                    .into_iter()
-                    .map(|mock_account| (mock_account.id, mock_account.states[0])),
-            )
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(
+            accounts
+                .into_iter()
+                .map(|mock_account| (mock_account.id, mock_account.states[0])),
+        )
+        .build(),
     );
 
     let state_view = DefaultStateView::new(store, false);
@@ -53,13 +52,12 @@ async fn test_verify_tx_happy_path_concurrent() {
         get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(
-                accounts
-                    .into_iter()
-                    .map(|mock_account| (mock_account.id, mock_account.states[0])),
-            )
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(
+            accounts
+                .into_iter()
+                .map(|mock_account| (mock_account.id, mock_account.states[0])),
+        )
+        .build(),
     );
 
     let state_view = Arc::new(DefaultStateView::new(store, false));
@@ -83,9 +81,7 @@ async fn test_verify_tx_vt1() {
     let account = MockPrivateAccount::<3>::from(1);
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(iter::once((account.id, account.states[0])))
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(iter::once((account.id, account.states[0]))).build(),
     );
 
     // The transaction's initial account hash uses `account.states[1]`, where the store expects
@@ -114,7 +110,7 @@ async fn test_verify_tx_vt2() {
     let account_not_in_store: MockPrivateAccount<3> = MockPrivateAccount::from(0);
 
     // Notice: account is not added to the store
-    let store = Arc::new(MockStoreSuccessBuilder::new().build());
+    let store = Arc::new(MockStoreSuccessBuilder::from_batches(iter::empty()).build());
 
     let tx = MockProvenTxBuilder::with_account(
         account_not_in_store.id,
@@ -141,9 +137,9 @@ async fn test_verify_tx_vt3() {
 
     // Notice: `consumed_note_in_store` is added to the store
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(iter::once((account.id, account.states[0])))
-            .initial_nullifiers(BTreeSet::from_iter(iter::once(nullifier_in_store.inner())), 1)
+        MockStoreSuccessBuilder::from_accounts(iter::once((account.id, account.states[0])))
+            .initial_nullifiers(BTreeSet::from_iter(iter::once(nullifier_in_store.inner())))
+            .initial_block_num(1)
             .build(),
     );
 
@@ -170,9 +166,7 @@ async fn test_verify_tx_vt4() {
     let account: MockPrivateAccount<3> = MockPrivateAccount::from(1);
 
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(iter::once((account.id, account.states[0])))
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(iter::once((account.id, account.states[0]))).build(),
     );
 
     let tx1 =
@@ -205,13 +199,12 @@ async fn test_verify_tx_vt5() {
 
     // Notice: `consumed_note_in_both_txs` is NOT in the store
     let store = Arc::new(
-        MockStoreSuccessBuilder::new()
-            .initial_accounts(
-                vec![account_1, account_2]
-                    .into_iter()
-                    .map(|account| (account.id, account.states[0])),
-            )
-            .build(),
+        MockStoreSuccessBuilder::from_accounts(
+            vec![account_1, account_2]
+                .into_iter()
+                .map(|account| (account.id, account.states[0])),
+        )
+        .build(),
     );
 
     let tx1 =

--- a/block-producer/src/test_utils/block.rs
+++ b/block-producer/src/test_utils/block.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     accounts::AccountId,
     crypto::merkle::Mmr,
     notes::{NoteEnvelope, Nullifier},
-    BlockHeader, Digest, Word, ACCOUNT_TREE_DEPTH, NOTE_TREE_DEPTH, ONE, ZERO,
+    BlockHeader, Digest, Word, ACCOUNT_TREE_DEPTH, BLOCK_OUTPUT_NOTES_TREE_DEPTH, ONE, ZERO,
 };
 use miden_vm::crypto::SimpleSmt;
 
@@ -46,7 +46,7 @@ pub async fn build_expected_block_header(
             entries.push(((index * 2) as u64 + 1, note.metadata().into()));
         }
 
-        SimpleSmt::<NOTE_TREE_DEPTH>::with_leaves(entries).unwrap().root()
+        SimpleSmt::<BLOCK_OUTPUT_NOTES_TREE_DEPTH>::with_leaves(entries).unwrap().root()
     };
 
     // Compute new chain MMR root

--- a/block-producer/src/test_utils/proven_tx.rs
+++ b/block-producer/src/test_utils/proven_tx.rs
@@ -64,8 +64,7 @@ impl MockProvenTxBuilder {
     ) -> Self {
         let nullifiers = range
             .map(|index| {
-                let nullifier =
-                    Digest::from([Felt::new(1), Felt::new(1), Felt::new(1), Felt::new(index)]);
+                let nullifier = Digest::from([ONE, ONE, ONE, Felt::new(index)]);
 
                 Nullifier::from(nullifier)
             })

--- a/block-producer/src/test_utils/store.rs
+++ b/block-producer/src/test_utils/store.rs
@@ -42,17 +42,11 @@ impl MockStoreSuccessBuilder {
         };
 
         let created_notes = note_created_smt_from_batches(batches.iter().cloned());
-        let produced_nullifiers = batches
-            .iter()
-            .cloned()
-            .flat_map(TransactionBatch::produced_nullifiers)
-            .map(|nullifier| nullifier.inner())
-            .collect();
 
         Self {
             accounts: Some(accounts_smt),
             notes: Some(created_notes),
-            produced_nullifiers: Some(produced_nullifiers),
+            produced_nullifiers: None,
             chain_mmr: None,
             block_num: None,
         }

--- a/block-producer/src/test_utils/store.rs
+++ b/block-producer/src/test_utils/store.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use miden_objects::{
     crypto::merkle::{Mmr, SimpleSmt, Smt, ValuePath},
     notes::{NoteEnvelope, Nullifier},
-    BlockHeader, Word, ACCOUNT_TREE_DEPTH, EMPTY_WORD, NOTE_TREE_DEPTH, ONE, ZERO,
+    BlockHeader, Word, ACCOUNT_TREE_DEPTH, BLOCK_OUTPUT_NOTES_TREE_DEPTH, EMPTY_WORD, ONE, ZERO,
 };
 
 use super::*;
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct MockStoreSuccessBuilder {
     accounts: Option<SimpleSmt<ACCOUNT_TREE_DEPTH>>,
-    notes: Option<SimpleSmt<NOTE_TREE_DEPTH>>,
+    notes: Option<SimpleSmt<BLOCK_OUTPUT_NOTES_TREE_DEPTH>>,
     produced_nullifiers: Option<Smt>,
     chain_mmr: Option<Mmr>,
     block_num: Option<u32>,
@@ -60,7 +60,7 @@ impl MockStoreSuccessBuilder {
                 entries.push(((index * 2) as u64 + 1, note.metadata().into()));
             }
 
-            SimpleSmt::<NOTE_TREE_DEPTH>::with_leaves(entries).unwrap()
+            SimpleSmt::<BLOCK_OUTPUT_NOTES_TREE_DEPTH>::with_leaves(entries).unwrap()
         };
 
         self.notes = Some(notes_smt);
@@ -137,7 +137,7 @@ pub struct MockStoreSuccess {
     pub accounts: Arc<RwLock<SimpleSmt<ACCOUNT_TREE_DEPTH>>>,
 
     /// Stores notes created
-    pub notes: Arc<RwLock<SimpleSmt<NOTE_TREE_DEPTH>>>,
+    pub notes: Arc<RwLock<SimpleSmt<BLOCK_OUTPUT_NOTES_TREE_DEPTH>>>,
 
     /// Stores the nullifiers of the notes that were consumed
     pub produced_nullifiers: Arc<RwLock<Smt>>,
@@ -183,7 +183,7 @@ impl ApplyBlock for MockStoreSuccess {
             entries.push((index * 2, note.note_id().into()));
             entries.push((index * 2 + 1, note.metadata().into()));
         }
-        let created_notes = SimpleSmt::<NOTE_TREE_DEPTH>::with_leaves(entries)?;
+        let created_notes = SimpleSmt::<BLOCK_OUTPUT_NOTES_TREE_DEPTH>::with_leaves(entries)?;
         debug_assert_eq!(created_notes.root(), block.header.note_root());
         let new_notes_root = locked_notes.set_subtree(0, created_notes)?;
         debug_assert_eq!(new_notes_root, block.header.note_root());

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -478,7 +478,7 @@ impl State {
 // UTILITIES
 // ================================================================================================
 
-/// Returns the nullifier's block number given its leaf value in the SMT.
+/// Returns the nullifier's leaf value in the SMT by its block number.
 fn block_to_nullifier_data(block: BlockNumber) -> Word {
     [Felt::from(block), Felt::ZERO, Felt::ZERO, Felt::ZERO]
 }


### PR DESCRIPTION
- `MockStoreSuccessBuilder` and `build_expected_block_header()` now compute produced notes root
- `MockStoreSuccessBuilder::new()` was replaced with two constructors: `from_batches` and `from_accounts` which allow it to fill initial account IDs and state and also nullifiers and produced notes.

This will resolve #79