### PR TITLE
ci: turn doc warnings into errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: ${{matrix.args}}
+          args:
+      - name: Check docs
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: -D warnings
+        with:
+          command: doc
+          args: --verbose --keep-going ${{matrix.args}}
 
   test:
     name: test ${{matrix.toolchain}} on ${{matrix.os}} with ${{matrix.args}}


### PR DESCRIPTION
Adds the same check as https://github.com/0xPolygonMiden/crypto/pull/256

This repo didn't have any issues with the existing docs.