### PR TITLE
gh: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/1-bugreport.yml
@@ -1,0 +1,55 @@
+name: "Bug Report"
+description: "File a bug report"
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+  - type: input
+    id: version
+    attributes:
+      label: "Version"
+      description: "Which node version are you running?"
+      placeholder: "v0.1.0"
+    validations:
+      required: true
+  - type: textarea
+    id: other-version
+    attributes:
+      label: "Other packages versions"
+      description: "Let us know of the versions of any other packages used. For example, which version of the client are you using?"
+      placeholder: "miden-client: v0.1.0"
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: "What happened?"
+      description: "Describe the behaviour you are experiencing."
+      placeholder: "Tell us what you see!"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-to-happen
+    attributes:
+      label: "What should have happened?"
+      description: "Describe the behaviour you expected to see."
+      placeholder: "Tell us what should have happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce-steps
+    attributes:
+      label: "How can this be reproduced?"
+      description: "If possible, describe how to replicate the unexpected behaviour that you see."
+      placeholder: "Steps!"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This is automatically formatted as code, no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,44 @@
+name: "Feature request"
+description: "Request new goodies"
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill a feature request!
+  - type: dropdown
+    id: target-group
+    attributes:
+      label: "To whom is this feature for?"
+      description: "Let us know who will use this new goodie!"
+      options:
+        - End user
+        - App developer
+        - Rollup operator
+    validations:
+      required: true
+  - type: textarea
+    id: scenario-why
+    attributes:
+      label: "Why is is this feature needed?"
+      description: "Context why a user needs this feature :)"
+      placeholder: "Alice loves Miden and wants to organize a small gather up for her local community. She wants to give proof of attendance as NFTs to everyone! We should have a default contract for that :)"
+    validations:
+      required: true
+  - type: textarea
+    id: scenario-how
+    attributes:
+      label: "How is this feature used?"
+      description: "Context on how the feature is used!"
+      placeholder: "Alice uses a wallet and deploy a standard attendance contract before the meetup. Once the meetup ends, she just runs a transaction to generate the NFTs!"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: "Anything else?"
+      description: "Anything else in your mind and you wnat to share with us?"
+      placeholder: "Here is why I think this is awesome!"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-task.yml
+++ b/.github/ISSUE_TEMPLATE/3-task.yml
@@ -1,0 +1,48 @@
+name: "Task"
+description: "Work item"
+title: "[Task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A task should be less than a week worth of work!
+  - type: checkboxes
+    id: component
+    attributes:
+      label: "Node's components affected by this task"
+      options:
+        - RPC
+        - Block producer
+        - Store
+        - Protobuf messages
+        - Testing
+    validations:
+      required: true
+  - type: textarea
+    id: task-what
+    attributes:
+      label: "What should be done?"
+      placeholder: "Add healthchecking to the servers"
+    validations:
+      required: true
+  - type: textarea
+    id: task-how
+    attributes:
+      label: "How should it be done?"
+      placeholder: "Add a /health endpoint to each of the servers, that returns a small JSON reponse and `200` while the service is healthy"
+    validations:
+      required: true
+  - type: textarea
+    id: task-done
+    attributes:
+      label: "When is this task done?"
+      placeholder: "The task is done when the services are deployed with healthcheck"
+    validations:
+      required: true
+  - type: textarea
+    id: task-related
+    attributes:
+      label: "Additional context"
+      description: "Add context to the tasks. E.g. other related tasks or relevant dicussions on PRs/chats."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,15 @@
+# Task description
+
+<describe what should be done>
+
+# Implementation suggestion
+
+<describe how it should be implemented>
+
+# Defintion of done
+
+<describe when this task is considered finished>
+
+# Context
+
+<add additional context in the form of other issues/PRs/discussions>


### PR DESCRIPTION
This adds issue templates. The goals here are:

- Make sure that we communicate what we want in the issue. The goal is for the issue to have enough context so that another dev can pick the issue up and start working on it.
- Add structure to issues when opened by people outside of the team. The goal is to make the issue template structure in such a way it is helpful for us to understand the external request, and to help any external contributor to give us the context we need to understand the issue/feature.

---

GH has moved away from the markdown templates to yaml based templates. So this PR is using the later. The syntax is [documented here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema).

I have kept the option of writing a blank issue, just in case the existing templates don't cover all possibilities, but I added an old style markdown template to give it at least some structure.