### PR TITLE
gh: fix task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-task.yml
+++ b/.github/ISSUE_TEMPLATE/3-task.yml
@@ -11,11 +11,11 @@ body:
     attributes:
       label: "Node's components affected by this task"
       options:
-        - RPC
-        - Block producer
-        - Store
-        - Protobuf messages
-        - Testing
+        - label: "RPC"
+        - label: "Block producer"
+        - label: "Store"
+        - label: "Protobuf messages"
+        - label: "Testing"
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
I found a issue with the task template. Maybe this is the reason why it is not rendering.

There should also be a issue template validation somewhere, at least the errors are [documented here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms). But I couldn't find the tool, I guess it is only available for the repo's admins.

Edit: Ahhhh, that was simple. I just had to navigate to the yaml file:

![image](https://github.com/0xPolygonMiden/miden-node/assets/310139/29251729-a0cd-46c0-8c41-f1486f55c542)

And yeah, the issue was the lack of a `label` in there.
