### PR TITLE
Fixed `nullifier_value_to_block_num` function

### DIFF
--- a/block-producer/src/block_builder/mod.rs
+++ b/block-producer/src/block_builder/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 pub(crate) mod prover;
+
 use self::prover::{block_witness::BlockWitness, BlockProver};
 
 #[cfg(test)]
@@ -77,8 +78,8 @@ where
             batches = %format_array(batches.iter().map(|batch| format_blake3_digest(batch.id()))),
         );
 
-        let account_updates: Vec<(AccountId, Digest)> =
-            batches.iter().flat_map(|batch| batch.updated_accounts()).collect();
+        let updated_accounts: Vec<(AccountId, Digest)> =
+            batches.iter().flat_map(TransactionBatch::updated_accounts).collect();
         let created_notes = batches
             .iter()
             .enumerate()
@@ -90,12 +91,12 @@ where
             })
             .collect();
         let produced_nullifiers: Vec<Nullifier> =
-            batches.iter().flat_map(|batch| batch.produced_nullifiers()).collect();
+            batches.iter().flat_map(TransactionBatch::produced_nullifiers).collect();
 
         let block_inputs = self
             .store
             .get_block_inputs(
-                account_updates.iter().map(|(account_id, _)| account_id),
+                updated_accounts.iter().map(|(account_id, _)| account_id),
                 produced_nullifiers.iter(),
             )
             .await?;
@@ -108,7 +109,7 @@ where
 
         let block = Block {
             header: new_block_header,
-            updated_accounts: account_updates,
+            updated_accounts,
             created_notes,
             produced_nullifiers,
         };

--- a/proto/src/domain/mod.rs
+++ b/proto/src/domain/mod.rs
@@ -1,5 +1,3 @@
-use miden_objects::Word;
-
 pub mod accounts;
 pub mod blocks;
 pub mod digest;
@@ -24,12 +22,4 @@ where
     From: TryInto<To, Error = E>,
 {
     from.into_iter().map(|e| e.try_into()).collect()
-}
-
-/// Given the leaf value of the nullifier SMT, returns the nullifier's block number.
-///
-/// There are no nullifiers in the genesis block. The value zero is instead used to signal absence
-/// of a value.
-pub fn nullifier_value_to_block_num(value: Word) -> u32 {
-    value[0].as_int().try_into().expect("invalid block number found in store")
 }

--- a/proto/src/domain/mod.rs
+++ b/proto/src/domain/mod.rs
@@ -31,5 +31,5 @@ where
 /// There are no nullifiers in the genesis block. The value zero is instead used to signal absence
 /// of a value.
 pub fn nullifier_value_to_block_num(value: Word) -> u32 {
-    value[3].as_int().try_into().expect("invalid block number found in store")
+    value[0].as_int().try_into().expect("invalid block number found in store")
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -9,7 +9,7 @@ pub mod generated;
 
 pub use domain::{
     accounts::{AccountInputRecord, AccountState},
-    convert, nullifier_value_to_block_num,
+    convert,
     nullifiers::NullifierWitness,
     try_convert,
 };

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -487,7 +487,7 @@ fn block_num_to_nullifier_value(block: BlockNumber) -> Word {
 ///
 /// There are no nullifiers in the genesis block. The value zero is instead used to signal absence
 /// of a value.
-pub fn nullifier_value_to_block_num(value: Word) -> BlockNumber {
+fn nullifier_value_to_block_num(value: Word) -> BlockNumber {
     value[0].as_int().try_into().expect("invalid block number found in store")
 }
 
@@ -557,4 +557,28 @@ async fn load_accounts(
 
     SimpleSmt::with_leaves(account_data)
         .map_err(StateInitializationError::FailedToCreateAccountsTree)
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_objects::{Felt, ZERO};
+
+    use super::{block_num_to_nullifier_value, nullifier_value_to_block_num};
+
+    #[test]
+    fn test_nullifier_data_encoding() {
+        let block_num = 123;
+        let nullifier_value = block_num_to_nullifier_value(block_num);
+
+        assert_eq!(nullifier_value, [Felt::from(block_num), ZERO, ZERO, ZERO])
+    }
+
+    #[test]
+    fn test_nullifier_data_decoding() {
+        let block_num = 123;
+        let nullifier_value = [Felt::from(block_num), ZERO, ZERO, ZERO];
+        let decoded_block_num = nullifier_value_to_block_num(nullifier_value);
+
+        assert_eq!(decoded_block_num, block_num);
+    }
 }

--- a/store/src/state.rs
+++ b/store/src/state.rs
@@ -4,7 +4,7 @@
 //! data is atomically written, and that reads are consistent.
 use std::{mem, sync::Arc};
 
-use miden_node_proto::{nullifier_value_to_block_num, AccountInputRecord, NullifierWitness};
+use miden_node_proto::{AccountInputRecord, NullifierWitness};
 use miden_node_utils::formatting::{format_account_id, format_array};
 use miden_objects::{
     crypto::{
@@ -164,7 +164,7 @@ impl State {
             // update nullifier tree
             let nullifier_tree = {
                 let mut nullifier_tree = inner.nullifier_tree.clone();
-                let nullifier_data = block_to_nullifier_data(block_header.block_num());
+                let nullifier_data = block_num_to_nullifier_value(block_header.block_num());
                 for nullifier in nullifiers.iter() {
                     nullifier_tree.insert(*nullifier, nullifier_data);
                 }
@@ -479,8 +479,16 @@ impl State {
 // ================================================================================================
 
 /// Returns the nullifier's leaf value in the SMT by its block number.
-fn block_to_nullifier_data(block: BlockNumber) -> Word {
+fn block_num_to_nullifier_value(block: BlockNumber) -> Word {
     [Felt::from(block), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+}
+
+/// Given the leaf value of the nullifier SMT, returns the nullifier's block number.
+///
+/// There are no nullifiers in the genesis block. The value zero is instead used to signal absence
+/// of a value.
+pub fn nullifier_value_to_block_num(value: Word) -> BlockNumber {
+    value[0].as_int().try_into().expect("invalid block number found in store")
 }
 
 /// Creates a [SimpleSmt] tree from the `notes`.
@@ -512,7 +520,7 @@ async fn load_nullifier_tree(db: &mut Db) -> Result<Smt, StateInitializationErro
     let len = nullifiers.len();
     let leaves = nullifiers
         .into_iter()
-        .map(|(nullifier, block)| (nullifier, block_to_nullifier_data(block)));
+        .map(|(nullifier, block)| (nullifier, block_num_to_nullifier_value(block)));
 
     let now = Instant::now();
     let nullifier_tree = Smt::with_entries(leaves)


### PR DESCRIPTION
This bug leaded to incorrect checking of already consumed notes.

This will resolve #249 