### PR TITLE
config: add systemd service files

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,13 @@
+## Service configuration files
+
+- `miden-faucet.service`: simple configuration to setup a faucet service monitored via systemd.
+- `miden-node.service`: simple configuration to setup full node service monitored via systemd.
+
+Install the above files to your system's unit directory (e.g.
+`/etc/systemd/system/`), and run the following commands to start the service:
+
+```sh
+systemctl daemon-reload                 # ask the systemd to load the new configuration files
+systemctl enable --now miden-node       # enable and start the node
+systemctl enable --now miden-faucet     # enable and start the faucet
+```

--- a/config/miden-faucet.service
+++ b/config/miden-faucet.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Miden faucet
+Wants=network-online.target
+Wants=miden-node.service
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=exec
+Environment="RUST_LOG=info"
+ExecStart=miden-faucet import --asset-amount 100 --faucet-path /srv/miden-node/accounts/account1.mac
+ExecStartPre=-rm store.sqlite3
+WorkingDirectory=/srv/miden-faucet
+RestartSec=5
+Restart=always

--- a/config/miden-node.service
+++ b/config/miden-node.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Miden node
+Wants=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=exec
+Environment="RUST_LOG=info"
+ExecStart=miden-node start
+WorkingDirectory=/srv/miden-node
+RestartSec=5
+Restart=always


### PR DESCRIPTION
This adds a two minimal systemd files to run a `miden-node` and `miden-faucet`.

These two service files are far from perfect, but it is nice to have them around if we need them once more.

For the moment the `faucet` is pigbacking in the node for the account details (from the genesis), and it removes the client's db on every restart. Both are not great, but to improve these the faucet needs to be improved. Which is at the moment is under development.