### PR TITLE
Setting up the mkdocs-material skeleton for this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,15 @@ genesis.dat
 *.sqlite3
 *.sqlite3-shm
 *.sqlite3-wal
+
+
+# Docs ignore
+.code
+.idea
+site/
+venv/
+env/
+*.out
+node_modules/
+*DS_Store
+*.iml

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Miden node
+
+theme:
+  name: material

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs-material==9.4.8
+markdown-include==0.8.1
+mkdocs-open-in-new-tab==1.0.3
+mkdocs-multirepo-plugin==0.7.0

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+virtualenv venv
+source venv/bin/activate
+pip3 install -r requirements.txt
+mkdocs serve --strict


### PR DESCRIPTION
This PR adds the mkdocs-material skeleton.

- Run the `run-docs-site.sh` script to bring up the side.
- Create new markdown content in the docs folder.
- Add new pages to the nav section in the `mkdocs.yml` file.