### PR TITLE
chore: update archived action on ci

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,10 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Install cargo make
         run: cargo install cargo-make
       - name: cargo make - doc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,12 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install minimal Rust with rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
-          override: true
       - name: Install cargo make
         run: cargo install cargo-make
       - name: cargo make - format-check
@@ -43,11 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install minimal Rust with clippy
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
+          toolchain: stable
           components: clippy
-          override: true
       - name: Install cargo make
         run: cargo install cargo-make
       - name: cargo make - clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Install cargo make
         run: cargo install cargo-make
       - name: cargo make - test


### PR DESCRIPTION
[As it was done for the miden-client workflows](https://github.com/0xPolygonMiden/miden-client/pull/222/files), this PR replaces the usage of `actions-rs/toolchain` which is archived as of now with the updated `dtolnay/rust-toolchain` action. 