### PR TITLE
bugfix: table name is block_headers instead of block_header

### DIFF
--- a/store/src/db/migrations.rs
+++ b/store/src/db/migrations.rs
@@ -27,7 +27,7 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             PRIMARY KEY (block_num, note_index),
             CONSTRAINT notes_block_number_is_u32 CHECK (block_num >= 0 AND block_num < 4294967296),
             CONSTRAINT notes_note_index_is_u32 CHECK (note_index >= 0 AND note_index < 4294967296),
-            FOREIGN KEY (block_num) REFERENCES block_header (block_num)
+            FOREIGN KEY (block_num) REFERENCES block_headers (block_num)
         ) STRICT, WITHOUT ROWID;
 
         CREATE TABLE
@@ -38,7 +38,7 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             block_num INTEGER NOT NULL,
 
             PRIMARY KEY (account_id),
-            FOREIGN KEY (block_num) REFERENCES block_header (block_num),
+            FOREIGN KEY (block_num) REFERENCES block_headers (block_num),
             CONSTRAINT accounts_block_num_is_u32 CHECK (block_num >= 0 AND block_num < 4294967296)
         ) STRICT, WITHOUT ROWID;
 
@@ -53,7 +53,7 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             CONSTRAINT nullifiers_nullifier_is_digest CHECK (length(nullifier) = 32),
             CONSTRAINT nullifiers_nullifier_prefix_is_u16 CHECK (nullifier_prefix >= 0 AND nullifier_prefix < 65536),
             CONSTRAINT nullifiers_block_number_is_u32 CHECK (block_number >= 0 AND block_number < 4294967296),
-            FOREIGN KEY (block_number) REFERENCES block_header (block_num)
+            FOREIGN KEY (block_number) REFERENCES block_headers (block_num)
         ) STRICT, WITHOUT ROWID;
         ",
     )])


### PR DESCRIPTION
The table in the references clause had a typo.