### PR TITLE
sqlite: use bundled version to enable FK checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "bindgen",
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -30,7 +30,7 @@ miden-node-utils = { path = "../utils", version = "0.2" }
 miden-objects = { workspace = true }
 once_cell = { version = "1.18.0" }
 prost = { version = "0.12" }
-rusqlite = { version = "0.30", features = ["array", "buildtime_bindgen"] }
+rusqlite = { version = "0.30", features = ["array", "buildtime_bindgen", "bundled"] }
 rusqlite_migration = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }

--- a/store/src/db/migrations.rs
+++ b/store/src/db/migrations.rs
@@ -25,9 +25,9 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             merkle_path BLOB NOT NULL,
 
             PRIMARY KEY (block_num, note_index),
+            CONSTRAINT fk_block_num FOREIGN KEY (block_num) REFERENCES block_headers (block_num),
             CONSTRAINT notes_block_number_is_u32 CHECK (block_num >= 0 AND block_num < 4294967296),
-            CONSTRAINT notes_note_index_is_u32 CHECK (note_index >= 0 AND note_index < 4294967296),
-            FOREIGN KEY (block_num) REFERENCES block_headers (block_num)
+            CONSTRAINT notes_note_index_is_u32 CHECK (note_index >= 0 AND note_index < 4294967296)
         ) STRICT, WITHOUT ROWID;
 
         CREATE TABLE
@@ -38,7 +38,7 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             block_num INTEGER NOT NULL,
 
             PRIMARY KEY (account_id),
-            FOREIGN KEY (block_num) REFERENCES block_headers (block_num),
+            CONSTRAINT fk_block_num FOREIGN KEY (block_num) REFERENCES block_headers (block_num),
             CONSTRAINT accounts_block_num_is_u32 CHECK (block_num >= 0 AND block_num < 4294967296)
         ) STRICT, WITHOUT ROWID;
 
@@ -50,10 +50,10 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             block_number INTEGER NOT NULL,
 
             PRIMARY KEY (nullifier),
+            CONSTRAINT fk_block_num FOREIGN KEY (block_number) REFERENCES block_headers (block_num),
             CONSTRAINT nullifiers_nullifier_is_digest CHECK (length(nullifier) = 32),
             CONSTRAINT nullifiers_nullifier_prefix_is_u16 CHECK (nullifier_prefix >= 0 AND nullifier_prefix < 65536),
-            CONSTRAINT nullifiers_block_number_is_u32 CHECK (block_number >= 0 AND block_number < 4294967296),
-            FOREIGN KEY (block_number) REFERENCES block_headers (block_num)
+            CONSTRAINT nullifiers_block_number_is_u32 CHECK (block_number >= 0 AND block_number < 4294967296)
         ) STRICT, WITHOUT ROWID;
         ",
     )])
@@ -61,5 +61,5 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
 
 #[test]
 fn migrations_test() {
-    assert!(MIGRATIONS.validate().is_ok());
+    assert_eq!(MIGRATIONS.validate(), Ok(()));
 }


### PR DESCRIPTION
I'm not sure why the PRAGMA wasn't sufficient. But this was caught by @phklive when integrating the faucet. The feature flag seems to be required