### PR TITLE
docs: update documentation on running node with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you intend on running the node inside a Docker container, you will need to fo
 2. Run the Docker container
 
     ```sh
-    docker run --name miden-node -p 57291:57291 -d miden-node-image
+    cargo make docker-run-node
     ```
 
     This command will run the node as a container named `miden-node` using the `miden-node-image` and make port `57291` available (rpc endpoint).

--- a/block-producer/src/batch_builder/batch.rs
+++ b/block-producer/src/batch_builder/batch.rs
@@ -71,19 +71,10 @@ impl TransactionBatch {
         }
 
         // TODO: document under what circumstances SMT creating can fail
-        let created_notes_smt =
-            BatchNoteTree::with_contiguous_leaves(created_notes.iter().map(|note| {
-                (
-                    note.id(),
-                    // TODO: Substitute by using just note.metadata() once this getter returns reference
-                    //       Tracking PR: https://github.com/0xPolygonMiden/miden-base/pull/593
-                    match note {
-                        OutputNote::Public(note) => note.metadata(),
-                        OutputNote::Private(note) => note.metadata(),
-                    },
-                )
-            }))
-            .map_err(|e| BuildBatchError::NotesSmtError(e, txs))?;
+        let created_notes_smt = BatchNoteTree::with_contiguous_leaves(
+            created_notes.iter().map(|note| (note.id(), note.metadata())),
+        )
+        .map_err(|e| BuildBatchError::NotesSmtError(e, txs))?;
 
         Ok(Self {
             id,


### PR DESCRIPTION
When following the repo's documentation I was unable to run the node using docker. I explained in more detail [on the discord server](https://discord.com/channels/893151281848406016/1114419272165376030/1222555506791415848).

I saw that we have a `docker-run-node` command on `Makefile.toml`, tried it and the node started successfully.

