### PR TITLE
fix: include batch index in db constraint for notes

### DIFF
--- a/store/src/db/migrations.rs
+++ b/store/src/db/migrations.rs
@@ -25,7 +25,7 @@ pub static MIGRATIONS: Lazy<Migrations> = Lazy::new(|| {
             tag INTEGER NOT NULL,
             merkle_path BLOB NOT NULL,
 
-            PRIMARY KEY (block_num, note_index),
+            PRIMARY KEY (block_num, batch_index, note_index),
             CONSTRAINT fk_block_num FOREIGN KEY (block_num) REFERENCES block_headers (block_num),
             CONSTRAINT notes_block_number_is_u32 CHECK (block_num >= 0 AND block_num < 4294967296),
             CONSTRAINT notes_batch_index_is_u32 CHECK (batch_index BETWEEN 0 AND 0xFFFFFFFF)


### PR DESCRIPTION
We found the following error logged on the node when running the integration tests in parallel:

```
2024-04-05T17:42:29.402418Z ERROR apply_block: miden-store: store/src/db/mod.rs:239: error: SQLite error: UNIQUE constraint failed: notes.block_num, notes.note_index
2024-04-05T17:42:29.402427Z ERROR store:apply_block:apply_block: miden-store: store/src/state.rs:104: error: Block applying was broken because of closed channel on database side: channel closed
```

apparently on #295 we changed the block's note tree to also use the note's batch. In there we included the note's batch index. The error from above is because the note's table on the db still has (block_num, note_index) as a primary key so two notes from different batches might conflict with each other.

## Steps to reproduce

- clone the miden-client repo and checkout to branch `igamigo-use-next`
- run `cargo make start-node`
- on a separate branch, run `cargo make integration-test`