### PR TITLE
fix: remove assert when producing block for new onchain account

### DIFF
--- a/store/src/db/sql.rs
+++ b/store/src/db/sql.rs
@@ -173,7 +173,6 @@ pub fn upsert_accounts(
         let full_account = match &update.details {
             None => None,
             Some(AccountDetails::Full(account)) => {
-                debug_assert!(account.is_new());
                 debug_assert_eq!(account_id, u64::from(account.id()));
 
                 if account.hash() != update.final_state_hash {


### PR DESCRIPTION
when running integration tests for onchain accounts we stumbled upon this error:

```bash
thread 'tokio-runtime-worker' panicked at store/src/db/sql.rs:176:17:
assertion failed: account.is_new()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-04-10T17:43:27.830234Z  INFO write_block_to_db: miden-store: store/src/db/mod.rs:290: close, time.busy: 418µs, time.idle: 18.3µs
2024-04-10T17:43:27.830332Z ERROR apply_block: miden-store: store/src/db/mod.rs:275: error: SQLite pool interaction task failed: Apply block task failed: Panic
2024-04-10T17:43:27.830331Z ERROR store:apply_block:apply_block: miden-store: store/src/state.rs:107: error: Block applying was broken because of closed channel on database side: channel closed
```

The culprit is the check:

```rust
Some(AccountDetails::Full(account)) => {
                debug_assert!(account.is_new());
                ...
```

The issue with this check is that whenever we submit a transaction from a new account we're already making the account nonce = 1 (could be > 1 once we enable multiple transactions for an account in a single block), but since it's the first transaction we submit to the node a Full account details is created.