### PR TITLE
Save blocks asynchronously

### DIFF
--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -12,23 +12,30 @@ impl BlockStore {
         Ok(Self { store_dir })
     }
 
-    pub fn save_block(&self, block_num: u32, data: &[u8]) -> Result<(), std::io::Error> {
-        let block_path = self.block_path(block_num);
-        let epoch_path = block_path.parent().ok_or(std::io::Error::from(ErrorKind::NotFound))?;
-
-        if !epoch_path.exists() {
-            std::fs::create_dir_all(epoch_path)?;
-        }
-
-        std::fs::write(block_path, data)
-    }
-
     pub async fn load_block(&self, block_num: u32) -> Result<Option<Vec<u8>>, std::io::Error> {
         match tokio::fs::read(self.block_path(block_num)).await {
             Ok(data) => Ok(Some(data)),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(err),
         }
+    }
+
+    pub async fn save_block(&self, block_num: u32, data: &[u8]) -> Result<(), std::io::Error> {
+        let (epoch_path, block_path) = self.epoch_block_path(block_num)?;
+        if !epoch_path.exists() {
+            tokio::fs::create_dir_all(epoch_path).await?;
+        }
+
+        tokio::fs::write(block_path, data).await
+    }
+
+    pub fn save_block_blocking(&self, block_num: u32, data: &[u8]) -> Result<(), std::io::Error> {
+        let (epoch_path, block_path) = self.epoch_block_path(block_num)?;
+        if !epoch_path.exists() {
+            std::fs::create_dir_all(epoch_path)?;
+        }
+
+        std::fs::write(block_path, data)
     }
 
     // HELPER FUNCTIONS
@@ -38,5 +45,12 @@ impl BlockStore {
         let epoch = block_num >> 16;
         let epoch_dir = self.store_dir.join(format!("{epoch:04x}"));
         epoch_dir.join(format!("block_{block_num:08x}.dat"))
+    }
+
+    fn epoch_block_path(&self, block_num: u32) -> Result<(PathBuf, PathBuf), std::io::Error> {
+        let block_path = self.block_path(block_num);
+        let epoch_path = block_path.parent().ok_or(std::io::Error::from(ErrorKind::NotFound))?;
+
+        Ok((epoch_path.to_path_buf(), block_path))
     }
 }

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -379,7 +379,7 @@ impl Db {
                             genesis_block.updated_accounts(),
                         )?;
 
-                        block_store.save_block(0, &genesis_block.to_bytes())?;
+                        block_store.save_block_blocking(0, &genesis_block.to_bytes())?;
 
                         transaction.commit()?;
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -257,7 +257,7 @@ impl State {
             let mut inner = self.inner.write().await;
 
             // Save the block before transaction is committed:
-            self.block_store.save_block(block_num, &block_data)?;
+            self.block_store.save_block(block_num, &block_data).await?;
 
             let _ = inform_acquire_done.send(());
 


### PR DESCRIPTION
I noticed that after refactoring, block saving, which is blocking, was moved from background thread to the async runtime. This can affect other async tasks, so I implemented async method as well. Unfortunately we can't simply get rid of blocking method now, since it is used in synchronous runtime (in genesis block storing).