### PR TITLE
Make proof verification error messages more detailed in the RPC

### DIFF
--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -14,7 +14,7 @@ pub struct CheckNullifiersRequest {
 /// Returns the block header corresponding to the requested block number, as well as the merkle
 /// path and current forest which validate the block's inclusion in the chain.
 ///
-/// The merkle path is an MMR proof for the block's leaf, based on the current forest.
+/// The Merkle path is an MMR proof for the block's leaf, based on the current chain length.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockHeaderByNumberRequest {

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -15,10 +15,10 @@ pub struct GetBlockHeaderByNumberResponse {
     /// The requested block header
     #[prost(message, optional, tag = "1")]
     pub block_header: ::core::option::Option<super::block_header::BlockHeader>,
-    /// Merkle path to verify the block's inclusion in the MMR at the returned `forest`
+    /// Merkle path to verify the block's inclusion in the MMR at the returned `chain_length`
     #[prost(message, optional, tag = "2")]
     pub mmr_path: ::core::option::Option<super::merkle::MerklePath>,
-    /// Current value of the MMR forest
+    /// Current chain length
     #[prost(fixed32, optional, tag = "3")]
     pub chain_length: ::core::option::Option<u32>,
 }


### PR DESCRIPTION
This small PR makes is so that we return more detailed error messages from the PRC when proof verification fails.