### PR TITLE
docs: Rename client binary name

### DIFF
--- a/bin/faucet/src/static/index.html
+++ b/bin/faucet/src/static/index.html
@@ -29,9 +29,9 @@
     <div id="info-container">
         <p id="info-message">You can consume the note by running the following commands in your shell</p>
         <p id="client-commands">
-            <span id="import-command" style="display: none;">miden-client input-notes import ./path/to/downloaded/note<br></span>
-            miden-client sync <br>
-            miden-client tx new consume-notes --account <span id="command-account-id"></span> <span id="note-id"></span>
+            <span id="import-command" style="display: none;">miden input-notes import ./path/to/downloaded/note<br></span>
+            miden sync <br>
+            miden tx new consume-notes --account <span id="command-account-id"></span> <span id="note-id"></span>
         </p>
     </div>
     <script src="./index.js"></script>


### PR DESCRIPTION
Addresses changes following https://github.com/0xPolygonMiden/miden-client/issues/314, which changed the name of the client into `miden`