### PR TITLE
fix: remove duplicate rpc server

### DIFF
--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -31,7 +31,6 @@ pub async fn serve(config: RpcConfig) -> Result<(), ApiError> {
 
     Server::builder()
         .accept_http1(true)
-        .add_service(rpc.clone())
         .add_service(tonic_web::enable(rpc))
         .serve(addr)
         .await


### PR DESCRIPTION
on #352 we added support for webrpc, but it causes the node to not start as it has the route definitions duplicated. I tested removing the line and running the miden client's integration test to make sure we're still supporting http2 requests.