### PR TITLE
feat: Use newer revisions for faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,19 +1570,19 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26dd1eb594629e583fae463c92f07c9e2c932e95a59a0b9cbc1453bf512108f"
+checksum = "bb0f5f1d9c548cfbdeda9cbe579138e45ca9c2ae88219a105c636a20d88233f3"
 dependencies = [
  "async-trait",
  "clap",
  "comfy-table",
  "figment",
  "lazy_static",
- "miden-lib 0.2.1",
- "miden-node-proto 0.2.1",
- "miden-objects 0.2.1",
- "miden-tx 0.2.3",
+ "miden-lib",
+ "miden-node-proto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miden-objects",
+ "miden-tx",
  "rand",
  "rusqlite",
  "rusqlite_migration",
@@ -1637,25 +1637,14 @@ dependencies = [
  "derive_more",
  "figment",
  "miden-client",
- "miden-lib 0.2.1",
+ "miden-lib",
  "miden-node-proto 0.3.0",
  "miden-node-utils 0.3.0",
- "miden-objects 0.2.1",
+ "miden-objects",
  "rand_chacha",
  "serde",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "miden-lib"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855aceec1ac4d01fc486a7c9c9cb348d05b3310c842580b25c5b79a65bd942e2"
-dependencies = [
- "miden-assembly",
- "miden-objects 0.2.1",
- "miden-stdlib",
 ]
 
 [[package]]
@@ -1665,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba8c32dda69e31d901eb7c8cefa4d2c45eac00710360206a5bf331a1ffb2fb42"
 dependencies = [
  "miden-assembly",
- "miden-objects 0.3.0",
+ "miden-objects",
  "miden-stdlib",
 ]
 
@@ -1676,12 +1665,12 @@ dependencies = [
  "anyhow",
  "clap",
  "figment",
- "miden-lib 0.3.0",
+ "miden-lib",
  "miden-node-block-producer",
  "miden-node-rpc",
  "miden-node-store",
  "miden-node-utils 0.3.0",
- "miden-objects 0.3.0",
+ "miden-objects",
  "rand_chacha",
  "serde",
  "tokio",
@@ -1701,10 +1690,10 @@ dependencies = [
  "miden-node-store",
  "miden-node-test-macro",
  "miden-node-utils 0.3.0",
- "miden-objects 0.3.0",
+ "miden-objects",
  "miden-processor",
  "miden-stdlib",
- "miden-tx 0.3.0",
+ "miden-tx",
  "once_cell",
  "serde",
  "thiserror",
@@ -1718,14 +1707,13 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f2118440be4382d633cc9ee3312b22b9c6bc2038296d33d8f384d25df694fd"
+version = "0.3.0"
 dependencies = [
  "hex",
- "miden-node-utils 0.2.1",
- "miden-objects 0.2.1",
+ "miden-node-utils 0.3.0",
+ "miden-objects",
  "miette",
+ "proptest",
  "prost",
  "prost-build",
  "protox",
@@ -1737,12 +1725,13 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cad7cb698a5e3cd387eca9380c0c6da1eea262b9527967b6eb755da3699b5b0"
 dependencies = [
  "hex",
- "miden-node-utils 0.3.0",
- "miden-objects 0.3.0",
+ "miden-node-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miden-objects",
  "miette",
- "proptest",
  "prost",
  "prost-build",
  "protox",
@@ -1762,8 +1751,8 @@ dependencies = [
  "miden-node-proto 0.3.0",
  "miden-node-store",
  "miden-node-utils 0.3.0",
- "miden-objects 0.3.0",
- "miden-tx 0.3.0",
+ "miden-objects",
+ "miden-tx",
  "prost",
  "serde",
  "tokio",
@@ -1782,10 +1771,10 @@ dependencies = [
  "directories",
  "figment",
  "hex",
- "miden-lib 0.3.0",
+ "miden-lib",
  "miden-node-proto 0.3.0",
  "miden-node-utils 0.3.0",
- "miden-objects 0.3.0",
+ "miden-objects",
  "once_cell",
  "prost",
  "rusqlite",
@@ -1809,29 +1798,12 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cdbbb3bc4ce1c13098c4f83eef02a517be2702dd5c026a28f69be435eb88f0"
-dependencies = [
- "anyhow",
- "figment",
- "itertools",
- "miden-objects 0.2.1",
- "serde",
- "thiserror",
- "tonic",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "miden-node-utils"
 version = "0.3.0"
 dependencies = [
  "anyhow",
  "figment",
  "itertools",
- "miden-objects 0.3.0",
+ "miden-objects",
  "serde",
  "thiserror",
  "tonic",
@@ -1841,18 +1813,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-objects"
-version = "0.2.1"
+name = "miden-node-utils"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f87a635484967ad871332d99791d7e1cada6857aa32cc4f72f1a8817c4016b4"
+checksum = "72178203f905caebaa6d33e44a8f45b9b8c2a3d98f7b40fffb83b7fd47cb2869"
 dependencies = [
- "miden-assembly",
- "miden-core",
- "miden-crypto",
- "miden-processor",
- "miden-verifier",
+ "anyhow",
+ "figment",
+ "itertools",
+ "miden-objects",
  "serde",
- "winter-rand-utils",
+ "thiserror",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1866,6 +1840,7 @@ dependencies = [
  "miden-crypto",
  "miden-processor",
  "miden-verifier",
+ "serde",
  "winter-rand-utils",
 ]
 
@@ -1904,25 +1879,12 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3367b700693148f79fd78113d86f3fab82646635d2f7d949d72f8bfcb98e5d46"
-dependencies = [
- "miden-lib 0.2.1",
- "miden-objects 0.2.1",
- "miden-processor",
- "miden-prover",
- "miden-verifier",
-]
-
-[[package]]
-name = "miden-tx"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a927829fd121ed73695e2ec472d222db0884a12f46c8f8d97cf0a82c8d4e0a"
 dependencies = [
- "miden-lib 0.3.0",
- "miden-objects 0.3.0",
+ "miden-lib",
+ "miden-objects",
  "miden-processor",
  "miden-prover",
  "miden-verifier",

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -23,11 +23,11 @@ actix-web = "4"
 async-mutex = "1.4.0"
 derive_more = "0.99.17"
 figment = { version = "0.10", features = ["toml", "env"] }
-miden-client = { version = "0.2", features = ["concurrent"] }
-miden-lib = { version = "0.2" }
+miden-client = { version = "0.3", features = ["concurrent"] }
+miden-lib = { version = "0.3" }
 miden-node-proto = { workspace = true }
 miden-node-utils = { workspace = true }
-miden-objects = { version = "0.2" }
+miden-objects = { version = "0.3" }
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -6,12 +6,18 @@ use miden_objects::{
     accounts::AccountId,
     assets::FungibleAsset,
     notes::{NoteId, NoteType},
+    transaction::OutputNote,
     utils::serde::Serializable,
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::{errors::FaucetError, utils::FaucetState};
+use crate::{
+    errors::FaucetError,
+    utils::{build_client, FaucetState},
+};
+
+const TOKEN_AMOUNT_OPTIONS: [u64; 3] = [100, 500, 1000];
 
 #[derive(Deserialize)]
 struct FaucetRequest {
@@ -23,14 +29,14 @@ struct FaucetRequest {
 #[derive(Serialize)]
 struct FaucetMetadataReponse {
     id: String,
-    asset_amount_options: Vec<u64>,
+    asset_amount_options: [u64; 3],
 }
 
 #[get("/get_metadata")]
 pub async fn get_metadata(state: web::Data<FaucetState>) -> HttpResponse {
     let response = FaucetMetadataReponse {
         id: state.id.to_string(),
-        asset_amount_options: state.asset_amount_options.clone(),
+        asset_amount_options: TOKEN_AMOUNT_OPTIONS,
     };
 
     HttpResponse::Ok().json(response)
@@ -47,11 +53,12 @@ pub async fn get_tokens(
     );
 
     // Check that the amount is in the asset amount options
-    if !state.asset_amount_options.contains(&req.asset_amount) {
+    if !TOKEN_AMOUNT_OPTIONS.contains(&req.asset_amount) {
         return Err(FaucetError::BadRequest("Invalid asset amount.".to_string()).into());
     }
 
-    let client = state.client.clone();
+    let client_config = state.faucet_config.clone();
+    let mut client = build_client(client_config.database_filepath, &client_config.node_url)?;
 
     // Receive and hex user account id
     let target_account_id = AccountId::from_hex(req.account_id.as_str())
@@ -73,15 +80,11 @@ pub async fn get_tokens(
 
     // Instantiate transaction request
     let tx_request = client
-        .lock()
-        .await
         .build_transaction_request(tx_template)
         .map_err(|err| FaucetError::InternalServerError(err.to_string()))?;
 
     // Run transaction executor & execute transaction
     let tx_result = client
-        .lock()
-        .await
         .new_transaction(tx_request)
         .map_err(|err| FaucetError::InternalServerError(err.to_string()))?;
 
@@ -90,8 +93,6 @@ pub async fn get_tokens(
 
     // Run transaction prover & send transaction to node
     client
-        .lock()
-        .await
         .submit_transaction(tx_result)
         .await
         .map_err(|err| FaucetError::InternalServerError(err.to_string()))?;
@@ -99,12 +100,12 @@ pub async fn get_tokens(
     let note_id: NoteId;
 
     // Serialize note into bytes
-    let bytes = match created_notes.first() {
-        Some(note) => {
+    let bytes = match created_notes.get_note(0) {
+        OutputNote::Full(note) => {
             note_id = note.id();
             InputNoteRecord::from(note.clone()).to_bytes()
         },
-        None => {
+        OutputNote::Header(_) => {
             return Err(
                 FaucetError::InternalServerError("Failed to generate note.".to_string()).into()
             )


### PR DESCRIPTION
Migrates faucet's revisions to the newer ones.
As a consequence of changes in how the store is handled between the client and `miden-base`'s `TransactionExecutor`, it is not `Send` and so a `Client` is instantiated on each request for now (which might be a net positive for how the faucet is supposed to work at least?).