### PR TITLE
feat: add config to make onchain genesis accounts

### DIFF
--- a/bin/node/src/commands/genesis/inputs.rs
+++ b/bin/node/src/commands/genesis/inputs.rs
@@ -25,6 +25,8 @@ pub struct BasicWalletInputs {
     pub init_seed: String,
     pub auth_scheme: AuthSchemeInput,
     pub auth_seed: String,
+    #[serde(default = "_default_true")]
+    pub on_chain: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -35,9 +37,15 @@ pub struct BasicFungibleFaucetInputs {
     pub token_symbol: String,
     pub decimals: u8,
     pub max_supply: u64,
+    #[serde(default = "_default_true")]
+    pub on_chain: bool,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub enum AuthSchemeInput {
     RpoFalcon512,
+}
+
+const fn _default_true() -> bool {
+    true
 }

--- a/bin/node/src/commands/genesis/inputs.rs
+++ b/bin/node/src/commands/genesis/inputs.rs
@@ -25,8 +25,7 @@ pub struct BasicWalletInputs {
     pub init_seed: String,
     pub auth_scheme: AuthSchemeInput,
     pub auth_seed: String,
-    #[serde(default = "_default_true")]
-    pub on_chain: bool,
+    pub storage_mode: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -37,15 +36,10 @@ pub struct BasicFungibleFaucetInputs {
     pub token_symbol: String,
     pub decimals: u8,
     pub max_supply: u64,
-    #[serde(default = "_default_true")]
-    pub on_chain: bool,
+    pub storage_mode: String,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub enum AuthSchemeInput {
     RpoFalcon512,
-}
-
-const fn _default_true() -> bool {
-    true
 }

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -126,11 +126,17 @@ fn create_accounts(
                 let (auth_scheme, auth_secret_key) =
                     parse_auth_inputs(inputs.auth_scheme, &inputs.auth_seed)?;
 
+                let storage_type = if inputs.on_chain {
+                    AccountStorageType::OnChain
+                } else {
+                    AccountStorageType::OffChain
+                };
+
                 let (account, account_seed) = create_basic_wallet(
                     init_seed,
                     auth_scheme,
                     AccountType::RegularAccountImmutableCode,
-                    AccountStorageType::OffChain,
+                    storage_type,
                 )?;
 
                 AccountData::new(account, Some(account_seed), auth_secret_key)
@@ -142,13 +148,19 @@ fn create_accounts(
                 let (auth_scheme, auth_secret_key) =
                     parse_auth_inputs(inputs.auth_scheme, &inputs.auth_seed)?;
 
+                let storage_type = if inputs.on_chain {
+                    AccountStorageType::OnChain
+                } else {
+                    AccountStorageType::OffChain
+                };
+
                 let (account, account_seed) = create_basic_fungible_faucet(
                     init_seed,
                     TokenSymbol::try_from(inputs.token_symbol.as_str())?,
                     inputs.decimals,
                     Felt::try_from(inputs.max_supply)
                         .expect("max supply value is greater than or equal to the field modulus"),
-                    AccountStorageType::OffChain,
+                    storage_type,
                     auth_scheme,
                 )?;
 

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -126,17 +126,13 @@ fn create_accounts(
                 let (auth_scheme, auth_secret_key) =
                     parse_auth_inputs(inputs.auth_scheme, &inputs.auth_seed)?;
 
-                let storage_type = if inputs.on_chain {
-                    AccountStorageType::OnChain
-                } else {
-                    AccountStorageType::OffChain
-                };
+                let storage_mode = parse_storage_mode(&inputs.storage_mode)?;
 
                 let (account, account_seed) = create_basic_wallet(
                     init_seed,
                     auth_scheme,
                     AccountType::RegularAccountImmutableCode,
-                    storage_type,
+                    storage_mode,
                 )?;
 
                 AccountData::new(account, Some(account_seed), auth_secret_key)
@@ -148,11 +144,7 @@ fn create_accounts(
                 let (auth_scheme, auth_secret_key) =
                     parse_auth_inputs(inputs.auth_scheme, &inputs.auth_seed)?;
 
-                let storage_type = if inputs.on_chain {
-                    AccountStorageType::OnChain
-                } else {
-                    AccountStorageType::OffChain
-                };
+                let storage_mode = parse_storage_mode(&inputs.storage_mode)?;
 
                 let (account, account_seed) = create_basic_fungible_faucet(
                     init_seed,
@@ -160,7 +152,7 @@ fn create_accounts(
                     inputs.decimals,
                     Felt::try_from(inputs.max_supply)
                         .expect("max supply value is greater than or equal to the field modulus"),
-                    storage_type,
+                    storage_mode,
                     auth_scheme,
                 )?;
 
@@ -207,6 +199,14 @@ fn parse_auth_inputs(
     }
 }
 
+fn parse_storage_mode(storage_type: &str) -> Result<AccountStorageType> {
+    match storage_type.to_lowercase().as_str() {
+        "on-chain" => Ok(AccountStorageType::OnChain),
+        "off-chain" => Ok(AccountStorageType::OffChain),
+        lowercase_type => Err(anyhow!("The provided value for storage_type ({}) does not match the expected values (on-chain, off-chain)", lowercase_type))
+    }
+}
+
 // TESTS
 // ================================================================================================
 
@@ -238,6 +238,7 @@ mod tests {
                 init_seed = "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                 auth_scheme = "RpoFalcon512"
                 auth_seed = "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                storage_mode = "off-chain"
 
                 [[accounts]]
                 type = "BasicFungibleFaucet"
@@ -247,6 +248,7 @@ mod tests {
                 token_symbol = "POL"
                 decimals = 12
                 max_supply = 1000000
+                storage_mode = "on-chain"
             "#,
             )?;
 
@@ -266,6 +268,10 @@ mod tests {
             // deserialize accounts and genesis_state
             let a0 = AccountData::read(a0_file_path).unwrap();
             let a1 = AccountData::read(a1_file_path).unwrap();
+
+            // assert that the accounts have the corresponding storage mode
+            assert!(!a0.account.is_on_chain());
+            assert!(a1.account.is_on_chain());
 
             let genesis_file_contents = fs::read(genesis_dat_file_path).unwrap();
             let genesis_state = GenesisState::read_from_bytes(&genesis_file_contents).unwrap();

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -199,11 +199,11 @@ fn parse_auth_inputs(
     }
 }
 
-fn parse_storage_mode(storage_type: &str) -> Result<AccountStorageType> {
-    match storage_type.to_lowercase().as_str() {
+fn parse_storage_mode(storage_mode: &str) -> Result<AccountStorageType> {
+    match storage_mode.to_lowercase().as_str() {
         "on-chain" => Ok(AccountStorageType::OnChain),
         "off-chain" => Ok(AccountStorageType::OffChain),
-        lowercase_type => Err(anyhow!("The provided value for storage_type ({}) does not match the expected values (on-chain, off-chain)", lowercase_type))
+        mode => Err(anyhow!("The provided value for storage_type ({mode}) does not match the expected values (on-chain, off-chain)"))
     }
 }
 

--- a/config/genesis.toml
+++ b/config/genesis.toml
@@ -4,19 +4,17 @@ timestamp = 1672531200
 
 [[accounts]]
 type = "BasicWallet"
+storage_mode = "off-chain"
 init_seed = "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 auth_scheme = "RpoFalcon512"
 auth_seed = "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-# To make this account on_chain uncomment the following
-# on_chain = true
 
 [[accounts]]
 type = "BasicFungibleFaucet"
+storage_mode = "off-chain"
 init_seed = "0xc123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 auth_scheme = "RpoFalcon512"
 auth_seed = "0xd123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 token_symbol = "POL"
 decimals = 12
 max_supply = 1000000
-# To make this account on_chain uncomment the following
-# on_chain = true

--- a/config/genesis.toml
+++ b/config/genesis.toml
@@ -11,7 +11,7 @@ auth_seed = "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [[accounts]]
 type = "BasicFungibleFaucet"
-storage_mode = "off-chain"
+storage_mode = "on-chain"
 init_seed = "0xc123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 auth_scheme = "RpoFalcon512"
 auth_seed = "0xd123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"

--- a/config/genesis.toml
+++ b/config/genesis.toml
@@ -7,6 +7,8 @@ type = "BasicWallet"
 init_seed = "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 auth_scheme = "RpoFalcon512"
 auth_seed = "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+# To make this account on_chain uncomment the following
+# on_chain = true
 
 [[accounts]]
 type = "BasicFungibleFaucet"
@@ -16,3 +18,5 @@ auth_seed = "0xd123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 token_symbol = "POL"
 decimals = 12
 max_supply = 1000000
+# To make this account on_chain uncomment the following
+# on_chain = true

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -31,7 +31,13 @@ impl GenesisState {
             .accounts
             .iter()
             .map(|account| {
-                BlockAccountUpdate::new(account.id(), account.hash(), AccountUpdateDetails::Private)
+                let account_update_details = if account.id().is_on_chain() {
+                    AccountUpdateDetails::New(account.clone())
+                } else {
+                    AccountUpdateDetails::Private
+                };
+
+                BlockAccountUpdate::new(account.id(), account.hash(), account_update_details)
             })
             .collect();
 


### PR DESCRIPTION
closes #305.

changes:

- added the possibility to specify whether the genesis accounts are on_chain or not. If not specified defaults to false ([11994b6](https://github.com/0xPolygonMiden/miden-node/pull/365/commits/11994b60dffd25118db344b2e00be0afe702514e))
- changed the `into_block` function of `GenesisState` so it choses the appropiate `AccountUpdateDetails` ([7bcfe25](https://github.com/0xPolygonMiden/miden-node/pull/365/commits/7bcfe25806dce9c621b67b35e612cb97422fd652))

## Steps To Test

1. initialize two miden clients
2. create a new genesis uncommenting the `on_chain = true` lines in the config for both accounts
3. start the node
4. import the accounts on each client
5. run a mint transaction on one of the clients, wait for a bit so the tx gets included in a block and sync on the other client. You should receive a nonce update on the faucet account