### PR TITLE
Synchronize block applying

### DIFF
--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -169,6 +169,21 @@ impl Db {
         })?
     }
 
+    /// Returns the latest applied block number.
+    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    pub async fn select_latest_block_num(&self) -> Result<BlockNumber> {
+        self.pool
+            .get()
+            .await?
+            .interact(sql::select_latest_block_num)
+            .await
+            .map_err(|err| {
+                DatabaseError::InteractError(format!(
+                    "Select latest block number task failed: {err}"
+                ))
+            })?
+    }
+
     /// Search for a [BlockHeader] from the database by its `block_num`.
     ///
     /// When `block_number` is [None], the latest block header is returned.

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -588,6 +588,21 @@ pub fn insert_block_header(transaction: &Transaction, block_header: &BlockHeader
     Ok(stmt.execute(params![block_header.block_num(), block_header.to_bytes()])?)
 }
 
+/// Select the latest applied block number from the DB using the given [Connection].
+///
+/// # Returns
+///
+/// The latest block number. If no blocks have been applied yet, `0` is returned.
+pub fn select_latest_block_num(conn: &mut Connection) -> Result<BlockNumber> {
+    let mut stmt =
+        conn.prepare("SELECT block_num FROM block_headers ORDER BY block_num DESC LIMIT 1")?;
+    let mut rows = stmt.query([])?;
+    match rows.next()? {
+        Some(row) => Ok(row.get(0)?),
+        None => Ok(0),
+    }
+}
+
 /// Select a [BlockHeader] from the DB by its `block_num` using the given [Connection].
 ///
 /// # Returns

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -142,6 +142,8 @@ pub enum ApplyBlockError {
     DatabaseError(#[from] DatabaseError),
     #[error("I/O error: {0}")]
     IoError(#[from] io::Error),
+    #[error("Task join error: {0}")]
+    TokioJoinError(#[from] tokio::task::JoinError),
     #[error("Concurrent write detected")]
     ConcurrentWrite,
     #[error("New block number must be 1 greater than the current block number")]


### PR DESCRIPTION
This resolves https://github.com/0xPolygonMiden/miden-node/issues/344

Now the in-memory data is being locked for the whole database commitment operation. Block saving started earlier, and it's possible to save unapplied block, so possible inconsistency is resolved by introducing "latest block number" variable which is updated in the same critical section, as commitment. Blocks later than latest block number are considered as candidates (unapplied blocks).