### PR TITLE
fix: Preserve transaction ordering in `BlockWitness`

### DIFF
--- a/crates/block-producer/src/block_builder/prover/block_witness.rs
+++ b/crates/block-producer/src/block_builder/prover/block_witness.rs
@@ -21,7 +21,7 @@ use crate::{
 /// Provides inputs to the `BlockKernel` so that it can generate the new header.
 #[derive(Debug, PartialEq)]
 pub struct BlockWitness {
-    pub(super) updated_accounts: BTreeMap<AccountId, AccountUpdateWitness>,
+    pub(super) updated_accounts: Vec<(AccountId, AccountUpdateWitness)>,
     /// (batch_index, created_notes_root) for batches that contain notes
     pub(super) batch_created_notes_roots: BTreeMap<usize, Digest>,
     pub(super) produced_nullifiers: BTreeMap<Nullifier, SmtProof>,
@@ -98,8 +98,8 @@ impl BlockWitness {
 
     /// Returns an iterator over all transactions which affected accounts in the block with corresponding account IDs.
     pub(super) fn transactions(&self) -> impl Iterator<Item = (TransactionId, AccountId)> + '_ {
-        self.updated_accounts.iter().flat_map(|(&account_id, update)| {
-            update.transactions.iter().map(move |&tx_id| (tx_id, account_id))
+        self.updated_accounts.iter().flat_map(|(account_id, update)| {
+            update.transactions.iter().map(move |tx_id| (*tx_id, *account_id))
         })
     }
 
@@ -247,8 +247,8 @@ impl BlockWitness {
 
         // Account stack inputs
         let mut num_accounts_updated: u64 = 0;
-        for (idx, (&account_id, account_update)) in self.updated_accounts.iter().enumerate() {
-            stack_inputs.push(account_id.into());
+        for (idx, (account_id, account_update)) in self.updated_accounts.iter().enumerate() {
+            stack_inputs.push((*account_id).into());
             stack_inputs.extend(account_update.final_state_hash);
 
             let idx = u64::try_from(idx).expect("can't be more than 2^64 - 1 accounts");


### PR DESCRIPTION
We found that the integration tests on the client were sometimes failing after the recent changes related to adding the transactions to the block structures. @mFragaBA investigated a bit and saw that the node was logging an `InvalidTxHash` error which implied problems with checking the consistency between the header and the block's transactions, concluding that the tests were flaky because this would only occur when a couple of transactions for different accounts are batched into the same block. This is because the `BlockWitness` keeps the transaction data in a `BTreeMap`, which breaks ordering with the iterator. There are structs that would preserve it while providing dictionary functionality, but in this case it seems we can just replace it with a `Vec`.
Ran the tests with these changes locally and [in the CI](https://github.com/0xPolygonMiden/miden-client/actions/runs/9469968083/job/26090499353) and it seems tests consistently pass again.