### PR TITLE
feat: store and retrieve aux field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Added `aux` column to notes table (#384).
 * Standardised CI and Makefile across Miden repositories (#367)
 * Remove client dependency from faucet (#368).
 * Return a list of committed transactions from the state sync endpoint (#377).

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -30,6 +30,7 @@ CREATE TABLE
     note_type   INTEGER NOT NULL, -- 1-Public (0b01), 2-OffChain (0b10), 3-Encrypted (0b11)
     sender      INTEGER NOT NULL,
     tag         INTEGER NOT NULL,
+    aux         INTEGER NOT NULL,
     merkle_path BLOB    NOT NULL,
     details     BLOB,
 

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -58,6 +58,8 @@ pub enum DatabaseError {
     DeserializationError(DeserializationError),
     #[error("Corrupted data: {0}")]
     CorruptedData(String),
+    #[error("Invalid Felt: {0}")]
+    InvalidFelt(String),
     #[error("Block applying was broken because of closed channel on state side: {0}")]
     ApplyBlockFailedClosedChannel(RecvError),
     #[error("Account {0} not found in the database")]


### PR DESCRIPTION
addresses #342.

I tried testing this using the integration tests on miden-client but they fail because I still can't use any other value than 0 for the aux field until https://github.com/0xPolygonMiden/miden-base/issues/731 is done. 

That being said, I somewhat tested this change by changing the hardcoded 0 value in the transaction kernel's create_note and using the same value for notes on the integration tests. They ran successfully with some fixes present in https://github.com/0xPolygonMiden/miden-client/pull/381 (mainly removing hardcoded values from the client side)

- the client was able to consume the notes
- I checked the node's db using `sqlite3` and the aux column of `notes` had the proper values