### PR TITLE
docs: fix invalid links in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ At this point, we are developing the Miden node for a centralized operator. Thus
 
 The Miden node is made up of 3 main components, which communicate over gRPC:
 
-- **[RPC](rpc):** an externally-facing component through which clients can interact with the node. It receives client requests (e.g., to synchronize with the latest state of the chain, or to submit transactions), performs basic validation, and forwards the requests to the appropriate internal components.
-- **[Store](store):** maintains the state of the chain. It serves as the "source of truth" for the chain - i.e., if it is not in the store, the node does not consider it to be part of the chain.
-- **[Block Producer](block-producer):** accepts transactions from the RPC component, creates blocks containing those transactions, and sends them to the store.
+- **[RPC](crates/rpc):** an externally-facing component through which clients can interact with the node. It receives client requests (e.g., to synchronize with the latest state of the chain, or to submit transactions), performs basic validation, and forwards the requests to the appropriate internal components.
+- **[Store](crates/store):** maintains the state of the chain. It serves as the "source of truth" for the chain - i.e., if it is not in the store, the node does not consider it to be part of the chain.
+- **[Block Producer](crates/block-producer):** accepts transactions from the RPC component, creates blocks containing those transactions, and sends them to the store.
 
 All 3 components can either run as one process, or each component can run in its own process. See the [Running the node](#running-the-node) section for more details.
 
@@ -86,9 +86,9 @@ Note that the `store.genesis_filepath` field in the config file must point to th
 If you intend on running the node as different processes, you will need to install and run each component separately.
 Please, refer to each component's documentation:
 
-- [RPC](rpc/README.md#usage)
-- [Store](store/README.md#usage)
-- [Block Producer](block-producer/README.md#usage)
+- [RPC](crates/rpc/README.md#usage)
+- [Store](crates/store/README.md#usage)
+- [Block Producer](crates/block-producer/README.md#usage)
 
 Each directory containing the executables also contains an example configuration file. Make sure that the configuration files are mutually consistent. That is, make sure that the URLs are valid and point to the right endpoint.
 


### PR DESCRIPTION
Fix the links to `rpc`, `store`, `block_producer` crates in the Readme.