### PR TITLE
feat: Add init commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Add `init` command for node and faucet (#392).
 * Added crate to distribute node RPC protobuf files (#391).
 * Changed state sync endpoint to return a list of `TransactionSummary` objects instead of just transaction IDs (#386).
 * Fixed faucet note script so that it uses the `aux` input (#387).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "rand_chacha",
  "serde",
  "thiserror",
+ "toml",
  "tonic",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "rand_chacha",
  "serde",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "actix-files",
  "actix-web",
  "async-mutex",
+ "clap",
  "derive_more",
  "figment",
  "miden-lib",

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -33,5 +33,6 @@ rand = { version = "0.8.5" }
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
+toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -21,6 +21,7 @@ actix-cors = "0.7.0"
 actix-files = "0.6.5"
 actix-web = "4"
 async-mutex = "1.4.0"
+clap = { version = "4.3", features = ["derive"] }
 derive_more = "0.99.17"
 figment = { version = "0.10", features = ["toml", "env"] }
 miden-lib = { workspace = true, features = ["concurrent"] }

--- a/bin/faucet/README.md
+++ b/bin/faucet/README.md
@@ -14,7 +14,7 @@ make docker-run-node
 make install-faucet-testing
 ```
 
-3. Create the faucet configuration file:
+3. Create the default faucet configuration file:
 ```bash
 miden-faucet init
 ```

--- a/bin/faucet/README.md
+++ b/bin/faucet/README.md
@@ -5,13 +5,23 @@ This crate contains a binary for running a Miden rollup faucet.
 ## Running the faucet
 1. Run a local node, for example using the docker image. From the "miden-node" repo root run the following commands:
 ```bash
-cargo make docker-build-node
-cargo make docker-run-node
+make docker-build-node
+make docker-run-node
 ```
 
-2. From the "miden-node" repo root run the faucet:
+2. Install the faucet (with the "testing" feature):
 ```bash
-cargo run --bin miden-faucet  --features testing --release
+make install-faucet-testing
+```
+
+3. Create the faucet configuration file:
+```bash
+miden-faucet init
+```
+
+4. Start the faucet server:
+```bash
+miden-faucet start
 ```
 
 After a few seconds you may go to `http://localhost:8080` and see the faucet UI.

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::{Endpoint, FAUCET_SERVER_PORT, MIDEN_NODE_PORT};
+use miden_node_utils::config::{Endpoint, DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT};
 use serde::{Deserialize, Serialize};
 
 // Faucet config
@@ -47,8 +47,8 @@ impl Display for FaucetConfig {
 impl Default for FaucetConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::localhost(FAUCET_SERVER_PORT),
-            node_url: Endpoint::localhost(MIDEN_NODE_PORT).to_string(),
+            endpoint: Endpoint::localhost(DEFAULT_FAUCET_SERVER_PORT),
+            node_url: Endpoint::localhost(DEFAULT_NODE_RPC_PORT).to_string(),
             timeout_ms: 10000,
             database_filepath: PathBuf::from("store.sqlite3"),
             asset_amount_options: vec![100, 500, 1000],

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::Endpoint;
+use miden_node_utils::config::{Endpoint, FAUCET_SERVER_PORT, MIDEN_NODE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Faucet config
@@ -41,5 +41,20 @@ impl Display for FaucetConfig {
             "{{ endpoint: \"{}\",  database_filepath: {:?}, asset_amount_options: {:?}, token_symbol: {}, decimals: {}, max_supply: {} }}",
             self.endpoint, self.database_filepath, self.asset_amount_options, self.token_symbol, self.decimals, self.max_supply
         ))
+    }
+}
+
+impl Default for FaucetConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Endpoint::localhost(FAUCET_SERVER_PORT),
+            node_url: Endpoint::localhost(MIDEN_NODE_PORT).to_string(),
+            timeout_ms: 10000,
+            database_filepath: PathBuf::from("store.sqlite3"),
+            asset_amount_options: vec![100, 500, 1000],
+            token_symbol: "POL".to_string(),
+            decimals: 8,
+            max_supply: 1000000,
+        }
     }
 }

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -12,6 +12,7 @@ use actix_web::{
     middleware::{DefaultHeaders, Logger},
     web, App, HttpServer,
 };
+use clap::{Parser, Subcommand};
 use errors::FaucetError;
 use miden_node_utils::config::load_config;
 use state::FaucetState;
@@ -26,8 +27,32 @@ use crate::{
 // =================================================================================================
 
 const COMPONENT: &str = "miden-faucet";
+const FAUCET_CONFIG_FILE_PATH: &str = "miden-faucet.toml";
 
-const FAUCET_CONFIG_FILE_PATH: &str = "config/miden-faucet.toml";
+// COMMANDS
+// ================================================================================================
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Start the faucet server
+    Start {
+        #[arg(short, long, value_name = "FILE", default_value = FAUCET_CONFIG_FILE_PATH)]
+        config: PathBuf,
+    },
+
+    /// Generates default configuration file for the faucet
+    Init {
+        #[arg(short, long, default_value = FAUCET_CONFIG_FILE_PATH)]
+        config_path: String,
+    },
+}
 
 // MAIN
 // =================================================================================================
@@ -37,37 +62,52 @@ async fn main() -> Result<(), FaucetError> {
     miden_node_utils::logging::setup_logging()
         .map_err(|err| FaucetError::StartError(err.to_string()))?;
 
-    let config: FaucetConfig = load_config(PathBuf::from(FAUCET_CONFIG_FILE_PATH).as_path())
-        .extract()
-        .map_err(|err| FaucetError::ConfigurationError(err.to_string()))?;
+    let cli = Cli::parse();
 
-    let faucet_state = FaucetState::new(config.clone()).await?;
+    match &cli.command {
+        Command::Start { config } => {
+            let config: FaucetConfig = load_config(config.as_path())
+                .extract()
+                .map_err(|err| FaucetError::ConfigurationError(err.to_string()))?;
 
-    info!(target: COMPONENT, %config, "Initializing server");
+            let faucet_state = FaucetState::new(config.clone()).await?;
 
-    info!("Server is now running on: {}", config.endpoint_url());
+            info!(target: COMPONENT, %config, "Initializing server");
 
-    HttpServer::new(move || {
-        let cors = Cors::default().allow_any_origin().allow_any_method();
-        App::new()
-            .app_data(web::Data::new(faucet_state.clone()))
-            .wrap(cors)
-            .wrap(Logger::default())
-            .wrap(DefaultHeaders::new().add(("Cache-Control", "no-cache")))
-            .service(get_metadata)
-            .service(get_tokens)
-            .service(
-                Files::new("/", "bin/faucet/src/static")
-                    .use_etag(false)
-                    .use_last_modified(false)
-                    .index_file("index.html"),
-            )
-    })
-    .bind((config.endpoint.host, config.endpoint.port))
-    .map_err(|err| FaucetError::StartError(err.to_string()))?
-    .run()
-    .await
-    .map_err(|err| FaucetError::StartError(err.to_string()))?;
+            info!("Server is now running on: {}", config.endpoint_url());
+
+            HttpServer::new(move || {
+                let cors = Cors::default().allow_any_origin().allow_any_method();
+                App::new()
+                    .app_data(web::Data::new(faucet_state.clone()))
+                    .wrap(cors)
+                    .wrap(Logger::default())
+                    .wrap(DefaultHeaders::new().add(("Cache-Control", "no-cache")))
+                    .service(get_metadata)
+                    .service(get_tokens)
+                    .service(
+                        Files::new("/", "bin/faucet/src/static")
+                            .use_etag(false)
+                            .use_last_modified(false)
+                            .index_file("index.html"),
+                    )
+            })
+            .bind((config.endpoint.host, config.endpoint.port))
+            .map_err(|err| FaucetError::StartError(err.to_string()))?
+            .run()
+            .await
+            .map_err(|err| FaucetError::StartError(err.to_string()))?;
+        },
+        Command::Init { config_path } => {
+            let current_dir = std::env::current_dir().map_err(|err| {
+                FaucetError::ConfigurationError(format!("failed to open current directory: {err}"))
+            })?;
+
+            let mut config = current_dir.clone();
+
+            config.push(config_path);
+        },
+    }
 
     Ok(())
 }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -29,6 +29,7 @@ miden-objects = { workspace = true }
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
+toml = { version = "0.8" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/bin/node/src/commands/genesis/inputs.rs
+++ b/bin/node/src/commands/genesis/inputs.rs
@@ -48,7 +48,6 @@ pub enum AuthSchemeInput {
 
 impl Default for GenesisInput {
     fn default() -> Self {
-        const SEED_SUFFIX: &str = "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         Self {
             version: 1,
             timestamp: SystemTime::now()
@@ -57,15 +56,19 @@ impl Default for GenesisInput {
                 .as_secs() as u32,
             accounts: vec![
                 AccountInput::BasicWallet(BasicWalletInputs {
-                    init_seed: "0xa".to_string() + SEED_SUFFIX,
+                    init_seed: "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_string(),
                     auth_scheme: AuthSchemeInput::RpoFalcon512,
-                    auth_seed: "0xb".to_string() + SEED_SUFFIX,
+                    auth_seed: "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_string(),
                     storage_mode: "off-chain".to_string(),
                 }),
                 AccountInput::BasicFungibleFaucet(BasicFungibleFaucetInputs {
-                    init_seed: "0xc".to_string() + SEED_SUFFIX,
+                    init_seed: "0xc123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_string(),
                     auth_scheme: AuthSchemeInput::RpoFalcon512,
-                    auth_seed: "0xd".to_string() + SEED_SUFFIX,
+                    auth_seed: "0xd123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                        .to_string(),
                     token_symbol: "POL".to_string(),
                     decimals: 12,
                     max_supply: 1000000,

--- a/bin/node/src/commands/genesis/inputs.rs
+++ b/bin/node/src/commands/genesis/inputs.rs
@@ -1,4 +1,6 @@
-use serde::Deserialize;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
 
 // INPUT HELPER STRUCTS
 // ================================================================================================
@@ -6,21 +8,21 @@ use serde::Deserialize;
 /// Input types are helper structures designed for parsing and deserializing genesis input files.
 /// They serve as intermediary representations, facilitating the conversion from
 /// placeholder types (like `GenesisInput`) to internal types (like `GenesisState`).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GenesisInput {
     pub version: u32,
     pub timestamp: u32,
     pub accounts: Vec<AccountInput>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum AccountInput {
     BasicWallet(BasicWalletInputs),
     BasicFungibleFaucet(BasicFungibleFaucetInputs),
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BasicWalletInputs {
     pub init_seed: String,
     pub auth_scheme: AuthSchemeInput,
@@ -28,7 +30,7 @@ pub struct BasicWalletInputs {
     pub storage_mode: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BasicFungibleFaucetInputs {
     pub init_seed: String,
     pub auth_scheme: AuthSchemeInput,
@@ -39,7 +41,37 @@ pub struct BasicFungibleFaucetInputs {
     pub storage_mode: String,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub enum AuthSchemeInput {
     RpoFalcon512,
+}
+
+impl Default for GenesisInput {
+    fn default() -> Self {
+        const SEED_SUFFIX: &str = "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        Self {
+            version: 1,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Current timestamp should be greater than unix epoch")
+                .as_secs() as u32,
+            accounts: vec![
+                AccountInput::BasicWallet(BasicWalletInputs {
+                    init_seed: "0xa".to_string() + SEED_SUFFIX,
+                    auth_scheme: AuthSchemeInput::RpoFalcon512,
+                    auth_seed: "0xb".to_string() + SEED_SUFFIX,
+                    storage_mode: "off-chain".to_string(),
+                }),
+                AccountInput::BasicFungibleFaucet(BasicFungibleFaucetInputs {
+                    init_seed: "0xc".to_string() + SEED_SUFFIX,
+                    auth_scheme: AuthSchemeInput::RpoFalcon512,
+                    auth_seed: "0xd".to_string() + SEED_SUFFIX,
+                    token_symbol: "POL".to_string(),
+                    decimals: 12,
+                    max_supply: 1000000,
+                    storage_mode: "on-chain".to_string(),
+                }),
+            ],
+        }
+    }
 }

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use inputs::{AccountInput, AuthSchemeInput, GenesisInput};
+pub use inputs::{AccountInput, AuthSchemeInput, GenesisInput};
 use miden_lib::{
     accounts::{faucets::create_basic_fungible_faucet, wallets::create_basic_wallet},
     AuthScheme,

--- a/bin/node/src/commands/init.rs
+++ b/bin/node/src/commands/init.rs
@@ -1,0 +1,28 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
+use anyhow::{anyhow, Result};
+
+use crate::config::NodeConfig;
+
+// INIT
+// ===================================================================================================
+
+pub fn init_config_files(config_file_path: PathBuf, _genesis_file_path: PathBuf) -> Result<()> {
+    let config = NodeConfig::default();
+    let config_as_toml_string = toml::to_string(&config)
+        .map_err(|err| anyhow!("Failed to serialize default config: {}", err))?;
+
+    let mut file_handle = File::options()
+        .write(true)
+        .create_new(true)
+        .open(&config_file_path)
+        .map_err(|err| anyhow!("Error opening the file: {err}"))?;
+
+    file_handle
+        .write(config_as_toml_string.as_bytes())
+        .map_err(|err| anyhow!("Error writing to file: {err}"))?;
+
+    println!("Config file successfully created at: {:?}", config_file_path);
+
+    Ok(())
+}

--- a/bin/node/src/commands/init.rs
+++ b/bin/node/src/commands/init.rs
@@ -2,27 +2,41 @@ use std::{fs::File, io::Write, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 
-use crate::config::NodeConfig;
+use crate::{commands::genesis::GenesisInput, config::NodeConfig};
 
 // INIT
 // ===================================================================================================
 
-pub fn init_config_files(config_file_path: PathBuf, _genesis_file_path: PathBuf) -> Result<()> {
+pub fn init_config_files(config_file_path: PathBuf, genesis_file_path: PathBuf) -> Result<()> {
     let config = NodeConfig::default();
     let config_as_toml_string = toml::to_string(&config)
         .map_err(|err| anyhow!("Failed to serialize default config: {}", err))?;
 
+    write_string_in_file(config_as_toml_string, &config_file_path)?;
+
+    println!("Config file successfully created at: {:?}", config_file_path);
+
+    let genesis = GenesisInput::default();
+    let genesis_as_toml_string = toml::to_string(&genesis)
+        .map_err(|err| anyhow!("Failed to serialize default config: {}", err))?;
+
+    write_string_in_file(genesis_as_toml_string, &genesis_file_path)?;
+
+    println!("Genesis config file successfully created at: {:?}", genesis_file_path);
+
+    Ok(())
+}
+
+fn write_string_in_file(content: String, path: &PathBuf) -> Result<()> {
     let mut file_handle = File::options()
         .write(true)
         .create_new(true)
-        .open(&config_file_path)
+        .open(path)
         .map_err(|err| anyhow!("Error opening the file: {err}"))?;
 
     file_handle
-        .write(config_as_toml_string.as_bytes())
+        .write(content.as_bytes())
         .map_err(|err| anyhow!("Error writing to file: {err}"))?;
-
-    println!("Config file successfully created at: {:?}", config_file_path);
 
     Ok(())
 }

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -1,3 +1,4 @@
 mod genesis;
+pub mod init;
 pub mod start;
 pub use genesis::make_genesis;

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -11,6 +11,16 @@ pub struct NodeConfig {
     pub store: Option<StoreConfig>,
 }
 
+impl Default for NodeConfig {
+    fn default() -> Self {
+        Self {
+            block_producer: Some(Default::default()),
+            rpc: Some(Default::default()),
+            store: Some(Default::default()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -67,7 +67,7 @@ pub enum Command {
         #[arg(short, long, default_value = NODE_CONFIG_FILE_PATH)]
         config_path: String,
 
-        #[arg(short, long, default_value = DEFAULT_GENESIS_FILE_PATH)]
+        #[arg(short, long, default_value = DEFAULT_GENESIS_INPUTS_PATH)]
         genesis_path: String,
     },
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
-use commands::start::{start_block_producer, start_node, start_rpc, start_store};
+use commands::{
+    init::init_config_files,
+    start::{start_block_producer, start_node, start_rpc, start_store},
+};
 use config::NodeConfig;
 use miden_node_utils::config::load_config;
 
@@ -55,6 +58,18 @@ pub enum Command {
         #[arg(short, long)]
         force: bool,
     },
+
+    /// Generates default configuration files for the node
+    ///
+    /// This command creates two files (miden-node.toml and genesis.toml) that provide configuration
+    /// details to the node. These files may be modified to change the node behavior.
+    Init {
+        #[arg(short, long, default_value = NODE_CONFIG_FILE_PATH)]
+        config_path: String,
+
+        #[arg(short, long, default_value = DEFAULT_GENESIS_FILE_PATH)]
+        genesis_path: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -94,6 +109,18 @@ async fn main() -> anyhow::Result<()> {
         },
         Command::MakeGenesis { output_path, force, inputs_path } => {
             commands::make_genesis(inputs_path, output_path, force)
+        },
+        Command::Init { config_path, genesis_path } => {
+            let current_dir = std::env::current_dir()
+                .map_err(|err| anyhow!("failed to open current directory: {err}"))?;
+
+            let mut config = current_dir.clone();
+            let mut genesis = current_dir.clone();
+
+            config.push(config_path);
+            genesis.push(genesis_path);
+
+            init_config_files(config, genesis)
         },
     }
 }

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use miden_node_utils::config::{Endpoint, BLOCK_PRODUCER_PORT, STORE_PORT};
+use miden_node_utils::config::{Endpoint, DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_STORE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -41,8 +41,8 @@ impl Display for BlockProducerConfig {
 impl Default for BlockProducerConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::localhost(BLOCK_PRODUCER_PORT),
-            store_url: Endpoint::localhost(STORE_PORT).to_string(),
+            endpoint: Endpoint::localhost(DEFAULT_BLOCK_PRODUCER_PORT),
+            store_url: Endpoint::localhost(DEFAULT_STORE_PORT).to_string(),
             verify_tx_proofs: true,
         }
     }

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use miden_node_utils::config::Endpoint;
+use miden_node_utils::config::{Endpoint, BLOCK_PRODUCER_PORT, STORE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -35,5 +35,15 @@ impl Display for BlockProducerConfig {
             "{{ endpoint: \"{}\", store_url: \"{}\" }}",
             self.endpoint, self.store_url
         ))
+    }
+}
+
+impl Default for BlockProducerConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Endpoint::localhost(BLOCK_PRODUCER_PORT),
+            store_url: Endpoint::localhost(STORE_PORT).to_string(),
+            verify_tx_proofs: true,
+        }
     }
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use miden_node_utils::config::Endpoint;
+use miden_node_utils::config::{Endpoint, BLOCK_PRODUCER_PORT, MIDEN_NODE_PORT, STORE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -27,5 +27,18 @@ impl Display for RpcConfig {
             "{{ endpoint: \"{}\", store_url: \"{}\", block_producer_url: \"{}\" }}",
             self.endpoint, self.store_url, self.block_producer_url
         ))
+    }
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Endpoint {
+                host: "0.0.0.0".to_string(),
+                port: MIDEN_NODE_PORT,
+            },
+            store_url: Endpoint::localhost(STORE_PORT).to_string(),
+            block_producer_url: Endpoint::localhost(BLOCK_PRODUCER_PORT).to_string(),
+        }
     }
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter};
 
-use miden_node_utils::config::{Endpoint, BLOCK_PRODUCER_PORT, MIDEN_NODE_PORT, STORE_PORT};
+use miden_node_utils::config::{
+    Endpoint, DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_NODE_RPC_PORT, DEFAULT_STORE_PORT,
+};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -35,10 +37,10 @@ impl Default for RpcConfig {
         Self {
             endpoint: Endpoint {
                 host: "0.0.0.0".to_string(),
-                port: MIDEN_NODE_PORT,
+                port: DEFAULT_NODE_RPC_PORT,
             },
-            store_url: Endpoint::localhost(STORE_PORT).to_string(),
-            block_producer_url: Endpoint::localhost(BLOCK_PRODUCER_PORT).to_string(),
+            store_url: Endpoint::localhost(DEFAULT_STORE_PORT).to_string(),
+            block_producer_url: Endpoint::localhost(DEFAULT_BLOCK_PRODUCER_PORT).to_string(),
         }
     }
 }

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::Endpoint;
+use miden_node_utils::config::{Endpoint, STORE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -33,5 +33,17 @@ impl Display for StoreConfig {
             "{{ endpoint: \"{}\",  database_filepath: {:?}, genesis_filepath: {:?}, blockstore_dir: {:?} }}",
             self.endpoint, self.database_filepath, self.genesis_filepath, self.blockstore_dir
         ))
+    }
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        const NODE_STORE_DIR: &str = "./";
+        Self {
+            endpoint: Endpoint::localhost(STORE_PORT),
+            database_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "miden-store.sqlite3"),
+            genesis_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "genesis.dat"),
+            blockstore_dir: PathBuf::from(NODE_STORE_DIR.to_string() + "blocks"),
+        }
     }
 }

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::{Endpoint, STORE_PORT};
+use miden_node_utils::config::{Endpoint, DEFAULT_STORE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -40,7 +40,7 @@ impl Default for StoreConfig {
     fn default() -> Self {
         const NODE_STORE_DIR: &str = "./";
         Self {
-            endpoint: Endpoint::localhost(STORE_PORT),
+            endpoint: Endpoint::localhost(DEFAULT_STORE_PORT),
             database_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "miden-store.sqlite3"),
             genesis_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "genesis.dat"),
             blockstore_dir: PathBuf::from(NODE_STORE_DIR.to_string() + "blocks"),

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -12,6 +12,10 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 
+pub const MIDEN_NODE_PORT: u16 = 57291;
+pub const BLOCK_PRODUCER_PORT: u16 = 48046;
+pub const STORE_PORT: u16 = 28943;
+
 /// The `(host, port)` pair for the server's listening socket.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Endpoint {
@@ -19,6 +23,12 @@ pub struct Endpoint {
     pub host: String,
     /// Port number used by the store.
     pub port: u16,
+}
+
+impl Endpoint {
+    pub fn localhost(port: u16) -> Self {
+        Endpoint { host: "localhost".to_string(), port }
+    }
 }
 
 impl ToSocketAddrs for Endpoint {

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 pub const MIDEN_NODE_PORT: u16 = 57291;
 pub const BLOCK_PRODUCER_PORT: u16 = 48046;
 pub const STORE_PORT: u16 = 28943;
+pub const FAUCET_SERVER_PORT: u16 = 8080;
 
 /// The `(host, port)` pair for the server's listening socket.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -12,10 +12,10 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 
-pub const MIDEN_NODE_PORT: u16 = 57291;
-pub const BLOCK_PRODUCER_PORT: u16 = 48046;
-pub const STORE_PORT: u16 = 28943;
-pub const FAUCET_SERVER_PORT: u16 = 8080;
+pub const DEFAULT_NODE_RPC_PORT: u16 = 57291;
+pub const DEFAULT_BLOCK_PRODUCER_PORT: u16 = 48046;
+pub const DEFAULT_STORE_PORT: u16 = 28943;
+pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
 
 /// The `(host, port)` pair for the server's listening socket.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
closes #385

This PR adds `init` commands in the node and faucet to generate default configuration files.

- `miden-node init` creates both "miden-node.toml" and "genesis.toml".
- `miden-faucet init` creates "miden-faucet.toml".