### PR TITLE
Addressed review comments for #390

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.4.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#861837b2f5ce4771af3a627e7e06f8cdcb672e80"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#c29d1def0bca6a66115a6011df1171d836563b90"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.4.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#861837b2f5ce4771af3a627e7e06f8cdcb672e80"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#c29d1def0bca6a66115a6011df1171d836563b90"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.4.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#861837b2f5ce4771af3a627e7e06f8cdcb672e80"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#c29d1def0bca6a66115a6011df1171d836563b90"
 dependencies = [
  "miden-lib",
  "miden-objects",

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -1,10 +1,16 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    mem,
+};
 
 use miden_objects::{
     accounts::AccountId,
     batches::BatchNoteTree,
     block::BlockAccountUpdate,
-    crypto::hash::blake::{Blake3Digest, Blake3_256},
+    crypto::{
+        hash::blake::{Blake3Digest, Blake3_256},
+        merkle::MerklePath,
+    },
     notes::{NoteId, Nullifier},
     transaction::{InputNoteCommitment, OutputNote, TransactionId, TxAccountUpdate},
     Digest, MAX_NOTES_PER_BATCH,
@@ -28,27 +34,36 @@ pub struct TransactionBatch {
     updated_accounts: Vec<(TransactionId, TxAccountUpdate)>,
     input_notes: Vec<InputNoteCommitment>,
     output_notes_smt: BatchNoteTree,
-    output_notes: BTreeMap<NoteId, OutputNote>,
+    output_notes: Vec<OutputNote>,
 }
 
 impl TransactionBatch {
-    // CONSTRUCTOR
+    // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
+
     /// Returns a new [TransactionBatch] instantiated from the provided vector of proven
-    /// transactions.
+    /// transactions. If a map of unauthenticated notes found in the store is provided, it is used
+    /// for transforming unauthenticated notes into authenticated notes.
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The number of created notes across all transactions exceeds 4096.
+    /// - The number of output notes across all transactions exceeds 4096.
+    /// - There are duplicated output notes or unauthenticated notes found across all transactions
+    ///   in the batch.
+    /// - Hashes for corresponding input notes and output notes don't match.
     ///
     /// TODO: enforce limit on the number of created nullifiers.
     #[instrument(target = "miden-block-producer", name = "new_batch", skip_all, err)]
-    pub fn new(txs: Vec<ProvenTransaction>) -> Result<Self, BuildBatchError> {
+    pub fn new(
+        txs: Vec<ProvenTransaction>,
+        found_unauthenticated_notes: Option<BTreeMap<NoteId, MerklePath>>,
+    ) -> Result<Self, BuildBatchError> {
         let id = Self::compute_id(&txs);
 
         // Populate batch output notes and updated accounts.
         let mut updated_accounts = vec![];
-        let mut output_notes = BTreeMap::new();
+        let mut output_notes = vec![];
+        let mut output_note_index = BTreeMap::new();
         let mut unauthenticated_input_notes = BTreeSet::new();
         for tx in &txs {
             // TODO: we need to handle a possibility that a batch contains multiple transactions against
@@ -57,9 +72,10 @@ impl TransactionBatch {
             //       into a single "update" `A` to `C`.
             updated_accounts.push((tx.id(), tx.account_update().clone()));
             for note in tx.output_notes().iter() {
-                if output_notes.insert(note.id(), note.clone()).is_some() {
+                if output_note_index.insert(note.id(), output_notes.len()).is_some() {
                     return Err(BuildBatchError::DuplicateOutputNote(note.id(), txs.clone()));
                 }
+                output_notes.push(Some(note.clone()));
             }
             // Check unauthenticated input notes for duplicates:
             for note in tx.get_unauthenticated_notes() {
@@ -82,27 +98,41 @@ impl TransactionBatch {
         let mut input_notes = vec![];
         for input_note in txs.iter().flat_map(|tx| tx.input_notes().iter()) {
             // Header is presented only for unauthenticated notes.
-            if let Some(input_note_header) = input_note.header() {
-                let id = input_note_header.id();
-                if let Some(output_note) = output_notes.remove(&id) {
-                    let input_hash = input_note_header.hash();
-                    let output_hash = output_note.hash();
-                    if output_hash != input_hash {
-                        return Err(BuildBatchError::NoteHashesMismatch {
-                            id,
-                            input_hash,
-                            output_hash,
-                            txs: txs.clone(),
-                        });
+            let input_note = match input_note.header() {
+                Some(input_note_header) => {
+                    let id = input_note_header.id();
+                    if let Some(note_index) = output_note_index.remove(&id) {
+                        if let Some(output_note) = mem::take(&mut output_notes[note_index]) {
+                            let input_hash = input_note_header.hash();
+                            let output_hash = output_note.hash();
+                            if output_hash != input_hash {
+                                return Err(BuildBatchError::NoteHashesMismatch {
+                                    id,
+                                    input_hash,
+                                    output_hash,
+                                    txs: txs.clone(),
+                                });
+                            }
+
+                            // Don't add input notes if corresponding output notes consumed in the same batch.
+                            continue;
+                        }
                     }
 
-                    // Don't add input notes if corresponding output notes consumed in the same batch.
-                    continue;
-                }
-            }
-
-            input_notes.push(input_note.clone());
+                    match found_unauthenticated_notes {
+                        Some(ref found_notes) => match found_notes.get(&input_note_header.id()) {
+                            Some(_path) => input_note.nullifier().into(),
+                            None => input_note.clone(),
+                        },
+                        None => input_note.clone(),
+                    }
+                },
+                None => input_note.clone(),
+            };
+            input_notes.push(input_note)
         }
+
+        let output_notes: Vec<_> = output_notes.into_iter().flatten().collect();
 
         if output_notes.len() > MAX_NOTES_PER_BATCH {
             return Err(BuildBatchError::TooManyNotesCreated(output_notes.len(), txs));
@@ -110,7 +140,7 @@ impl TransactionBatch {
 
         // Build the output notes SMT.
         let output_notes_smt = BatchNoteTree::with_contiguous_leaves(
-            output_notes.iter().map(|(&id, note)| (id, note.metadata())),
+            output_notes.iter().map(|note| (note.id(), note.metadata())),
         )
         .expect("Unreachable: fails only if the output note list contains duplicates");
 
@@ -168,7 +198,7 @@ impl TransactionBatch {
     }
 
     /// Returns output notes list.
-    pub fn output_notes(&self) -> &BTreeMap<NoteId, OutputNote> {
+    pub fn output_notes(&self) -> &Vec<OutputNote> {
         &self.output_notes
     }
 

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -63,13 +63,10 @@ impl TransactionBatch {
                 }
             }
             // Check unauthenticated input notes for duplicates:
-            for note in tx.input_notes().iter() {
-                // Header is presented only for unauthenticated notes.
-                if let Some(header) = note.header() {
-                    let id = header.id();
-                    if !unauthenticated_input_notes.insert(id) {
-                        return Err(BuildBatchError::DuplicateUnauthenticatedNote(id, txs.clone()));
-                    }
+            for note in tx.get_unauthenticated_notes() {
+                let id = note.id();
+                if !unauthenticated_input_notes.insert(id) {
+                    return Err(BuildBatchError::DuplicateUnauthenticatedNote(id, txs.clone()));
                 }
             }
         }
@@ -90,14 +87,7 @@ impl TransactionBatch {
                 let id = input_note_header.id();
                 if let Some(output_note) = output_notes.remove(&id) {
                     let input_hash = input_note_header.hash();
-
-                    // TODO: substitute with just next line once [OutputNote::hash] is implemented
-                    // let output_hash = output_note.hash();
-                    let OutputNote::Header(output_header) = output_note.shrink() else {
-                        unreachable!()
-                    };
-                    let output_hash = output_header.hash();
-
+                    let output_hash = output_note.hash();
                     if output_hash != input_hash {
                         return Err(BuildBatchError::NoteHashesMismatch {
                             id,

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -103,7 +103,7 @@ impl TransactionBatch {
             return Err(BuildBatchError::TooManyNotesCreated(output_notes.len(), txs));
         }
 
-        // TODO: document under what circumstances SMT creating can fail
+        // Build the output notes SMT. Will fail if the output note list contains duplicates.
         let output_notes_smt = BatchNoteTree::with_contiguous_leaves(
             output_notes.iter().map(|note| (note.id(), note.metadata())),
         )

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -132,7 +132,7 @@ where
                     .read()
                     .await
                     .iter()
-                    .flat_map(|batch| batch.output_notes().iter().map(OutputNote::id)),
+                    .flat_map(|batch| batch.output_notes().keys().copied()),
             )
             .collect();
 

--- a/crates/block-producer/src/batch_builder/tests/mod.rs
+++ b/crates/block-producer/src/batch_builder/tests/mod.rs
@@ -155,5 +155,5 @@ fn dummy_tx_batch(starting_account_index: u32, num_txs_in_batch: usize) -> Trans
             MockProvenTxBuilder::with_account_index(starting_account_index + index as u32).build()
         })
         .collect();
-    TransactionBatch::new(txs).unwrap()
+    TransactionBatch::new(txs, None).unwrap()
 }

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, sync::Arc};
 use async_trait::async_trait;
 use miden_node_utils::formatting::{format_array, format_blake3_digest};
 use miden_objects::{
-    block::{Block, BlockAccountUpdate},
+    block::{Block, BlockAccountUpdate, NoteBatch},
     notes::Nullifier,
 };
 use tracing::{debug, info, instrument};
@@ -76,8 +76,10 @@ where
         let updated_accounts: Vec<_> =
             batches.iter().flat_map(TransactionBatch::updated_accounts).collect();
 
-        let created_notes: Vec<_> =
-            batches.iter().map(TransactionBatch::output_notes).cloned().collect();
+        let created_notes: Vec<NoteBatch> = batches
+            .iter()
+            .map(|batch| batch.output_notes().values().cloned().collect())
+            .collect();
 
         let produced_nullifiers: Vec<Nullifier> =
             batches.iter().flat_map(TransactionBatch::produced_nullifiers).collect();

--- a/crates/block-producer/src/block_builder/prover/tests.rs
+++ b/crates/block-producer/src/block_builder/prover/tests.rs
@@ -69,7 +69,7 @@ fn test_block_witness_validation_inconsistent_account_ids() {
             )
             .build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         let batch_2 = {
@@ -80,7 +80,7 @@ fn test_block_witness_validation_inconsistent_account_ids() {
             )
             .build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         vec![batch_1, batch_2]
@@ -134,19 +134,25 @@ fn test_block_witness_validation_inconsistent_account_hashes() {
     };
 
     let batches = {
-        let batch_1 = TransactionBatch::new(vec![MockProvenTxBuilder::with_account(
-            account_id_1,
-            account_1_hash_batches,
-            Digest::default(),
+        let batch_1 = TransactionBatch::new(
+            vec![MockProvenTxBuilder::with_account(
+                account_id_1,
+                account_1_hash_batches,
+                Digest::default(),
+            )
+            .build()],
+            None,
         )
-        .build()])
         .unwrap();
-        let batch_2 = TransactionBatch::new(vec![MockProvenTxBuilder::with_account(
-            account_id_2,
-            Digest::default(),
-            Digest::default(),
+        let batch_2 = TransactionBatch::new(
+            vec![MockProvenTxBuilder::with_account(
+                account_id_2,
+                Digest::default(),
+                Digest::default(),
+            )
+            .build()],
+            None,
         )
-        .build()])
         .unwrap();
 
         vec![batch_1, batch_2]
@@ -229,8 +235,8 @@ async fn test_compute_account_root_success() {
             })
             .collect();
 
-        let batch_1 = TransactionBatch::new(txs[..2].to_vec()).unwrap();
-        let batch_2 = TransactionBatch::new(txs[2..].to_vec()).unwrap();
+        let batch_1 = TransactionBatch::new(txs[..2].to_vec(), None).unwrap();
+        let batch_2 = TransactionBatch::new(txs[2..].to_vec(), None).unwrap();
 
         vec![batch_1, batch_2]
     };
@@ -373,7 +379,7 @@ async fn test_compute_note_root_empty_notes_success() {
         .unwrap();
 
     let batches: Vec<TransactionBatch> = {
-        let batch = TransactionBatch::new(Vec::new()).unwrap();
+        let batch = TransactionBatch::new(vec![], None).unwrap();
         vec![batch]
     };
 
@@ -446,8 +452,8 @@ async fn test_compute_note_root_success() {
             })
             .collect();
 
-        let batch_1 = TransactionBatch::new(txs[..2].to_vec()).unwrap();
-        let batch_2 = TransactionBatch::new(txs[2..].to_vec()).unwrap();
+        let batch_1 = TransactionBatch::new(txs[..2].to_vec(), None).unwrap();
+        let batch_2 = TransactionBatch::new(txs[2..].to_vec(), None).unwrap();
 
         vec![batch_1, batch_2]
     };
@@ -495,13 +501,13 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
         let batch_1 = {
             let tx = MockProvenTxBuilder::with_account_index(0).nullifiers_range(0..1).build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         let batch_2 = {
             let tx = MockProvenTxBuilder::with_account_index(1).nullifiers_range(1..2).build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         vec![batch_1, batch_2]
@@ -571,13 +577,13 @@ async fn test_compute_nullifier_root_empty_success() {
         let batch_1 = {
             let tx = MockProvenTxBuilder::with_account_index(0).build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         let batch_2 = {
             let tx = MockProvenTxBuilder::with_account_index(1).build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         vec![batch_1, batch_2]
@@ -624,13 +630,13 @@ async fn test_compute_nullifier_root_success() {
         let batch_1 = {
             let tx = MockProvenTxBuilder::with_account_index(0).nullifiers_range(0..1).build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         let batch_2 = {
             let tx = MockProvenTxBuilder::with_account_index(1).nullifiers_range(1..2).build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         vec![batch_1, batch_2]

--- a/crates/block-producer/src/block_builder/tests.rs
+++ b/crates/block-producer/src/block_builder/tests.rs
@@ -37,7 +37,7 @@ async fn test_apply_block_called_nonempty_batches() {
             )
             .build();
 
-            TransactionBatch::new(vec![tx]).unwrap()
+            TransactionBatch::new(vec![tx], None).unwrap()
         };
 
         vec![batch_1]

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -85,6 +85,14 @@ pub enum BuildBatchError {
 
     #[error("Unauthenticated transaction notes not found in the store: {0:?}")]
     UnauthenticatedNotesNotFound(Vec<NoteId>, Vec<ProvenTransaction>),
+
+    #[error("Note hashes mismatch for note {id}: (input: {input_hash}, output: {output_hash})")]
+    NoteHashesMismatch {
+        id: NoteId,
+        input_hash: Digest,
+        output_hash: Digest,
+        txs: Vec<ProvenTransaction>,
+    },
 }
 
 impl BuildBatchError {
@@ -95,6 +103,7 @@ impl BuildBatchError {
             BuildBatchError::NotePathsError(_, txs) => txs,
             BuildBatchError::DuplicateUnauthenticatedNote(_, txs) => txs,
             BuildBatchError::UnauthenticatedNotesNotFound(_, txs) => txs,
+            BuildBatchError::NoteHashesMismatch { txs, .. } => txs,
         }
     }
 }

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -80,8 +80,11 @@ pub enum BuildBatchError {
     #[error("Failed to get note paths: {0}")]
     NotePathsError(NotePathsError, Vec<ProvenTransaction>),
 
-    #[error("Duplicated note ID in the batch: {0}")]
+    #[error("Duplicated unauthenticated transaction input note ID in the batch: {0}")]
     DuplicateUnauthenticatedNote(NoteId, Vec<ProvenTransaction>),
+
+    #[error("Duplicated transaction output note ID in the batch: {0}")]
+    DuplicateOutputNote(NoteId, Vec<ProvenTransaction>),
 
     #[error("Unauthenticated transaction notes not found in the store: {0:?}")]
     UnauthenticatedNotesNotFound(Vec<NoteId>, Vec<ProvenTransaction>),
@@ -102,6 +105,7 @@ impl BuildBatchError {
             BuildBatchError::NotesSmtError(_, txs) => txs,
             BuildBatchError::NotePathsError(_, txs) => txs,
             BuildBatchError::DuplicateUnauthenticatedNote(_, txs) => txs,
+            BuildBatchError::DuplicateOutputNote(_, txs) => txs,
             BuildBatchError::UnauthenticatedNotesNotFound(_, txs) => txs,
             BuildBatchError::NoteHashesMismatch { txs, .. } => txs,
         }

--- a/crates/block-producer/src/test_utils/batch.rs
+++ b/crates/block-producer/src/test_utils/batch.rs
@@ -24,7 +24,7 @@ impl TransactionBatchConstructor for TransactionBatch {
             })
             .collect();
 
-        Self::new(txs).unwrap()
+        Self::new(txs, None).unwrap()
     }
 
     fn from_txs(starting_account_index: u32, num_txs_in_batch: u64) -> Self {
@@ -36,6 +36,6 @@ impl TransactionBatchConstructor for TransactionBatch {
             })
             .collect();
 
-        Self::new(txs).unwrap()
+        Self::new(txs, None).unwrap()
     }
 }

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -171,10 +171,5 @@ pub(crate) fn note_created_smt_from_note_batches<'a>(
 
 #[cfg(test)]
 pub(crate) fn note_created_smt_from_batches(batches: &[TransactionBatch]) -> BlockNoteTree {
-    let batches: Vec<Vec<OutputNote>> = batches
-        .iter()
-        .map(|batch| batch.output_notes().values().cloned().collect())
-        .collect();
-
-    note_created_smt_from_note_batches(batches.iter())
+    note_created_smt_from_note_batches(batches.iter().map(TransactionBatch::output_notes))
 }

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -169,7 +169,6 @@ pub(crate) fn note_created_smt_from_note_batches<'a>(
     BlockNoteTree::with_entries(note_leaf_iterator).unwrap()
 }
 
-#[cfg(test)]
 pub(crate) fn note_created_smt_from_batches(batches: &[TransactionBatch]) -> BlockNoteTree {
     note_created_smt_from_note_batches(batches.iter().map(TransactionBatch::output_notes))
 }

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -169,6 +169,12 @@ pub(crate) fn note_created_smt_from_note_batches<'a>(
     BlockNoteTree::with_entries(note_leaf_iterator).unwrap()
 }
 
+#[cfg(test)]
 pub(crate) fn note_created_smt_from_batches(batches: &[TransactionBatch]) -> BlockNoteTree {
-    note_created_smt_from_note_batches(batches.iter().map(TransactionBatch::output_notes))
+    let batches: Vec<Vec<OutputNote>> = batches
+        .iter()
+        .map(|batch| batch.output_notes().values().cloned().collect())
+        .collect();
+
+    note_created_smt_from_note_batches(batches.iter())
 }

--- a/crates/block-producer/src/txqueue/tests/mod.rs
+++ b/crates/block-producer/src/txqueue/tests/mod.rs
@@ -40,7 +40,8 @@ impl BatchBuilderSuccess {
 #[async_trait]
 impl BatchBuilder for BatchBuilderSuccess {
     async fn build_batch(&self, txs: Vec<ProvenTransaction>) -> Result<(), BuildBatchError> {
-        let batch = TransactionBatch::new(txs).expect("Tx batch building should have succeeded");
+        let batch =
+            TransactionBatch::new(txs, None).expect("Tx batch building should have succeeded");
         self.ready_batches
             .send(batch)
             .expect("Sending to channel should have succeeded");
@@ -104,7 +105,7 @@ async fn test_build_batch_success() {
         receiver.try_recv(),
         "A single transaction produces a single batch"
     );
-    let expected = TransactionBatch::new(vec![tx.clone()]).expect("Valid transactions");
+    let expected = TransactionBatch::new(vec![tx.clone()], None).expect("Valid transactions");
     assert_eq!(expected, batch, "The batch should have the one transaction added to the queue");
 
     // a batch will include up to `batch_size` transactions
@@ -123,7 +124,7 @@ async fn test_build_batch_success() {
         receiver.try_recv(),
         "{batch_size} transactions create a single batch"
     );
-    let expected = TransactionBatch::new(txs).expect("Valid transactions");
+    let expected = TransactionBatch::new(txs, None).expect("Valid transactions");
     assert_eq!(expected, batch, "The batch should the transactions to fill a batch");
 
     // the transaction queue eagerly produces batches
@@ -138,7 +139,7 @@ async fn test_build_batch_success() {
     for expected_batch in txs.chunks(batch_size).map(|txs| txs.to_vec()) {
         tokio::time::advance(build_batch_frequency).await;
         let batch = receiver.try_recv().expect("Queue not empty");
-        let expected = TransactionBatch::new(expected_batch).expect("Valid transactions");
+        let expected = TransactionBatch::new(expected_batch, None).expect("Valid transactions");
         assert_eq!(expected, batch, "The batch should the transactions to fill a batch");
     }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BTreeSet,
     fs::{self, create_dir_all},
     sync::Arc,
 };
@@ -168,14 +167,6 @@ impl Db {
     pub async fn select_notes(&self) -> Result<Vec<NoteRecord>> {
         self.pool.get().await?.interact(sql::select_notes).await.map_err(|err| {
             DatabaseError::InteractError(format!("Select notes task failed: {err}"))
-        })?
-    }
-
-    /// Loads all the note IDs from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
-    pub async fn select_note_ids(&self) -> Result<BTreeSet<NoteId>> {
-        self.pool.get().await?.interact(sql::select_note_ids).await.map_err(|err| {
-            DatabaseError::InteractError(format!("Select note IDs task failed: {err}"))
         })?
     }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     fs::{self, create_dir_all},
     sync::Arc,
 };
@@ -277,6 +278,14 @@ impl Db {
             .map_err(|err| {
                 DatabaseError::InteractError(format!("Select note by id task failed: {err}"))
             })?
+    }
+
+    /// Loads all note IDs matching a certain NoteId from the database.
+    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    pub async fn select_note_ids(&self, note_ids: Vec<NoteId>) -> Result<BTreeSet<NoteId>> {
+        self.select_notes_by_id(note_ids)
+            .await
+            .map(|notes| notes.into_iter().map(|note| note.note_id.into()).collect())
     }
 
     /// Inserts the data of a new block into the DB.

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -1,6 +1,6 @@
 //! Wrapper functions for SQL statements.
 
-use std::{borrow::Cow, collections::BTreeSet, rc::Rc};
+use std::{borrow::Cow, rc::Rc};
 
 use miden_node_proto::domain::accounts::{AccountInfo, AccountSummary};
 use miden_objects::{
@@ -365,25 +365,6 @@ pub fn select_notes(conn: &mut Connection) -> Result<Vec<NoteRecord>> {
             details,
             merkle_path,
         })
-    }
-    Ok(notes)
-}
-
-/// Select all note IDs from the DB using the given [Connection].
-///
-/// # Returns
-///
-/// A set with note IDs, or an error.
-pub fn select_note_ids(conn: &mut Connection) -> Result<BTreeSet<NoteId>> {
-    let mut stmt = conn.prepare("SELECT note_id FROM notes ORDER BY note_id")?;
-    let mut rows = stmt.query([])?;
-
-    let mut notes = BTreeSet::new();
-    while let Some(row) = rows.next()? {
-        let note_id_data = row.get_ref(0)?.as_blob()?;
-        let note_id = RpoDigest::read_from_bytes(note_id_data)?.into();
-
-        notes.insert(note_id);
     }
     Ok(notes)
 }


### PR DESCRIPTION
This PR is created in order to address remaining review comments in https://github.com/0xPolygonMiden/miden-node/pull/390. We had to merge that PR in order to make miden-note compilable against the latest miden-base.

Here we remove in-memory notes map in favor of direct queries to database. Output notes consumed in the same batch now removed from output notes list and SMT, corresponding input notes also removed from a batch and don't affect produced nullifiers set. Input unauthenticated notes are checked for duplicates as well, as output notes. Hashes of all corresponding output/input notes are required to be equal.

Resolves: https://github.com/0xPolygonMiden/miden-node/issues/381