### PR TITLE
chore: use workspace inheritance for crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.78"
+version = "0.5.0"
 license = "MIT"
 authors = ["Miden contributors"]
 homepage = "https://polygon.technology/polygon-miden"

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-faucet"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node token faucet"
 readme = "README.md"
 keywords = ["miden", "node", "faucet"]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-node"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node binary"
 readme.workspace = true
 keywords = ["miden", "node"]

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-node-block-producer"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node's block producer component"
 readme = "README.md"
 keywords = ["miden", "node", "block-producer"]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-node-proto"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node message definitions (Store, Block Producer and RPC)"
 readme = "README.md"
 keywords = ["miden", "node", "protobuf", "rpc"]

--- a/crates/rpc-proto/Cargo.toml
+++ b/crates/rpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-rpc-proto"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node RPC message definitions"
 readme = "README.md"
 keywords = ["miden", "node", "protobuf", "rpc"]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-node-rpc"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node's front-end RPC server"
 readme = "README.md"
 keywords = ["miden", "node", "rpc"]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-node-store"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node's state store component"
 readme = "README.md"
 keywords = ["miden", "node", "store"]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-node-utils"
-version = "0.5.0"
+version.workspace = true
 description = "Miden node's shared utilities"
 readme = "README.md"
 keywords = ["miden", "node", "utils"]


### PR DESCRIPTION
This removes the need to edit each crate's toml file when bumping the version.

This is under the assumption that these are always in lockstep.