### PR TITLE
feat(node): normalize configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.0 (TBD)
 
+### Enhancements
+
+* [BREAKING] Configuration files with unknown properties are now rejected (#401).
+* [BREAKING] Removed redundant node configuration properties (#401).
+
 ## 0.4.0 (2024-07-04)
 
 ### Features

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 // ================================================================================================
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FaucetConfig {
     /// Endpoint of the faucet
     pub endpoint: Endpoint,

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -66,8 +66,7 @@ async fn main() -> Result<(), FaucetError> {
 
     match &cli.command {
         Command::Start { config } => {
-            let config: FaucetConfig = load_config(config.as_path())
-                .extract()
+            let config: FaucetConfig = load_config(config)
                 .map_err(|err| FaucetError::ConfigurationError(err.to_string()))?;
 
             let faucet_state = FaucetState::new(config.clone()).await?;

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -78,7 +78,7 @@ pub fn make_genesis(inputs_path: &PathBuf, output_path: &PathBuf, force: &bool) 
         },
     };
 
-    let genesis_input: GenesisInput = load_config(inputs_path).extract().map_err(|err| {
+    let genesis_input: GenesisInput = load_config(inputs_path).map_err(|err| {
         anyhow!("Failed to load {} genesis input file: {err}", inputs_path.display())
     })?;
     info!("Genesis input file: {} has successfully been loaded.", output_path.display());

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -23,8 +23,6 @@ impl Default for NodeConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use figment::Jail;
     use miden_node_block_producer::config::BlockProducerConfig;
     use miden_node_rpc::config::RpcConfig;
@@ -58,8 +56,7 @@ mod tests {
                 "#,
             )?;
 
-            let config: NodeConfig =
-                load_config(PathBuf::from(NODE_CONFIG_FILE_PATH).as_path()).extract()?;
+            let config: NodeConfig = load_config(NODE_CONFIG_FILE_PATH)?;
 
             assert_eq!(
                 config,

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Node top-level configuration.
 #[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NodeConfig {
     block_producer: NormalizedBlockProducerConfig,
     rpc: NormalizedRpcConfig,
@@ -14,12 +15,14 @@ pub struct NodeConfig {
 
 /// A specialized variant of [RpcConfig] with redundant fields within [NodeConfig] removed.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct NormalizedRpcConfig {
     endpoint: Endpoint,
 }
 
 /// A specialized variant of [BlockProducerConfig] with redundant fields within [NodeConfig] removed.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct NormalizedBlockProducerConfig {
     endpoint: Endpoint,
     verify_tx_proofs: bool,

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -6,7 +6,6 @@ use commands::{
     init::init_config_files,
     start::{start_block_producer, start_node, start_rpc, start_store},
 };
-use config::NodeConfig;
 use miden_node_utils::config::load_config;
 
 mod commands;
@@ -87,25 +86,23 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Command::Start { command, config } => {
-            let config: NodeConfig = load_config(config).map_err(|err| {
-                anyhow!("failed to load config file `{}`: {err}", config.display())
-            })?;
-            match command {
-                StartCommand::Node => start_node(config).await,
-                StartCommand::BlockProducer => {
-                    start_block_producer(
-                        config.block_producer.context("Missing block-producer configuration.")?,
-                    )
-                    .await
-                },
-                StartCommand::Rpc => {
-                    start_rpc(config.rpc.context("Missing rpc configuration.")?).await
-                },
-                StartCommand::Store => {
-                    start_store(config.store.context("Missing store configuration.")?).await
-                },
-            }
+        Command::Start { command, config } => match command {
+            StartCommand::Node => {
+                let config = load_config(config).context("Loading configuration file")?;
+                start_node(config).await
+            },
+            StartCommand::BlockProducer => {
+                let config = load_config(config).context("Loading configuration file")?;
+                start_block_producer(config).await
+            },
+            StartCommand::Rpc => {
+                let config = load_config(config).context("Loading configuration file")?;
+                start_rpc(config).await
+            },
+            StartCommand::Store => {
+                let config = load_config(config).context("Loading configuration file")?;
+                start_store(config).await
+            },
         },
         Command::MakeGenesis { output_path, force, inputs_path } => {
             commands::make_genesis(inputs_path, output_path, force)

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
 
     match &cli.command {
         Command::Start { command, config } => {
-            let config: NodeConfig = load_config(config).extract().map_err(|err| {
+            let config: NodeConfig = load_config(config).map_err(|err| {
                 anyhow!("failed to load config file `{}`: {err}", config.display())
             })?;
             match command {

--- a/config/miden-node.toml
+++ b/config/miden-node.toml
@@ -3,7 +3,6 @@
 [block_producer]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
 endpoint = { host = "localhost", port = 48046 }
-store_url = "http://localhost:28943"
 # enables or disables the verification of transaction proofs before they are accepted into the
 # transaction queue.
 verify_tx_proofs = true
@@ -11,8 +10,6 @@ verify_tx_proofs = true
 [rpc]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16
 endpoint = { host = "0.0.0.0", port = 57291 }
-block_producer_url = "http://localhost:48046"
-store_url = "http://localhost:28943"
 
 [store]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-store', 1)) % 2**16

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// Block producer specific configuration
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockProducerConfig {
     pub endpoint: Endpoint,
 

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 // ================================================================================================
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RpcConfig {
     pub endpoint: Endpoint,
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 // ================================================================================================
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StoreConfig {
     /// Defines the listening socket.
     pub endpoint: Endpoint,

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -51,6 +51,8 @@ impl Display for Endpoint {
 /// relative, searches in parent directories all the way to the root as well.
 ///
 /// The above configuration options are indented to support easy of packaging and deployment.
-pub fn load_config(config_file: &Path) -> Figment {
-    Figment::from(Toml::file(config_file))
+pub fn load_config<T: for<'a> Deserialize<'a>>(
+    config_file: impl AsRef<Path>,
+) -> figment::Result<T> {
+    Figment::from(Toml::file(config_file.as_ref())).extract()
 }


### PR DESCRIPTION
Simplifies node configuration by removing all redundant options.

The following options are removed 

- block_producer.store_url
- rpc.store_url
- rpc.block_producer_url

as they are already covered by `store.endpoint` and `block_producer.endpoint`.

Note that this only impacts the configuration options as seen by the caller of the node binary. Individual node components (rpc, store, block_producer) still have the original configuration objects. This PR only strips out the duplicate options for the user.

In addition, this PR removes the optional indirection in `NodeConfig`. ~Maybe this is incorrect, and the `figment` crate somehow requires this to handle missing options properly? I don't think so; but maybe there was a reason for this beyond old changes :)~

Closes #334.

------------------------------------

Update after this PR was reworked (the above all still holds true).

Configuration of the various `miden-node start xxx` options are now handled separately. This gives us better type safety without any options.

In addition, we now disallow unknown configuration options. I think this is safer as otherwise users are left wondering why their inputs are doing nothing.

`load_config` is now also generic which makes it more ergonomic imo.