### PR TITLE
feat(block-producer): nullifier map type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [BREAKING] Configuration files with unknown properties are now rejected (#401).
 * [BREAKING] Removed redundant node configuration properties (#401).
+* Improve type safety of the transaction inputs nullifier mapping (#406).
 
 ## 0.4.0 (2024-07-04)
 

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -252,7 +252,7 @@ fn ensure_tx_inputs_constraints(
     let infracting_nullifiers: Vec<Nullifier> = tx_inputs
         .nullifiers
         .into_iter()
-        .filter_map(|(nullifier_in_tx, block_num)| (block_num != 0).then_some(nullifier_in_tx))
+        .filter_map(|(nullifier_in_tx, block_num)| block_num.is_some().then_some(nullifier_in_tx))
         .collect();
 
     if !infracting_nullifiers.is_empty() {

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU32,
+};
 
 use async_trait::async_trait;
 use miden_objects::{
@@ -224,7 +227,7 @@ impl Store for MockStoreSuccess {
                 let nullifier = commitment.nullifier();
                 let nullifier_value = locked_produced_nullifiers.get_value(&nullifier.inner());
 
-                (nullifier, nullifier_value[0].inner() as u32)
+                (nullifier, NonZeroU32::new(nullifier_value[0].inner() as u32))
             })
             .collect();
 


### PR DESCRIPTION
Improve the type safety of `TransactionInputs::nullifiers` mapping by using `Option<NonZeroU32>` instead of relying on zero to indicate none.

Shower thought: is there utility in allowing a nullifier set to be included in the genesis block? Maybe for bootstrapping test networks..

(I'm happy to also just drop this PR, its not a major thing)