### PR TITLE
feat(faucet): embed static website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BREAKING] Configuration files with unknown properties are now rejected (#401).
 * [BREAKING] Removed redundant node configuration properties (#401).
 * Improve type safety of the transaction inputs nullifier mapping (#406).
+* Embed the faucet's static website resources (#411).
 
 ## 0.4.0 (2024-07-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,29 +35,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-files"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0773d59061dedb49a8aed04c67291b9d8cf2fe0b60130a381aab53c6dd86e9be"
-dependencies = [
- "actix-http",
- "actix-service",
- "actix-utils",
- "actix-web",
- "bitflags 2.6.0",
- "bytes",
- "derive_more",
- "futures-core",
- "http-range",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "v_htmlescape",
-]
-
-[[package]]
 name = "actix-http"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +197,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "actix-web-static-files"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf6d1ef6d7a60e084f9e0595e2a5234abda14e76c105ecf8e2d0e8800c41a1f"
+dependencies = [
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "static-files",
 ]
 
 [[package]]
@@ -642,6 +631,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "change-detection"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159fa412eae48a1d94d0b9ecdb85c97ce56eb2a347c62394d3fdbf221adabc1a"
+dependencies = [
+ "path-matchers",
+ "path-slash",
+]
 
 [[package]]
 name = "chrono"
@@ -1148,12 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
 name = "http-range-header"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,8 +1534,8 @@ name = "miden-faucet"
 version = "0.5.0"
 dependencies = [
  "actix-cors",
- "actix-files",
  "actix-web",
+ "actix-web-static-files",
  "async-mutex",
  "clap",
  "derive_more",
@@ -1555,6 +1548,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde",
+ "static-files",
  "thiserror",
  "toml",
  "tonic",
@@ -2060,6 +2054,21 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-matchers"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36cd9b72a47679ec193a5f0229d9ab686b7bd45e1fbc59ccf953c9f3d83f7b2b"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "path-slash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
 
 [[package]]
 name = "pear"
@@ -2671,6 +2680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "static-files"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8590e848e1c53be9258210bcd4a8f4118e08988f03a4e2d63b62e4ad9f7ced"
+dependencies = [
+ "change-detection",
+ "mime_guess",
+ "path-slash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,12 +3235,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "v_htmlescape"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
 
 [[package]]
 name = "valuable"

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -32,11 +32,11 @@ miden-tx = { workspace = true,  features = ["concurrent"] }
 rand = { version = "0.8" }
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-static-files = "0.2.1"
+static-files = "0.2"
 thiserror = { workspace = true }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]
-static-files = "0.2.1"
+static-files = "0.2"

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -18,8 +18,8 @@ testing = ["miden-objects/testing", "miden-lib/testing"]
 
 [dependencies]
 actix-cors = "0.7"
-actix-files = "0.6"
 actix-web = "4.8"
+actix-web-static-files = "4.0"
 async-mutex = "1.4"
 clap = { version = "4.5", features = ["derive"] }
 derive_more = "0.99"
@@ -32,7 +32,11 @@ miden-tx = { workspace = true,  features = ["concurrent"] }
 rand = { version = "0.8" }
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+static-files = "0.2.1"
 thiserror = { workspace = true }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }
+
+[build-dependencies]
+static-files = "0.2.1"

--- a/bin/faucet/build.rs
+++ b/bin/faucet/build.rs
@@ -1,0 +1,12 @@
+use std::str::FromStr;
+
+fn main() -> std::io::Result<()> {
+    // The location of our static faucet website files.
+    let static_dir = std::path::PathBuf::from_str(std::env!("CARGO_MANIFEST_DIR"))
+        .unwrap()
+        .join("src")
+        .join("static");
+    println!("cargo::rerun-if-changed={}", static_dir.to_str().expect("Valid utf-8"));
+    // This makes the static files available as an embedded resource.
+    static_files::resource_dir(static_dir).build()
+}

--- a/bin/faucet/src/static/index.js
+++ b/bin/faucet/src/static/index.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
     publicButton.addEventListener('click', () => {handleButtonClick(false)});
 
     function fetchMetadata() {
-        fetch('http://localhost:8080/get_metadata')
+        fetch(window.location.href + 'get_metadata')
             .then(response => response.json())
             .then(data => {
                 faucetIdElem.textContent = data.id;
@@ -54,7 +54,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         loading.style.display = 'block';
         try {
-            const response = await fetch('http://localhost:8080/get_tokens', {
+            const response = await fetch(window.location.href + 'get_tokens', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ account_id: accountId, is_private_note: isPrivateNote, asset_amount: parseInt(assetSelect.value)})


### PR DESCRIPTION
This PR simplifies faucet deployment by embedding the website within the binary. This removes the need to separately deploy the website resources.

To facilitate this, this PR also fixes a paper-cut with the javascript callbacks. Previously these were hardcoded to use `localhost:8080` as the server address. These would have to be manually edited to the correct URL (which might be a proxy) during deployment. Instead we now use `window.location.href` which gives the correct url of the current page.

Note: I am not a web expert so if anyone has any input on the above that would be welcome.

------------------------

The static embedding is handled using a build script + additional dependencies, which I dislike but it seems this is the "blessed" way to achieve this using `actix-web`.

I tested this locally but without a proxy. Though I don't see why this would matter :)