### PR TITLE
Added warning on `CHANGELOG.md` modification

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,17 +9,6 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  version:
-    name: check rust version consistency
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-        with:
-          profile: minimal
-          override: true
-      - name: check rust versions
-        run: ./scripts/check-rust-version.sh
-
   rustfmt:
     name: rustfmt check nightly on ubuntu-latest
     runs-on: ubuntu-latest
@@ -41,3 +30,43 @@ jobs:
           rustup update --no-self-update nightly
           rustup +nightly component add clippy
           make clippy
+
+  doc:
+    name: doc stable on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Build docs
+        run: |
+          rustup update --no-self-update
+          make doc
+
+  version:
+    name: check rust version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+        with:
+          profile: minimal
+          override: true
+      - name: check rust versions
+        run: ./scripts/check-rust-version.sh
+
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check if CHANGELOG.md is modified
+        run: |
+          # Get the list of changed files in the PR
+          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
+          # Check if CHANGELOG.md is in the list of changed files
+          if echo "$changed_files" | grep -q '^CHANGELOG.md$'; then
+            echo "CHANGELOG.md has been modified."
+          else
+            echo $'::warning file=CHANGELOG.md::CHANGELOG.md has not been modified.\n This warning can be ignored if is has been explicitely decided not to log changes.\n Except in this situation, make sure to add log changes.'
+            exit 1
+          fi


### PR DESCRIPTION
In this PR I propose to add a warning in the CI if the `CHANGELOG.md` file has not been modified.