### PR TITLE
feat: update miden-base dependencies

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ name: changelog
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   changelog:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,9 +1557,8 @@ dependencies = [
 
 [[package]]
 name = "miden-lib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b08cc040917b9585125558a01f884e0afe86e3fec7be68c010c9e38c0481b9"
+version = "0.5.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?rev=5cb5047#5cb5047f67a4164ae875336d9beae75095242ea7"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1707,9 +1706,8 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98421893abf6fa3a67216580ddad615df876b74810151892dc797bacfeb67849"
+version = "0.5.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?rev=5cb5047#5cb5047f67a4164ae875336d9beae75095242ea7"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1759,9 +1757,8 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c509531fd448636f19c2ddb173f47db809de4d91586fe315aacfa1c3d263236"
+version = "0.5.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?rev=5cb5047#5cb5047f67a4164ae875336d9beae75095242ea7"
 dependencies = [
  "miden-lib",
  "miden-objects",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 miden-air = { version = "0.9", default-features = false }
-miden-lib = { version = "0.4" }
+miden-lib = { rev = "5cb5047", git = "https://github.com/0xPolygonMiden/miden-base" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.5" }
 miden-node-faucet = { path = "bin/faucet", version = "0.5" }
 miden-node-proto = { path = "crates/proto", version = "0.5" }
@@ -36,10 +36,10 @@ miden-node-rpc-proto = { path = "crates/rpc-proto", version = "0.5" }
 miden-node-store = { path = "crates/store", version = "0.5" }
 miden-node-test-macro = { path = "crates/test-macro" }
 miden-node-utils = { path = "crates/utils", version = "0.5" }
-miden-objects = { version = "0.4" }
+miden-objects = { rev = "5cb5047", git = "https://github.com/0xPolygonMiden/miden-base" }
 miden-processor = { version = "0.9" }
 miden-stdlib = { version = "0.9", default-features = false }
-miden-tx = { version = "0.4" }
+miden-tx = { rev = "5cb5047", git = "https://github.com/0xPolygonMiden/miden-base" }
 thiserror = { version = "1.0" }
 tonic = { version = "0.11" }
 tracing = { version = "0.1" }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -95,7 +95,7 @@ impl FaucetClient {
             .map_err(|err| FaucetError::InternalServerError(err.to_string()))?;
 
         let note_type = if is_private_note {
-            NoteType::OffChain
+            NoteType::Private
         } else {
             NoteType::Public
         };

--- a/crates/block-producer/src/block_builder/prover/tests.rs
+++ b/crates/block-producer/src/block_builder/prover/tests.rs
@@ -417,7 +417,7 @@ async fn test_compute_note_root_success() {
             note_digest.into(),
             NoteMetadata::new(
                 account_id,
-                NoteType::OffChain,
+                NoteType::Private,
                 NoteTag::for_local_use_case(0u16, 0u16).unwrap(),
                 ONE,
             )

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -146,17 +146,15 @@ where
         }
 
         // Remove new nullifiers of transactions in block
-        for nullifier in block.created_nullifiers() {
+        for nullifier in block.nullifiers() {
             let was_in_flight = locked_nullifiers_in_flight.remove(nullifier);
             debug_assert!(was_in_flight);
         }
 
         // Remove new notes of transactions in block
-        for batch in block.created_notes() {
-            for note in batch.iter() {
-                let was_in_flight = locked_notes_in_flight.remove(&note.id());
-                debug_assert!(was_in_flight);
-            }
+        for (_, note) in block.notes() {
+            let was_in_flight = locked_notes_in_flight.remove(&note.id());
+            debug_assert!(was_in_flight);
         }
 
         Ok(())

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -78,7 +78,7 @@ impl MockProvenTxBuilder {
             .map(|note_index| {
                 let note_id = Hasher::hash(&note_index.to_be_bytes());
                 let note_metadata =
-                    NoteMetadata::new(self.account_id, NoteType::OffChain, 0.into(), ONE).unwrap();
+                    NoteMetadata::new(self.account_id, NoteType::Private, 0.into(), ONE).unwrap();
 
                 OutputNote::Header(NoteHeader::new(note_id.into(), note_metadata))
             })

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -200,7 +200,7 @@ impl ApplyBlock for MockStoreSuccess {
         debug_assert_eq!(locked_accounts.root(), block.header().account_root());
 
         // update nullifiers
-        for nullifier in block.created_nullifiers() {
+        for nullifier in block.nullifiers() {
             locked_produced_nullifiers
                 .insert(nullifier.inner(), [block.header().block_num().into(), ZERO, ZERO, ZERO]);
         }

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -27,7 +27,7 @@ CREATE TABLE
     batch_index INTEGER NOT NULL, -- Index of batch in block, starting from 0
     note_index  INTEGER NOT NULL, -- Index of note in batch, starting from 0
     note_id     BLOB    NOT NULL,
-    note_type   INTEGER NOT NULL, -- 1-Public (0b01), 2-OffChain (0b10), 3-Encrypted (0b11)
+    note_type   INTEGER NOT NULL, -- 1-Public (0b01), 2-Private (0b10), 3-Encrypted (0b11)
     sender      INTEGER NOT NULL,
     tag         INTEGER NOT NULL,
     aux         INTEGER NOT NULL,

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -313,7 +313,7 @@ impl Db {
                     &transaction,
                     &block.header(),
                     &notes,
-                    block.created_nullifiers(),
+                    block.nullifiers(),
                     block.updated_accounts(),
                 )?;
 

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -274,8 +274,8 @@ impl api_server::Api for StoreApi {
             block_num,
             block_hash = %block.hash(),
             account_count = block.updated_accounts().len(),
-            note_count = block.created_notes().len(),
-            nullifier_count = block.created_nullifiers().len(),
+            note_count = block.notes().count(),
+            nullifier_count = block.nullifiers().len(),
         );
 
         // TODO: Why the error is swallowed here? Fix or add a comment with explanation.

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -196,7 +196,7 @@ impl State {
 
             // nullifiers can be produced only once
             let duplicate_nullifiers: Vec<_> = block
-                .created_nullifiers()
+                .nullifiers()
                 .iter()
                 .filter(|&n| inner.nullifier_tree.get_block_num(n).is_some())
                 .cloned()
@@ -230,7 +230,7 @@ impl State {
             // update nullifier tree
             let nullifier_tree = {
                 let mut nullifier_tree = inner.nullifier_tree.clone();
-                for nullifier in block.created_nullifiers() {
+                for nullifier in block.nullifiers() {
                     nullifier_tree
                         .insert(nullifier, block_num)
                         .map_err(ApplyBlockError::FailedToUpdateNullifierTree)?;


### PR DESCRIPTION
This PR updates the miden-base dependencies to the current `next` branch tip.

#407 is currently blocked by the recently merged [PR in `base/miden-objects`](https://github.com/0xPolygonMiden/miden-base/pull/797). This PR unblocks #407 by updating our dependencies to include it.

I opened this as a separate PR since there are some associated changes that need reviewing.

I'm also unsure of the cross-repo update procedure so maybe this is the wrong way of doing it.

Lastly, probably we don't want to track `next` so I've specified the current latest commit.

-------------------------

This PR also added an unrelated fix to the changelog workflow which could be pulled into a separate PR if we want this to remain more "pure". See [this comment](https://github.com/0xPolygonMiden/miden-node/pull/416#issuecomment-2247787390) for details.