### PR TITLE
Rerun build scripts for protobuf on env changed

### DIFF
--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -11,7 +11,8 @@ use prost::Message;
 /// This is done only if BUILD_PROTO environment variable is set to `1` to avoid running the script
 /// on crates.io where repo-level .proto files are not available.
 fn main() -> miette::Result<()> {
-    println!("cargo:rerun-if-changed=../../proto");
+    println!("cargo::rerun-if-changed=../../proto");
+    println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 
     // Skip this build script in BUILD_PROTO environment variable is not set to `1`.
     if env::var("BUILD_PROTO").unwrap_or("0".to_string()) == "0" {

--- a/crates/rpc-proto/build.rs
+++ b/crates/rpc-proto/build.rs
@@ -20,7 +20,8 @@ const DOC_COMMENT: &str =
 /// This is done only if BUILD_PROTO environment variable is set to `1` to avoid running the script
 /// on crates.io where repo-level .proto files are not available.
 fn main() -> io::Result<()> {
-    println!("cargo:rerun-if-changed=../../proto");
+    println!("cargo::rerun-if-changed=../../proto");
+    println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 
     // skip this build script in BUILD_PROTO environment variable is not set to `1`
     if env::var("BUILD_PROTO").unwrap_or("0".to_string()) == "0" {


### PR DESCRIPTION
Build scripts for code generation from *.proto files depend on `BUILD_PROTO` environment variable. But when user sets value of this variable to "1" after previous run, build scripts runs are skipped. This PR fixes that.