### PR TITLE
feat: implement `CheckNullifiersByPrefix` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Added `CheckNullifiersByPrefix` endpoint (#419).
 - [BREAKING] Configuration files with unknown properties are now rejected (#401).
 - [BREAKING] Removed redundant node configuration properties (#401).
 - Improve type safety of the transaction inputs nullifier mapping (#406).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Enhancements
 
-- Added `CheckNullifiersByPrefix` endpoint (#419).
 - [BREAKING] Configuration files with unknown properties are now rejected (#401).
 - [BREAKING] Removed redundant node configuration properties (#401).
 - Improve type safety of the transaction inputs nullifier mapping (#406).
@@ -13,6 +12,7 @@
 - Added warning on CI for `CHANGELOG.md` (#413).
 - Now accounts for genesis are optional. Accounts directory will be overwritten, if `--force` flag is set (#420).
 - Added `GetAccountStateDelta` endpoint (#418).
+- Added `CheckNullifiersByPrefix` endpoint (#419).
 
 ### Fixes
 

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -5,6 +5,14 @@ pub struct ApplyBlockRequest {
     #[prost(bytes = "vec", tag = "1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
 }
+/// Returns a list of nullifiers recorded in the node
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CheckNullifiersByPrefixRequest {
+    /// Nullifier prefixes the client is interested in.
+    #[prost(uint32, repeated, tag = "1")]
+    pub prefixes: ::prost::alloc::vec::Vec<u32>,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersRequest {

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -5,11 +5,11 @@ pub struct ApplyBlockRequest {
     #[prost(bytes = "vec", tag = "1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
 }
-/// Returns a list of nullifiers recorded in the node
+/// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersByPrefixRequest {
-    /// Number of bits used for nullifier prefix.
+    /// Number of bits used for nullifier prefix. Currently the only supported value is 16.
     #[prost(uint32, tag = "1")]
     pub prefix_len: u32,
     /// List of nullifiers to check. Each nullifier is specified by its prefix with length equal

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -9,9 +9,13 @@ pub struct ApplyBlockRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersByPrefixRequest {
-    /// Nullifier prefixes the client is interested in.
-    #[prost(uint32, repeated, tag = "1")]
-    pub prefixes: ::prost::alloc::vec::Vec<u32>,
+    /// Number of bits used for nullifier prefix.
+    #[prost(uint32, tag = "1")]
+    pub prefix_len: u32,
+    /// List of nullifiers to check. Each nullifier is specified by its prefix with length equal
+    /// to prefix_len
+    #[prost(uint32, repeated, tag = "2")]
+    pub nullifiers: ::prost::alloc::vec::Vec<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -12,6 +12,7 @@ pub struct CheckNullifiersResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersByPrefixResponse {
+    /// List of nullifiers matching the 16-bit prefixes specified in the request.
     #[prost(message, repeated, tag = "1")]
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierUpdate>,
 }

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -12,7 +12,7 @@ pub struct CheckNullifiersResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersByPrefixResponse {
-    /// List of nullifiers matching the 16-bit prefixes specified in the request.
+    /// List of nullifiers matching the prefixes specified in the request.
     #[prost(message, repeated, tag = "1")]
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierUpdate>,
 }

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -11,6 +11,12 @@ pub struct CheckNullifiersResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CheckNullifiersByPrefixResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub nullifiers: ::prost::alloc::vec::Vec<NullifierUpdate>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockHeaderByNumberResponse {
     /// The requested block header
     #[prost(message, optional, tag = "1")]

--- a/crates/proto/src/generated/rpc.rs
+++ b/crates/proto/src/generated/rpc.rs
@@ -84,6 +84,30 @@ pub mod api_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        pub async fn check_nullifiers(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::requests::CheckNullifiersRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/rpc.Api/CheckNullifiers");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "CheckNullifiers"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn check_nullifiers_by_prefix(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -109,30 +133,6 @@ pub mod api_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rpc.Api", "CheckNullifiersByPrefix"));
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn check_nullifiers(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::requests::CheckNullifiersRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::super::responses::CheckNullifiersResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/rpc.Api/CheckNullifiers");
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "CheckNullifiers"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_account_details(
@@ -319,6 +319,13 @@ pub mod api_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ApiServer.
     #[async_trait]
     pub trait Api: Send + Sync + 'static {
+        async fn check_nullifiers(
+            &self,
+            request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersResponse>,
+            tonic::Status,
+        >;
         async fn check_nullifiers_by_prefix(
             &self,
             request: tonic::Request<
@@ -326,13 +333,6 @@ pub mod api_server {
             >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::CheckNullifiersByPrefixResponse>,
-            tonic::Status,
-        >;
-        async fn check_nullifiers(
-            &self,
-            request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::super::responses::CheckNullifiersResponse>,
             tonic::Status,
         >;
         async fn get_account_details(
@@ -468,6 +468,55 @@ pub mod api_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
+                "/rpc.Api/CheckNullifiers" => {
+                    #[allow(non_camel_case_types)]
+                    struct CheckNullifiersSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::CheckNullifiersRequest,
+                    > for CheckNullifiersSvc<T> {
+                        type Response = super::super::responses::CheckNullifiersResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::requests::CheckNullifiersRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::check_nullifiers(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CheckNullifiersSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/rpc.Api/CheckNullifiersByPrefix" => {
                     #[allow(non_camel_case_types)]
                     struct CheckNullifiersByPrefixSvc<T: Api>(pub Arc<T>);
@@ -503,55 +552,6 @@ pub mod api_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = CheckNullifiersByPrefixSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/rpc.Api/CheckNullifiers" => {
-                    #[allow(non_camel_case_types)]
-                    struct CheckNullifiersSvc<T: Api>(pub Arc<T>);
-                    impl<
-                        T: Api,
-                    > tonic::server::UnaryService<
-                        super::super::requests::CheckNullifiersRequest,
-                    > for CheckNullifiersSvc<T> {
-                        type Response = super::super::responses::CheckNullifiersResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<
-                                super::super::requests::CheckNullifiersRequest,
-                            >,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Api>::check_nullifiers(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = CheckNullifiersSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/proto/src/generated/rpc.rs
+++ b/crates/proto/src/generated/rpc.rs
@@ -84,6 +84,33 @@ pub mod api_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        pub async fn check_nullifiers_by_prefix(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::requests::CheckNullifiersByPrefixRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersByPrefixResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rpc.Api/CheckNullifiersByPrefix",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("rpc.Api", "CheckNullifiersByPrefix"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn check_nullifiers(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -292,6 +319,15 @@ pub mod api_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ApiServer.
     #[async_trait]
     pub trait Api: Send + Sync + 'static {
+        async fn check_nullifiers_by_prefix(
+            &self,
+            request: tonic::Request<
+                super::super::requests::CheckNullifiersByPrefixRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersByPrefixResponse>,
+            tonic::Status,
+        >;
         async fn check_nullifiers(
             &self,
             request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
@@ -432,6 +468,56 @@ pub mod api_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
+                "/rpc.Api/CheckNullifiersByPrefix" => {
+                    #[allow(non_camel_case_types)]
+                    struct CheckNullifiersByPrefixSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::CheckNullifiersByPrefixRequest,
+                    > for CheckNullifiersByPrefixSvc<T> {
+                        type Response = super::super::responses::CheckNullifiersByPrefixResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::requests::CheckNullifiersByPrefixRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::check_nullifiers_by_prefix(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CheckNullifiersByPrefixSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/rpc.Api/CheckNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct CheckNullifiersSvc<T: Api>(pub Arc<T>);

--- a/crates/proto/src/generated/store.rs
+++ b/crates/proto/src/generated/store.rs
@@ -106,6 +106,33 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("store.Api", "ApplyBlock"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn check_nullifiers_by_prefix(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::requests::CheckNullifiersByPrefixRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersByPrefixResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/CheckNullifiersByPrefix",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("store.Api", "CheckNullifiersByPrefix"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn check_nullifiers(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -419,6 +446,15 @@ pub mod api_server {
             tonic::Response<super::super::responses::ApplyBlockResponse>,
             tonic::Status,
         >;
+        async fn check_nullifiers_by_prefix(
+            &self,
+            request: tonic::Request<
+                super::super::requests::CheckNullifiersByPrefixRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersByPrefixResponse>,
+            tonic::Status,
+        >;
         async fn check_nullifiers(
             &self,
             request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
@@ -619,6 +655,56 @@ pub mod api_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = ApplyBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/store.Api/CheckNullifiersByPrefix" => {
+                    #[allow(non_camel_case_types)]
+                    struct CheckNullifiersByPrefixSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::CheckNullifiersByPrefixRequest,
+                    > for CheckNullifiersByPrefixSvc<T> {
+                        type Response = super::super::responses::CheckNullifiersByPrefixResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::requests::CheckNullifiersByPrefixRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::check_nullifiers_by_prefix(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CheckNullifiersByPrefixSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/proto/src/generated/store.rs
+++ b/crates/proto/src/generated/store.rs
@@ -106,6 +106,32 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("store.Api", "ApplyBlock"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn check_nullifiers(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::requests::CheckNullifiersRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/CheckNullifiers",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("store.Api", "CheckNullifiers"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn check_nullifiers_by_prefix(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -131,32 +157,6 @@ pub mod api_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("store.Api", "CheckNullifiersByPrefix"));
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn check_nullifiers(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::requests::CheckNullifiersRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::super::responses::CheckNullifiersResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/store.Api/CheckNullifiers",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("store.Api", "CheckNullifiers"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_account_details(
@@ -446,6 +446,13 @@ pub mod api_server {
             tonic::Response<super::super::responses::ApplyBlockResponse>,
             tonic::Status,
         >;
+        async fn check_nullifiers(
+            &self,
+            request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::CheckNullifiersResponse>,
+            tonic::Status,
+        >;
         async fn check_nullifiers_by_prefix(
             &self,
             request: tonic::Request<
@@ -453,13 +460,6 @@ pub mod api_server {
             >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::CheckNullifiersByPrefixResponse>,
-            tonic::Status,
-        >;
-        async fn check_nullifiers(
-            &self,
-            request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::super::responses::CheckNullifiersResponse>,
             tonic::Status,
         >;
         async fn get_account_details(
@@ -670,6 +670,55 @@ pub mod api_server {
                     };
                     Box::pin(fut)
                 }
+                "/store.Api/CheckNullifiers" => {
+                    #[allow(non_camel_case_types)]
+                    struct CheckNullifiersSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::UnaryService<
+                        super::super::requests::CheckNullifiersRequest,
+                    > for CheckNullifiersSvc<T> {
+                        type Response = super::super::responses::CheckNullifiersResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::requests::CheckNullifiersRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::check_nullifiers(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CheckNullifiersSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/store.Api/CheckNullifiersByPrefix" => {
                     #[allow(non_camel_case_types)]
                     struct CheckNullifiersByPrefixSvc<T: Api>(pub Arc<T>);
@@ -705,55 +754,6 @@ pub mod api_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = CheckNullifiersByPrefixSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/store.Api/CheckNullifiers" => {
-                    #[allow(non_camel_case_types)]
-                    struct CheckNullifiersSvc<T: Api>(pub Arc<T>);
-                    impl<
-                        T: Api,
-                    > tonic::server::UnaryService<
-                        super::super::requests::CheckNullifiersRequest,
-                    > for CheckNullifiersSvc<T> {
-                        type Response = super::super::responses::CheckNullifiersResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<
-                                super::super::requests::CheckNullifiersRequest,
-                            >,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Api>::check_nullifiers(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = CheckNullifiersSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -10,6 +10,12 @@ message ApplyBlockRequest {
     bytes block = 1;
 }
 
+// Returns a list of nullifiers recorded in the node
+message CheckNullifiersByPrefixRequest {
+    // Nullifier prefixes the client is interested in.
+    repeated uint32 prefixes = 1;
+}
+
 message CheckNullifiersRequest {
     repeated digest.Digest nullifiers = 1;
 }

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -10,9 +10,9 @@ message ApplyBlockRequest {
     bytes block = 1;
 }
 
-// Returns a list of nullifiers recorded in the node
+// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 message CheckNullifiersByPrefixRequest {
-    // Number of bits used for nullifier prefix.
+    // Number of bits used for nullifier prefix. Currently the only supported value is 16.
     uint32 prefix_len = 1;
     // List of nullifiers to check. Each nullifier is specified by its prefix with length equal
     // to prefix_len

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -12,8 +12,11 @@ message ApplyBlockRequest {
 
 // Returns a list of nullifiers recorded in the node
 message CheckNullifiersByPrefixRequest {
-    // Nullifier prefixes the client is interested in.
-    repeated uint32 prefixes = 1;
+    // Number of bits used for nullifier prefix.
+    uint32 prefix_len = 1;
+    // List of nullifiers to check. Each nullifier is specified by its prefix with length equal
+    // to prefix_len
+    repeated uint32 nullifiers = 2;
 }
 
 message CheckNullifiersRequest {

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -18,7 +18,7 @@ message CheckNullifiersResponse {
 }
 
 message CheckNullifiersByPrefixResponse {
-    // List of nullifiers matching the 16-bit prefixes specified in the request.
+    // List of nullifiers matching the prefixes specified in the request.
     repeated NullifierUpdate nullifiers = 1;
 }
 

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -17,6 +17,10 @@ message CheckNullifiersResponse {
     repeated smt.SmtOpening proofs = 1;
 }
 
+message CheckNullifiersByPrefixResponse {
+    repeated NullifierUpdate nullifiers = 1;
+}
+
 message GetBlockHeaderByNumberResponse {
     // The requested block header
     block_header.BlockHeader block_header = 1;

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -18,6 +18,7 @@ message CheckNullifiersResponse {
 }
 
 message CheckNullifiersByPrefixResponse {
+    // List of nullifiers matching the 16-bit prefixes specified in the request.
     repeated NullifierUpdate nullifiers = 1;
 }
 

--- a/crates/rpc-proto/proto/rpc.proto
+++ b/crates/rpc-proto/proto/rpc.proto
@@ -6,8 +6,8 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
-    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}

--- a/crates/rpc-proto/proto/rpc.proto
+++ b/crates/rpc-proto/proto/rpc.proto
@@ -6,6 +6,7 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}

--- a/crates/rpc-proto/proto/store.proto
+++ b/crates/rpc-proto/proto/store.proto
@@ -9,8 +9,8 @@ import "responses.proto";
 
 service Api {
     rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
-    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}

--- a/crates/rpc-proto/proto/store.proto
+++ b/crates/rpc-proto/proto/store.proto
@@ -9,6 +9,7 @@ import "responses.proto";
 
 service Api {
     rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -2,14 +2,14 @@ use miden_node_proto::{
     generated::{
         block_producer::api_client as block_producer_client,
         requests::{
-            CheckNullifiersRequest, GetAccountDetailsRequest, GetAccountStateDeltaRequest,
-            GetBlockByNumberRequest, GetBlockHeaderByNumberRequest, GetNotesByIdRequest,
-            SubmitProvenTransactionRequest, SyncStateRequest,
+            CheckNullifiersByPrefixRequest, CheckNullifiersRequest, GetAccountDetailsRequest,
+            GetAccountStateDeltaRequest, GetBlockByNumberRequest, GetBlockHeaderByNumberRequest,
+            GetNotesByIdRequest, SubmitProvenTransactionRequest, SyncStateRequest,
         },
         responses::{
-            CheckNullifiersResponse, GetAccountDetailsResponse, GetAccountStateDeltaResponse,
-            GetBlockByNumberResponse, GetBlockHeaderByNumberResponse, GetNotesByIdResponse,
-            SubmitProvenTransactionResponse, SyncStateResponse,
+            CheckNullifiersByPrefixResponse, CheckNullifiersResponse, GetAccountDetailsResponse,
+            GetAccountStateDeltaResponse, GetBlockByNumberResponse, GetBlockHeaderByNumberResponse,
+            GetNotesByIdResponse, SubmitProvenTransactionResponse, SyncStateResponse,
         },
         rpc::api_server,
         store::api_client as store_client,
@@ -80,6 +80,22 @@ impl api_server::Api for RpcApi {
         }
 
         self.store.clone().check_nullifiers(request).await
+    }
+
+    #[instrument(
+        target = "miden-rpc",
+        name = "rpc:check_nullifiers_by_prefix",
+        skip_all,
+        ret(level = "debug"),
+        err
+    )]
+    async fn check_nullifiers_by_prefix(
+        &self,
+        request: Request<CheckNullifiersByPrefixRequest>,
+    ) -> Result<Response<CheckNullifiersByPrefixResponse>, Status> {
+        debug!(target: COMPONENT, request = ?request.get_ref());
+
+        self.store.clone().check_nullifiers_by_prefix(request).await
     }
 
     #[instrument(

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -165,6 +165,7 @@ impl Db {
     }
 
     /// Loads the nullifiers that match the prefixes from the DB.
+    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
     pub async fn select_nullifiers_by_prefix(
         &self,
         prefix_len: u32,

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -166,12 +166,13 @@ impl Db {
 
     pub async fn select_nullifiers_by_prefix(
         &self,
-        prefixes: Vec<u32>,
+        prefix_len: u32,
+        nullifier_prefixes: Vec<u32>,
     ) -> Result<Vec<NullifierInfo>> {
         self.pool
             .get()
             .await?
-            .interact(move |conn| sql::select_nullifiers_by_prefix(conn, &prefixes))
+            .interact(move |conn| sql::select_nullifiers_by_prefix(conn, prefix_len, &nullifier_prefixes))
             .await
             .map_err(|err| {
                 DatabaseError::InteractError(format!(

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -164,6 +164,7 @@ impl Db {
         })?
     }
 
+    /// Loads the nullifiers that match the prefixes from the DB.
     pub async fn select_nullifiers_by_prefix(
         &self,
         prefix_len: u32,
@@ -172,7 +173,9 @@ impl Db {
         self.pool
             .get()
             .await?
-            .interact(move |conn| sql::select_nullifiers_by_prefix(conn, prefix_len, &nullifier_prefixes))
+            .interact(move |conn| {
+                sql::select_nullifiers_by_prefix(conn, prefix_len, &nullifier_prefixes)
+            })
             .await
             .map_err(|err| {
                 DatabaseError::InteractError(format!(

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -164,6 +164,22 @@ impl Db {
         })?
     }
 
+    pub async fn select_nullifiers_by_prefix(
+        &self,
+        prefixes: Vec<u32>,
+    ) -> Result<Vec<NullifierInfo>> {
+        self.pool
+            .get()
+            .await?
+            .interact(move |conn| sql::select_nullifiers_by_prefix(conn, &prefixes))
+            .await
+            .map_err(|err| {
+                DatabaseError::InteractError(format!(
+                    "Select nullifiers by prefix task failed: {err}"
+                ))
+            })?
+    }
+
     /// Loads all the notes from the DB.
     #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
     pub async fn select_notes(&self) -> Result<Vec<NoteRecord>> {

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -353,6 +353,17 @@ pub fn select_nullifiers_by_block_range(
     Ok(result)
 }
 
+/// Select nullifiers created that match the `nullifier_prefixes` filter using the given
+/// [Connection].
+///
+/// Each value of the `nullifier_prefixes` is only the `prefix_len` most significant bits
+/// of the nullifier of interest to the client. This hides the details of the specific
+/// nullifier being requested.
+///
+/// # Returns
+///
+/// A vector of [NullifierInfo] with the nullifiers and the block height at which they were
+/// created, or an error.
 pub fn select_nullifiers_by_prefix(
     conn: &mut Connection,
     _prefix_len: u32,

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -358,7 +358,7 @@ pub fn select_nullifiers_by_block_range(
 ///
 /// Each value of the `nullifier_prefixes` is only the `prefix_len` most significant bits
 /// of the nullifier of interest to the client. This hides the details of the specific
-/// nullifier being requested.
+/// nullifier being requested. Currently the only supported prefix length is 16 bits.
 ///
 /// # Returns
 ///
@@ -366,9 +366,11 @@ pub fn select_nullifiers_by_block_range(
 /// created, or an error.
 pub fn select_nullifiers_by_prefix(
     conn: &mut Connection,
-    _prefix_len: u32,
+    prefix_len: u32,
     nullifier_prefixes: &[u32],
 ) -> Result<Vec<NullifierInfo>> {
+    assert_eq!(prefix_len, 16, "Only 16-bit prefixes are supported");
+
     let nullifier_prefixes: Vec<Value> =
         nullifier_prefixes.iter().copied().map(u32_to_value).collect();
 

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -355,6 +355,7 @@ pub fn select_nullifiers_by_block_range(
 
 pub fn select_nullifiers_by_prefix(
     conn: &mut Connection,
+    _prefix_len: u32,
     nullifier_prefixes: &[u32],
 ) -> Result<Vec<NullifierInfo>> {
     let nullifier_prefixes: Vec<Value> =

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -540,9 +540,9 @@ fn test_sql_select_nullifiers_by_block_range() {
 #[test]
 fn test_select_nullifiers_by_prefix() {
     let mut conn = create_db();
-
+    const PREFIX_LEN: u32 = 16;
     // test empty table
-    let nullifiers = sql::select_nullifiers_by_prefix(&mut conn, &[]).unwrap();
+    let nullifiers = sql::select_nullifiers_by_prefix(&mut conn, PREFIX_LEN, &[]).unwrap();
     assert!(nullifiers.is_empty());
 
     // test single item
@@ -554,9 +554,12 @@ fn test_select_nullifiers_by_prefix() {
     sql::insert_nullifiers_for_block(&transaction, &[nullifier1], block_number1).unwrap();
     transaction.commit().unwrap();
 
-    let nullifiers =
-        sql::select_nullifiers_by_prefix(&mut conn, &[sql::get_nullifier_prefix(&nullifier1)])
-            .unwrap();
+    let nullifiers = sql::select_nullifiers_by_prefix(
+        &mut conn,
+        PREFIX_LEN,
+        &[sql::get_nullifier_prefix(&nullifier1)],
+    )
+    .unwrap();
     assert_eq!(
         nullifiers,
         vec![NullifierInfo {
@@ -578,9 +581,12 @@ fn test_select_nullifiers_by_prefix() {
     assert_eq!(nullifiers, vec![(nullifier1, block_number1), (nullifier2, block_number2)]);
 
     // only the nullifiers matching the prefix are included
-    let nullifiers =
-        sql::select_nullifiers_by_prefix(&mut conn, &[sql::get_nullifier_prefix(&nullifier1)])
-            .unwrap();
+    let nullifiers = sql::select_nullifiers_by_prefix(
+        &mut conn,
+        PREFIX_LEN,
+        &[sql::get_nullifier_prefix(&nullifier1)],
+    )
+    .unwrap();
     assert_eq!(
         nullifiers,
         vec![NullifierInfo {
@@ -588,9 +594,12 @@ fn test_select_nullifiers_by_prefix() {
             block_num: block_number1
         }]
     );
-    let nullifiers =
-        sql::select_nullifiers_by_prefix(&mut conn, &[sql::get_nullifier_prefix(&nullifier2)])
-            .unwrap();
+    let nullifiers = sql::select_nullifiers_by_prefix(
+        &mut conn,
+        PREFIX_LEN,
+        &[sql::get_nullifier_prefix(&nullifier2)],
+    )
+    .unwrap();
     assert_eq!(
         nullifiers,
         vec![NullifierInfo {
@@ -602,6 +611,7 @@ fn test_select_nullifiers_by_prefix() {
     // All matching nullifiers are included
     let nullifiers = sql::select_nullifiers_by_prefix(
         &mut conn,
+        PREFIX_LEN,
         &[sql::get_nullifier_prefix(&nullifier1), sql::get_nullifier_prefix(&nullifier2)],
     )
     .unwrap();
@@ -622,6 +632,7 @@ fn test_select_nullifiers_by_prefix() {
     // If a non-matching prefix is provided, no nullifiers are returned
     let nullifiers = sql::select_nullifiers_by_prefix(
         &mut conn,
+        PREFIX_LEN,
         &[sql::get_nullifier_prefix(&num_to_nullifier(3 << 48))],
     )
     .unwrap();

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -538,6 +538,97 @@ fn test_sql_select_nullifiers_by_block_range() {
 }
 
 #[test]
+fn test_select_nullifiers_by_prefix() {
+    let mut conn = create_db();
+
+    // test empty table
+    let nullifiers = sql::select_nullifiers_by_prefix(&mut conn, &[]).unwrap();
+    assert!(nullifiers.is_empty());
+
+    // test single item
+    let nullifier1 = num_to_nullifier(1 << 48);
+    let block_number1 = 1;
+    create_block(&mut conn, block_number1);
+
+    let transaction = conn.transaction().unwrap();
+    sql::insert_nullifiers_for_block(&transaction, &[nullifier1], block_number1).unwrap();
+    transaction.commit().unwrap();
+
+    let nullifiers =
+        sql::select_nullifiers_by_prefix(&mut conn, &[sql::get_nullifier_prefix(&nullifier1)])
+            .unwrap();
+    assert_eq!(
+        nullifiers,
+        vec![NullifierInfo {
+            nullifier: nullifier1,
+            block_num: block_number1
+        }]
+    );
+
+    // test two elements
+    let nullifier2 = num_to_nullifier(2 << 48);
+    let block_number2 = 2;
+    create_block(&mut conn, block_number2);
+
+    let transaction = conn.transaction().unwrap();
+    sql::insert_nullifiers_for_block(&transaction, &[nullifier2], block_number2).unwrap();
+    transaction.commit().unwrap();
+
+    let nullifiers = sql::select_nullifiers(&mut conn).unwrap();
+    assert_eq!(nullifiers, vec![(nullifier1, block_number1), (nullifier2, block_number2)]);
+
+    // only the nullifiers matching the prefix are included
+    let nullifiers =
+        sql::select_nullifiers_by_prefix(&mut conn, &[sql::get_nullifier_prefix(&nullifier1)])
+            .unwrap();
+    assert_eq!(
+        nullifiers,
+        vec![NullifierInfo {
+            nullifier: nullifier1,
+            block_num: block_number1
+        }]
+    );
+    let nullifiers =
+        sql::select_nullifiers_by_prefix(&mut conn, &[sql::get_nullifier_prefix(&nullifier2)])
+            .unwrap();
+    assert_eq!(
+        nullifiers,
+        vec![NullifierInfo {
+            nullifier: nullifier2,
+            block_num: block_number2
+        }]
+    );
+
+    // All matching nullifiers are included
+    let nullifiers = sql::select_nullifiers_by_prefix(
+        &mut conn,
+        &[sql::get_nullifier_prefix(&nullifier1), sql::get_nullifier_prefix(&nullifier2)],
+    )
+    .unwrap();
+    assert_eq!(
+        nullifiers,
+        vec![
+            NullifierInfo {
+                nullifier: nullifier1,
+                block_num: block_number1
+            },
+            NullifierInfo {
+                nullifier: nullifier2,
+                block_num: block_number2
+            }
+        ]
+    );
+
+    // If a non-matching prefix is provided, no nullifiers are returned
+    let nullifiers = sql::select_nullifiers_by_prefix(
+        &mut conn,
+        &[sql::get_nullifier_prefix(&num_to_nullifier(3 << 48))],
+    )
+    .unwrap();
+    assert!(nullifiers.is_empty());
+}
+
+#[test]
 fn test_db_block_header() {
     let mut conn = create_db();
 

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -8,18 +8,19 @@ use miden_node_proto::{
         account::AccountSummary,
         note::NoteSyncRecord,
         requests::{
-            ApplyBlockRequest, CheckNullifiersRequest, GetAccountDetailsRequest,
-            GetAccountStateDeltaRequest, GetBlockByNumberRequest, GetBlockHeaderByNumberRequest,
-            GetBlockInputsRequest, GetNotesByIdRequest, GetTransactionInputsRequest,
-            ListAccountsRequest, ListNotesRequest, ListNullifiersRequest, SyncStateRequest,
+            ApplyBlockRequest, CheckNullifiersByPrefixRequest, CheckNullifiersRequest,
+            GetAccountDetailsRequest, GetAccountStateDeltaRequest, GetBlockByNumberRequest,
+            GetBlockHeaderByNumberRequest, GetBlockInputsRequest, GetNotesByIdRequest,
+            GetTransactionInputsRequest, ListAccountsRequest, ListNotesRequest,
+            ListNullifiersRequest, SyncStateRequest,
         },
         responses::{
-            AccountTransactionInputRecord, ApplyBlockResponse, CheckNullifiersResponse,
-            GetAccountDetailsResponse, GetAccountStateDeltaResponse, GetBlockByNumberResponse,
-            GetBlockHeaderByNumberResponse, GetBlockInputsResponse, GetNotesByIdResponse,
-            GetTransactionInputsResponse, ListAccountsResponse, ListNotesResponse,
-            ListNullifiersResponse, NullifierTransactionInputRecord, NullifierUpdate,
-            SyncStateResponse,
+            AccountTransactionInputRecord, ApplyBlockResponse, CheckNullifiersByPrefixResponse,
+            CheckNullifiersResponse, GetAccountDetailsResponse, GetAccountStateDeltaResponse,
+            GetBlockByNumberResponse, GetBlockHeaderByNumberResponse, GetBlockInputsResponse,
+            GetNotesByIdResponse, GetTransactionInputsResponse, ListAccountsResponse,
+            ListNotesResponse, ListNullifiersResponse, NullifierTransactionInputRecord,
+            NullifierUpdate, SyncStateResponse,
         },
         smt::SmtLeafEntry,
         store::api_server,
@@ -108,6 +109,35 @@ impl api_server::Api for StoreApi {
         let proofs = self.state.check_nullifiers(&nullifiers).await;
 
         Ok(Response::new(CheckNullifiersResponse { proofs: convert(proofs) }))
+    }
+
+    #[instrument(
+        target = "miden-store",
+        name = "store:check_nullifiers_by_prefix",
+        skip_all,
+        ret(level = "debug"),
+        err
+    )]
+    async fn check_nullifiers_by_prefix(
+        &self,
+        request: tonic::Request<CheckNullifiersByPrefixRequest>,
+    ) -> Result<Response<CheckNullifiersByPrefixResponse>, Status> {
+        let request = request.into_inner();
+        let prefixes = request.prefixes;
+
+        let nullifiers = self
+            .state
+            .check_nullifiers_by_prefix(prefixes)
+            .await
+            .map_err(internal_error)?
+            .into_iter()
+            .map(|nullifier_info| NullifierUpdate {
+                nullifier: Some(nullifier_info.nullifier.into()),
+                block_num: nullifier_info.block_num,
+            })
+            .collect();
+
+        Ok(Response::new(CheckNullifiersByPrefixResponse { nullifiers }))
     }
 
     /// Returns info which can be used by the client to sync up to the latest state of the chain

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -111,6 +111,9 @@ impl api_server::Api for StoreApi {
         Ok(Response::new(CheckNullifiersResponse { proofs: convert(proofs) }))
     }
 
+    /// Returns nullifiers that match the specified prefixes and have been consumed.
+    ///
+    /// Currently the only supported prefix length is 16 bits.
     #[instrument(
         target = "miden-store",
         name = "store:check_nullifiers_by_prefix",

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -123,11 +123,14 @@ impl api_server::Api for StoreApi {
         request: tonic::Request<CheckNullifiersByPrefixRequest>,
     ) -> Result<Response<CheckNullifiersByPrefixResponse>, Status> {
         let request = request.into_inner();
-        let prefixes = request.prefixes;
+
+        if request.prefix_len != 16 {
+            return Err(Status::invalid_argument("Only 16-bit prefixes are supported"));
+        }
 
         let nullifiers = self
             .state
-            .check_nullifiers_by_prefix(prefixes)
+            .check_nullifiers_by_prefix(request.prefix_len, request.nullifiers)
             .await
             .map_err(internal_error)?
             .into_iter()

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -368,6 +368,13 @@ impl State {
         }
     }
 
+    pub async fn check_nullifiers_by_prefix(
+        &self,
+        prefixes: Vec<u32>,
+    ) -> Result<Vec<NullifierInfo>, DatabaseError> {
+        self.db.select_nullifiers_by_prefix(prefixes).await
+    }
+
     /// Generates membership proofs for each one of the `nullifiers` against the latest nullifier
     /// tree.
     ///

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -370,9 +370,10 @@ impl State {
 
     pub async fn check_nullifiers_by_prefix(
         &self,
-        prefixes: Vec<u32>,
+        prefix_len: u32,
+        nullifier_prefixes: Vec<u32>,
     ) -> Result<Vec<NullifierInfo>, DatabaseError> {
-        self.db.select_nullifiers_by_prefix(prefixes).await
+        self.db.select_nullifiers_by_prefix(prefix_len, nullifier_prefixes).await
     }
 
     /// Generates membership proofs for each one of the `nullifiers` against the latest nullifier

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -10,6 +10,12 @@ message ApplyBlockRequest {
     bytes block = 1;
 }
 
+// Returns a list of nullifiers recorded in the node
+message CheckNullifiersByPrefixRequest {
+    // Nullifier prefixes the client is interested in.
+    repeated uint32 prefixes = 1;
+}
+
 message CheckNullifiersRequest {
     repeated digest.Digest nullifiers = 1;
 }

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -10,9 +10,9 @@ message ApplyBlockRequest {
     bytes block = 1;
 }
 
-// Returns a list of nullifiers recorded in the node
+// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 message CheckNullifiersByPrefixRequest {
-    // Number of bits used for nullifier prefix.
+    // Number of bits used for nullifier prefix. Currently the only supported value is 16.
     uint32 prefix_len = 1;
     // List of nullifiers to check. Each nullifier is specified by its prefix with length equal
     // to prefix_len

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -12,8 +12,11 @@ message ApplyBlockRequest {
 
 // Returns a list of nullifiers recorded in the node
 message CheckNullifiersByPrefixRequest {
-    // Nullifier prefixes the client is interested in.
-    repeated uint32 prefixes = 1;
+    // Number of bits used for nullifier prefix.
+    uint32 prefix_len = 1;
+    // List of nullifiers to check. Each nullifier is specified by its prefix with length equal
+    // to prefix_len
+    repeated uint32 nullifiers = 2;
 }
 
 message CheckNullifiersRequest {

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -18,7 +18,7 @@ message CheckNullifiersResponse {
 }
 
 message CheckNullifiersByPrefixResponse {
-    // List of nullifiers matching the 16-bit prefixes specified in the request.
+    // List of nullifiers matching the prefixes specified in the request.
     repeated NullifierUpdate nullifiers = 1;
 }
 

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -17,6 +17,10 @@ message CheckNullifiersResponse {
     repeated smt.SmtOpening proofs = 1;
 }
 
+message CheckNullifiersByPrefixResponse {
+    repeated NullifierUpdate nullifiers = 1;
+}
+
 message GetBlockHeaderByNumberResponse {
     // The requested block header
     block_header.BlockHeader block_header = 1;

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -18,6 +18,7 @@ message CheckNullifiersResponse {
 }
 
 message CheckNullifiersByPrefixResponse {
+    // List of nullifiers matching the 16-bit prefixes specified in the request.
     repeated NullifierUpdate nullifiers = 1;
 }
 

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -6,8 +6,8 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
-    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -6,6 +6,7 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -9,8 +9,8 @@ import "responses.proto";
 
 service Api {
     rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
-    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -9,6 +9,7 @@ import "responses.proto";
 
 service Api {
     rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
+    rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
     rpc GetAccountDetails(requests.GetAccountDetailsRequest) returns (responses.GetAccountDetailsResponse) {}
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}


### PR DESCRIPTION
closes #404

This is my first time implementing something in the node, I originally made this to better understand the node internals. Be sure to correct me if I missed something important in terms of validation or security.

This PR looks to add a new endpoint to the node that lets users check if a note is consumed without directly exposing its nullifier. In the next hours I'll also be adding a PR in the client that uses this endpoint to deal with imported notes.