### PR TITLE
Make accounts optional for genesis generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Embed the faucet's static website resources (#411).
 - CI check for proto file consistency (#412).
 - Added warning on CI for `CHANGELOG.md` (#413).
+- Now accounts for genesis are optional. Accounts directory will be overwritten, if `--force` flag is set (#420).
 
 ### Fixes
 

--- a/bin/node/src/commands/genesis/inputs.rs
+++ b/bin/node/src/commands/genesis/inputs.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct GenesisInput {
     pub version: u32,
     pub timestamp: u32,
-    pub accounts: Vec<AccountInput>,
+    pub accounts: Option<Vec<AccountInput>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -54,7 +54,7 @@ impl Default for GenesisInput {
                 .duration_since(UNIX_EPOCH)
                 .expect("Current timestamp should be greater than unix epoch")
                 .as_secs() as u32,
-            accounts: vec![
+            accounts: Some(vec![
                 AccountInput::BasicWallet(BasicWalletInputs {
                     init_seed: "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
                         .to_string(),
@@ -74,7 +74,7 @@ impl Default for GenesisInput {
                     max_supply: 1000000,
                     storage_mode: "on-chain".to_string(),
                 }),
-            ],
+            ]),
         }
     }
 }

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Context, Result};
 pub use inputs::{AccountInput, AuthSchemeInput, GenesisInput};
 use miden_lib::{
     accounts::{faucets::create_basic_fungible_faucet, wallets::create_basic_wallet},
@@ -83,7 +83,8 @@ pub fn make_genesis(inputs_path: &PathBuf, output_path: &PathBuf, force: &bool) 
     })?;
     info!("Genesis input file: {} has successfully been loaded.", output_path.display());
 
-    let accounts = create_accounts(&genesis_input.accounts, parent_path, force)?;
+    let accounts =
+        create_accounts(&genesis_input.accounts.unwrap_or_default(), parent_path, force)?;
     info!(
         "Accounts have successfully been created at: {}/{}",
         parent_path.display(),
@@ -110,10 +111,17 @@ fn create_accounts(
     let mut accounts_path = PathBuf::from(&parent_path);
     accounts_path.push(DEFAULT_ACCOUNTS_DIR);
 
-    if !accounts_path.try_exists()? {
-        fs::create_dir_all(&accounts_path)
-            .map_err(|err| anyhow!("Failed to create accounts directory: {err}"))?;
+    if accounts_path.try_exists()? {
+        if !force {
+            bail!(
+                "Failed to create accounts directory because it already exists. \
+                Use the --force flag to overwrite."
+            );
+        }
+        fs::remove_dir_all(&accounts_path).context("Failed to remove accounts directory")?;
     }
+
+    fs::create_dir_all(&accounts_path).context("Failed to create accounts directory")?;
 
     let mut final_accounts = Vec::new();
 
@@ -167,7 +175,7 @@ fn create_accounts(
 
         if let Ok(path_exists) = path.try_exists() {
             if path_exists && !force {
-                return Err(anyhow!("Failed to generate account file {} because it already exists. Use the --force flag to overwrite.", path.display()));
+                bail!("Failed to generate account file {} because it already exists. Use the --force flag to overwrite.", path.display());
             }
         }
 


### PR DESCRIPTION
Resolves: https://github.com/0xPolygonMiden/miden-node/issues/198

With this PR user won't be forced to create at least one account in genesis. Also I slightly changed behavior working with `accounts` directory during genesis creation: if this directory already exists, program will fail. If `--force` flag is provided, directory will be overwritten.