### PR TITLE
feat(store): cache sql statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `GetAccountStateDelta` endpoint (#418).
 - Added `CheckNullifiersByPrefix` endpoint (#419).
 - Support multiple inflight transactions on the same account (#407).
+- Cache sql statements (#427).
 
 ### Fixes
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     errors::{DatabaseError, DatabaseSetupError, GenesisError, StateSyncError},
     genesis::GenesisState,
     types::{AccountId, BlockNumber},
-    COMPONENT,
+    COMPONENT, SQL_STATEMENT_CACHE_CAPACITY,
 };
 
 mod migrations;
@@ -117,6 +117,11 @@ impl Db {
                             // this module for every connection we create to the DB to support the
                             // queries we want to run
                             array::load_module(conn)?;
+
+                            // Increase the statement cache size.
+                            conn.set_prepared_statement_cache_capacity(
+                                SQL_STATEMENT_CACHE_CAPACITY,
+                            );
 
                             // Enable the WAL mode. This allows concurrent reads while the
                             // transaction is being written, this is required for proper

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -11,3 +11,6 @@ pub mod types;
 // CONSTANTS
 // =================================================================================================
 pub const COMPONENT: &str = "miden-store";
+
+/// Number of sql statements that each connection will cache.
+const SQL_STATEMENT_CACHE_CAPACITY: usize = 32;


### PR DESCRIPTION
Replace all `conn.prepare` with `conn.prepare_cached` and double the cache size limit from the [default of 16](https://docs.rs/rusqlite/latest/src/rusqlite/lib.rs.html#152) to 32. We currently have 22 different statements so this should be adequate for a while.

Closes #423.