### PR TITLE
ci: auto-close linked issues

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,17 +2,19 @@
 # Runs changelog related jobs.
 # CI job heavily inspired by: https://github.com/tarides/changelog-check-action
 
-name: changelog
+name: auto-close
 
 on:
   pull_request:
     types: [opened, reopened, edited]
 
 jobs:
-  changelog:
+  auto-close:
     runs-on: ubuntu-latest
     steps:
       - name: Log stuff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           linked_issue_id="$( gh api graphql -f query='
           query($pr:ID!) {

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,21 @@
+
+# Runs changelog related jobs.
+# CI job heavily inspired by: https://github.com/tarides/changelog-check-action
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log stuff
+        run: |
+          echo Issue url: ${{ github.event.pull_request.issue_url }}
+          echo ID: ${{ github.event.pull_request.id }}
+          echo Node ID: ${{ github.event.pull_request.node_id }}
+          echo Number: ${{ github.event.pull_request.number }}
+          echo Links: ${{ github.event.pull_request._links.issue.href }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log stuff
-        env:
-          PR_ID: ${{ github.event.pull_request.node_id }}
         run: |
           linked_issue_id="$( gh api graphql -f query='
           query($pr:ID!) {
@@ -33,8 +31,6 @@ jobs:
                 }
               }
             }
-          }' -f pr=$PR_ID --jq '.data.node.closingIssuesReferences.nodes[0].projectItems.nodes[0].id')"
+          }' -f pr=${{ github.event.pull_request.node_id }} --jq '.data.node.closingIssuesReferences.nodes[0].projectItems.nodes[0].id')"
           echo "ISSUE ID:"
           echo "$linked_issue_id"
-          echo "PR_ID:"
-          echo "${{env.PR_ID}}"

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -6,7 +6,7 @@ name: changelog
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
 
 jobs:
   changelog:

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,14 +2,14 @@
 # Runs changelog related jobs.
 # CI job heavily inspired by: https://github.com/tarides/changelog-check-action
 
-name: issue_closer
+name: changelog
 
 on:
   pull_request:
     types: [opened, reopened]
 
 jobs:
-  close_test:
+  changelog:
     runs-on: ubuntu-latest
     steps:
       - name: Log stuff

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -24,15 +24,10 @@ jobs:
                   totalCount
                   nodes { 
                     id 
-                    projectItems(first: 5) {
-                      nodes {
-                        id
-                      }
-                    }
                   }
                 }
               }
             }
-          }' -f pr=${{ github.event.pull_request.node_id }} --jq '.data.node.closingIssuesReferences.nodes[0].projectItems.nodes[0].id')"
+          }' -f pr=${{ github.event.pull_request.node_id }} --jq '.data.node.closingIssuesReferences.nodes[0].id')"
           echo "ISSUE ID:"
           echo "$linked_issue_id"

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,14 +2,14 @@
 # Runs changelog related jobs.
 # CI job heavily inspired by: https://github.com/tarides/changelog-check-action
 
-name: issue closer
+name: issue_closer
 
 on:
   pull_request:
     types: [opened, reopened]
 
 jobs:
-  close:
+  close_test:
     runs-on: ubuntu-latest
     steps:
       - name: Log stuff

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -6,7 +6,7 @@ name: auto-close
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   auto-close:
@@ -28,6 +28,6 @@ jobs:
                 }
               }
             }
-          }' -f pr=${{ github.event.pull_request.node_id }} --jq '.data.node.closingIssuesReferences.nodes[0].id')"
+          }' -f pr=${{ github.event.pull_request.node_id }} --jq '.data.node.closingIssuesReferences')"
           echo "ISSUE ID:"
           echo "$linked_issue_id"

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,20 +2,39 @@
 # Runs changelog related jobs.
 # CI job heavily inspired by: https://github.com/tarides/changelog-check-action
 
-name: changelog
+name: issue closer
 
 on:
   pull_request:
     types: [opened, reopened]
 
 jobs:
-  changelog:
+  close:
     runs-on: ubuntu-latest
     steps:
       - name: Log stuff
+        env:
+          PR_ID: ${{ github.event.pull_request.node_id }}
         run: |
-          echo Issue url: ${{ github.event.pull_request.issue_url }}
-          echo ID: ${{ github.event.pull_request.id }}
-          echo Node ID: ${{ github.event.pull_request.node_id }}
-          echo Number: ${{ github.event.pull_request.number }}
-          echo Links: ${{ github.event.pull_request._links.issue.href }}
+          linked_issue_id="$( gh api graphql -f query='
+          query($pr:ID!) {
+            node(id: $pr) {
+              ... on PullRequest {
+                closingIssuesReferences(first:1, userLinkedOnly:false) {
+                  totalCount
+                  nodes { 
+                    id 
+                    projectItems(first: 5) {
+                      nodes {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f pr=$PR_ID --jq '.data.node.closingIssuesReferences.nodes[0].projectItems.nodes[0].id')"
+          echo "ISSUE ID:"
+          echo "$linked_issue_id"
+          echo "PR_ID:"
+          echo "${{env.PR_ID}}"


### PR DESCRIPTION
Playing with a workflow to close issues on merge into `next`.

Example action [here](https://medium.com/@martatatiana/github-projects-change-issue-status-based-on-pull-request-change-45dcacab9fb7).

Closes #431 