### PR TITLE
feat: Add note `execution_hint` to store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Support multiple inflight transactions on the same account (#407).
 - Added `SyncNotes` endpoint (#424).
 - Cache sql statements (#427).
+- Added `execution_hint` field to `Notes` table.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Support multiple inflight transactions on the same account (#407).
 - Added `SyncNotes` endpoint (#424).
 - Cache sql statements (#427).
-- Added `execution_hint` field to `Notes` table.
+- Added `execution_hint` field to `Notes` table (#441).
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#30ef0b225cd2a9f430a13e385937653e8f47408c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#017d4be2018a660d8550c246c37fc8a7b02217e6"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#30ef0b225cd2a9f430a13e385937653e8f47408c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#017d4be2018a660d8550c246c37fc8a7b02217e6"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#30ef0b225cd2a9f430a13e385937653e8f47408c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#017d4be2018a660d8550c246c37fc8a7b02217e6"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2569,18 +2569,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.206"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.206"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.8.0"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -170,6 +170,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -614,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 dependencies = [
  "jobserver",
  "libc",
@@ -674,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -684,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -743,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1239,6 +1240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#3e777450d5e240655f04502a82e26db91ebd302c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#30ef0b225cd2a9f430a13e385937653e8f47408c"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1712,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#3e777450d5e240655f04502a82e26db91ebd302c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#30ef0b225cd2a9f430a13e385937653e8f47408c"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1763,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.5.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#3e777450d5e240655f04502a82e26db91ebd302c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#30ef0b225cd2a9f430a13e385937653e8f47408c"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1851,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -2001,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -2562,18 +2569,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2582,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
  "itoa",
  "memchr",
@@ -2729,9 +2736,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2746,15 +2753,15 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3387,6 +3394,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -73,9 +73,14 @@ pub async fn get_tokens(
         .expect("failed to build note tag for local execution");
 
     // Serialize note into bytes
-    // NOTE: Because this client does not sync, it always effectively executes against block 0. 
+    // NOTE: Because this client does not sync, it always effectively executes against block 0.
     // Ideally, we should export these note details with a more sensible `after_block_num`
-    let bytes = NoteFile::NoteDetails { details: note_details, after_block_num: 0, tag: Some(note_tag) }.to_bytes();
+    let bytes = NoteFile::NoteDetails {
+        details: note_details,
+        after_block_num: 0,
+        tag: Some(note_tag),
+    }
+    .to_bytes();
 
     info!("A new note has been created: {}", note_id);
 

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -73,7 +73,9 @@ pub async fn get_tokens(
         .expect("failed to build note tag for local execution");
 
     // Serialize note into bytes
-    let bytes = NoteFile::NoteDetails(note_details, Some(note_tag)).to_bytes();
+    // NOTE: Because this client does not sync, it always effectively executes against block 0. 
+    // Ideally, we should export these note details with a more sensible `after_block_num`
+    let bytes = NoteFile::NoteDetails { details: note_details, after_block_num: 0, tag: Some(note_tag) }.to_bytes();
 
     info!("A new note has been created: {}", note_id);
 

--- a/crates/block-producer/src/block_builder/prover/tests.rs
+++ b/crates/block-producer/src/block_builder/prover/tests.rs
@@ -13,7 +13,7 @@ use miden_objects::{
         EmptySubtreeRoots, LeafIndex, MerklePath, Mmr, MmrPeaks, SimpleSmt, Smt, SmtLeaf, SmtProof,
         SMT_DEPTH,
     },
-    notes::{NoteHeader, NoteMetadata, NoteTag, NoteType},
+    notes::{NoteExecutionHint, NoteHeader, NoteMetadata, NoteTag, NoteType},
     transaction::{OutputNote, ProvenTransaction},
     Felt, BLOCK_NOTES_TREE_DEPTH, ONE, ZERO,
 };
@@ -515,6 +515,7 @@ async fn test_compute_note_root_success() {
                 account_id,
                 NoteType::Private,
                 NoteTag::for_local_use_case(0u16, 0u16).unwrap(),
+                NoteExecutionHint::none(),
                 ONE,
             )
             .unwrap(),

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use miden_air::HashFunction;
 use miden_objects::{
     accounts::AccountId,
-    notes::{Note, NoteHeader, NoteMetadata, NoteType, Nullifier},
+    notes::{Note, NoteExecutionHint, NoteHeader, NoteMetadata, NoteType, Nullifier},
     transaction::{InputNote, OutputNote, ProvenTransaction, ProvenTransactionBuilder},
     vm::ExecutionProof,
     Digest, Felt, Hasher, ONE,
@@ -77,8 +77,14 @@ impl MockProvenTxBuilder {
         let notes = range
             .map(|note_index| {
                 let note_id = Hasher::hash(&note_index.to_be_bytes());
-                let note_metadata =
-                    NoteMetadata::new(self.account_id, NoteType::Private, 0.into(), ONE).unwrap();
+                let note_metadata = NoteMetadata::new(
+                    self.account_id,
+                    NoteType::Private,
+                    0.into(),
+                    NoteExecutionHint::none(),
+                    ONE,
+                )
+                .unwrap();
 
                 OutputNote::Header(NoteHeader::new(note_id.into(), note_metadata))
             })

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -26,8 +26,15 @@ impl From<NoteMetadata> for crate::generated::note::NoteMetadata {
         let sender = Some(val.sender().into());
         let note_type = val.note_type() as u32;
         let tag = val.tag().into();
+        let execution_hint: u64 = Felt::from(val.execution_hint()).into();
         let aux = val.aux().into();
 
-        crate::generated::note::NoteMetadata { sender, note_type, tag, aux }
+        crate::generated::note::NoteMetadata {
+            sender,
+            note_type,
+            tag,
+            execution_hint,
+            aux,
+        }
     }
 }

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -16,11 +16,7 @@ impl TryFrom<crate::generated::note::NoteMetadata> for NoteMetadata {
         let note_type = NoteType::try_from(value.note_type as u64)?;
         let tag = NoteTag::from(value.tag);
 
-        // TODO: Conversion/helper functions should be provided for these conversions
-        let execution_hint_tag = (value.execution_hint & 0xFF) as u8;
-        let execution_hint_payload = ((value.execution_hint >> 8) & 0xFFFFFF) as u32;
-        let execution_hint =
-            NoteExecutionHint::from_parts(execution_hint_tag, execution_hint_payload)?;
+        let execution_hint = NoteExecutionHint::try_from(value.execution_hint)?;
 
         let aux = Felt::try_from(value.aux).map_err(|_| ConversionError::NotAValidFelt)?;
 

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -15,9 +15,16 @@ impl TryFrom<crate::generated::note::NoteMetadata> for NoteMetadata {
             .try_into()?;
         let note_type = NoteType::try_from(value.note_type as u64)?;
         let tag = NoteTag::from(value.tag);
+
+        // TODO: Conversion/helper functions should be provided for these conversions
+        let execution_hint_tag = (value.execution_hint & 0xFF) as u8;
+        let execution_hint_payload = ((value.execution_hint >> 8) & 0xFFFFFF) as u32;
+        let execution_hint =
+            NoteExecutionHint::from_parts(execution_hint_tag, execution_hint_payload)?;
+
         let aux = Felt::try_from(value.aux).map_err(|_| ConversionError::NotAValidFelt)?;
 
-        Ok(NoteMetadata::new(sender, note_type, tag, NoteExecutionHint::none(), aux)?)
+        Ok(NoteMetadata::new(sender, note_type, tag, execution_hint, aux)?)
     }
 }
 

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    notes::{NoteMetadata, NoteTag, NoteType},
+    notes::{NoteExecutionHint, NoteMetadata, NoteTag, NoteType},
     Felt,
 };
 
@@ -17,7 +17,7 @@ impl TryFrom<crate::generated::note::NoteMetadata> for NoteMetadata {
         let tag = NoteTag::from(value.tag);
         let aux = Felt::try_from(value.aux).map_err(|_| ConversionError::NotAValidFelt)?;
 
-        Ok(NoteMetadata::new(sender, note_type, tag, aux)?)
+        Ok(NoteMetadata::new(sender, note_type, tag, NoteExecutionHint::none(),aux)?)
     }
 }
 

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -33,7 +33,7 @@ impl From<NoteMetadata> for crate::generated::note::NoteMetadata {
         let sender = Some(val.sender().into());
         let note_type = val.note_type() as u32;
         let tag = val.tag().into();
-        let execution_hint: u64 = Felt::from(val.execution_hint()).into();
+        let execution_hint: u64 = val.execution_hint().into();
         let aux = val.aux().into();
 
         crate::generated::note::NoteMetadata {

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -17,7 +17,7 @@ impl TryFrom<crate::generated::note::NoteMetadata> for NoteMetadata {
         let tag = NoteTag::from(value.tag);
         let aux = Felt::try_from(value.aux).map_err(|_| ConversionError::NotAValidFelt)?;
 
-        Ok(NoteMetadata::new(sender, note_type, tag, NoteExecutionHint::none(),aux)?)
+        Ok(NoteMetadata::new(sender, note_type, tag, NoteExecutionHint::none(), aux)?)
     }
 }
 

--- a/crates/proto/src/generated/note.rs
+++ b/crates/proto/src/generated/note.rs
@@ -9,6 +9,8 @@ pub struct NoteMetadata {
     #[prost(fixed32, tag = "3")]
     pub tag: u32,
     #[prost(fixed64, tag = "4")]
+    pub execution_hint: u64,
+    #[prost(fixed64, tag = "5")]
     pub aux: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/crates/rpc-proto/proto/note.proto
+++ b/crates/rpc-proto/proto/note.proto
@@ -9,7 +9,8 @@ message NoteMetadata {
     account.AccountId sender = 1;
     uint32 note_type = 2;
     fixed32 tag = 3;
-    fixed64 aux = 4;
+    fixed64 execution_hint = 4;
+    fixed64 aux = 5;
 }
 
 message Note {

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -23,16 +23,17 @@ CREATE TABLE
 CREATE TABLE
     notes
 (
-    block_num   INTEGER NOT NULL,
-    batch_index INTEGER NOT NULL, -- Index of batch in block, starting from 0
-    note_index  INTEGER NOT NULL, -- Index of note in batch, starting from 0
-    note_id     BLOB    NOT NULL,
-    note_type   INTEGER NOT NULL, -- 1-Public (0b01), 2-Private (0b10), 3-Encrypted (0b11)
-    sender      INTEGER NOT NULL,
-    tag         INTEGER NOT NULL,
-    aux         INTEGER NOT NULL,
-    merkle_path BLOB    NOT NULL,
-    details     BLOB,
+    block_num      INTEGER NOT NULL,
+    batch_index    INTEGER NOT NULL, -- Index of batch in block, starting from 0
+    note_index     INTEGER NOT NULL, -- Index of note in batch, starting from 0
+    note_id        BLOB    NOT NULL,
+    note_type      INTEGER NOT NULL, -- 1-Public (0b01), 2-Private (0b10), 3-Encrypted (0b11)
+    sender         INTEGER NOT NULL,
+    tag            INTEGER NOT NULL,
+    aux            INTEGER NOT NULL,
+    merkle_path    BLOB    NOT NULL,
+    details        BLOB,
+    execution_hint INTEGER,
 
     PRIMARY KEY (block_num, batch_index, note_index),
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num),

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -31,9 +31,9 @@ CREATE TABLE
     sender         INTEGER NOT NULL,
     tag            INTEGER NOT NULL,
     aux            INTEGER NOT NULL,
+    execution_hint INTEGER NOT NULL,
     merkle_path    BLOB    NOT NULL,
     details        BLOB,
-    execution_hint INTEGER,
 
     PRIMARY KEY (block_num, batch_index, note_index),
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num),

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -450,7 +450,13 @@ pub fn select_notes(conn: &mut Connection) -> Result<Vec<NoteRecord>> {
         let aux: u64 = row.get(7)?;
         let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
 
-        let metadata = NoteMetadata::new(sender.try_into()?, note_type, tag.into(), NoteExecutionHint::none(), aux)?;
+        let metadata = NoteMetadata::new(
+            sender.try_into()?,
+            note_type,
+            tag.into(),
+            NoteExecutionHint::none(),
+            aux,
+        )?;
 
         notes.push(NoteRecord {
             block_num: row.get(0)?,
@@ -590,8 +596,13 @@ pub fn select_notes_since_block_by_tag_and_sender(
         let details_data = row.get_ref(9)?.as_blob_or_null()?;
         let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
 
-        let metadata =
-            NoteMetadata::new(sender.try_into()?, NoteType::try_from(note_type)?, tag.into(), NoteExecutionHint::none(), aux)?;
+        let metadata = NoteMetadata::new(
+            sender.try_into()?,
+            NoteType::try_from(note_type)?,
+            tag.into(),
+            NoteExecutionHint::none(),
+            aux,
+        )?;
 
         let note = NoteRecord {
             block_num,
@@ -677,8 +688,13 @@ pub fn select_notes_since_block_by_tag(
         let details_data = row.get_ref(9)?.as_blob_or_null()?;
         let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
 
-        let metadata =
-            NoteMetadata::new(sender.try_into()?, NoteType::try_from(note_type)?, tag.into(), NoteExecutionHint::None, aux)?;
+        let metadata = NoteMetadata::new(
+            sender.try_into()?,
+            NoteType::try_from(note_type)?,
+            tag.into(),
+            NoteExecutionHint::None,
+            aux,
+        )?;
 
         let note = NoteRecord {
             block_num,
@@ -740,7 +756,13 @@ pub fn select_notes_by_id(conn: &mut Connection, note_ids: &[NoteId]) -> Result<
         let aux: u64 = row.get(7)?;
         let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
 
-        let metadata = NoteMetadata::new(sender.try_into()?, note_type, tag.into(), NoteExecutionHint::none(), aux)?;
+        let metadata = NoteMetadata::new(
+            sender.try_into()?,
+            note_type,
+            tag.into(),
+            NoteExecutionHint::none(),
+            aux,
+        )?;
 
         notes.push(NoteRecord {
             block_num: row.get(0)?,

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -450,7 +450,7 @@ pub fn select_notes(conn: &mut Connection) -> Result<Vec<NoteRecord>> {
         let tag: u32 = row.get(6)?;
         let aux: u64 = row.get(7)?;
         let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
-        let execution_hint = row.get_ref(10)?.as_i64()? as u64;
+        let execution_hint = column_value_as_u64(row, 10)?;
 
         let metadata = NoteMetadata::new(
             sender.try_into()?,
@@ -600,7 +600,7 @@ pub fn select_notes_since_block_by_tag_and_sender(
         let merkle_path = MerklePath::read_from_bytes(merkle_path_data)?;
         let details_data = row.get_ref(9)?.as_blob_or_null()?;
         let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
-        let execution_hint = row.get_ref(10)?.as_i64()? as u64;
+        let execution_hint = column_value_as_u64(row, 10)?;
 
         let metadata = NoteMetadata::new(
             sender.try_into()?,
@@ -694,7 +694,7 @@ pub fn select_notes_since_block_by_tag(
         let merkle_path = MerklePath::read_from_bytes(merkle_path_data)?;
         let details_data = row.get_ref(9)?.as_blob_or_null()?;
         let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
-        let execution_hint = row.get_ref(10)?.as_i64()? as u64;
+        let execution_hint = column_value_as_u64(row, 10)?;
 
         let metadata = NoteMetadata::new(
             sender.try_into()?,
@@ -764,7 +764,7 @@ pub fn select_notes_by_id(conn: &mut Connection, note_ids: &[NoteId]) -> Result<
         let tag: u32 = row.get(6)?;
         let aux: u64 = row.get(7)?;
         let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
-        let execution_hint = row.get_ref(10)?.as_i64()? as u64;
+        let execution_hint = column_value_as_u64(row, 10)?;
 
         let metadata = NoteMetadata::new(
             sender.try_into()?,

--- a/crates/store/src/db/sql.rs
+++ b/crates/store/src/db/sql.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     accounts::{delta::AccountUpdateDetails, Account, AccountDelta},
     block::{BlockAccountUpdate, BlockNoteIndex},
     crypto::{hash::rpo::RpoDigest, merkle::MerklePath},
-    notes::{NoteId, NoteMetadata, NoteType, Nullifier},
+    notes::{NoteExecutionHint, NoteId, NoteMetadata, NoteType, Nullifier},
     transaction::TransactionId,
     utils::serde::{Deserializable, Serializable},
     BlockHeader,
@@ -450,7 +450,7 @@ pub fn select_notes(conn: &mut Connection) -> Result<Vec<NoteRecord>> {
         let aux: u64 = row.get(7)?;
         let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
 
-        let metadata = NoteMetadata::new(sender.try_into()?, note_type, tag.into(), aux)?;
+        let metadata = NoteMetadata::new(sender.try_into()?, note_type, tag.into(), NoteExecutionHint::none(), aux)?;
 
         notes.push(NoteRecord {
             block_num: row.get(0)?,
@@ -591,7 +591,7 @@ pub fn select_notes_since_block_by_tag_and_sender(
         let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
 
         let metadata =
-            NoteMetadata::new(sender.try_into()?, NoteType::try_from(note_type)?, tag.into(), aux)?;
+            NoteMetadata::new(sender.try_into()?, NoteType::try_from(note_type)?, tag.into(), NoteExecutionHint::none(), aux)?;
 
         let note = NoteRecord {
             block_num,
@@ -678,7 +678,7 @@ pub fn select_notes_since_block_by_tag(
         let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
 
         let metadata =
-            NoteMetadata::new(sender.try_into()?, NoteType::try_from(note_type)?, tag.into(), aux)?;
+            NoteMetadata::new(sender.try_into()?, NoteType::try_from(note_type)?, tag.into(), NoteExecutionHint::None, aux)?;
 
         let note = NoteRecord {
             block_num,
@@ -740,7 +740,7 @@ pub fn select_notes_by_id(conn: &mut Connection, note_ids: &[NoteId]) -> Result<
         let aux: u64 = row.get(7)?;
         let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
 
-        let metadata = NoteMetadata::new(sender.try_into()?, note_type, tag.into(), aux)?;
+        let metadata = NoteMetadata::new(sender.try_into()?, note_type, tag.into(), NoteExecutionHint::none(), aux)?;
 
         notes.push(NoteRecord {
             block_num: row.get(0)?,

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -785,7 +785,9 @@ fn test_notes() {
     let note_id = num_to_rpo_digest(3);
     let tag = 5u32;
     let sender = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER));
-    let note_metadata = NoteMetadata::new(sender, NoteType::Public, tag.into(), NoteExecutionHint::none(), ZERO).unwrap();
+    let note_metadata =
+        NoteMetadata::new(sender, NoteType::Public, tag.into(), NoteExecutionHint::none(), ZERO)
+            .unwrap();
 
     let values = [(note_index, note_id, note_metadata)];
     let notes_db = BlockNoteTree::with_entries(values.iter().cloned()).unwrap();
@@ -796,8 +798,14 @@ fn test_notes() {
         block_num: block_num_1,
         note_index,
         note_id,
-        metadata: NoteMetadata::new(sender, NoteType::Public, tag.into(), NoteExecutionHint::none(),Default::default())
-            .unwrap(),
+        metadata: NoteMetadata::new(
+            sender,
+            NoteType::Public,
+            tag.into(),
+            NoteExecutionHint::none(),
+            Default::default(),
+        )
+        .unwrap(),
         details,
         merkle_path: merkle_path.clone(),
     };

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -17,7 +17,7 @@ use miden_objects::{
     assets::{Asset, AssetVault, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     block::{BlockAccountUpdate, BlockNoteIndex, BlockNoteTree},
     crypto::{hash::rpo::RpoDigest, merkle::MerklePath},
-    notes::{NoteId, NoteMetadata, NoteType, Nullifier},
+    notes::{NoteExecutionHint, NoteId, NoteMetadata, NoteType, Nullifier},
     BlockHeader, Felt, FieldElement, Word, ONE, ZERO,
 };
 use rusqlite::{vtab::array, Connection};
@@ -175,6 +175,7 @@ fn test_sql_select_notes() {
                 ACCOUNT_ID_OFF_CHAIN_SENDER.try_into().unwrap(),
                 NoteType::Public,
                 i.into(),
+                NoteExecutionHint::none(),
                 Default::default(),
             )
             .unwrap(),
@@ -784,7 +785,7 @@ fn test_notes() {
     let note_id = num_to_rpo_digest(3);
     let tag = 5u32;
     let sender = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER));
-    let note_metadata = NoteMetadata::new(sender, NoteType::Public, tag.into(), ZERO).unwrap();
+    let note_metadata = NoteMetadata::new(sender, NoteType::Public, tag.into(), NoteExecutionHint::none(), ZERO).unwrap();
 
     let values = [(note_index, note_id, note_metadata)];
     let notes_db = BlockNoteTree::with_entries(values.iter().cloned()).unwrap();
@@ -795,7 +796,7 @@ fn test_notes() {
         block_num: block_num_1,
         note_index,
         note_id,
-        metadata: NoteMetadata::new(sender, NoteType::Public, tag.into(), Default::default())
+        metadata: NoteMetadata::new(sender, NoteType::Public, tag.into(), NoteExecutionHint::none(),Default::default())
             .unwrap(),
         details,
         merkle_path: merkle_path.clone(),

--- a/proto/note.proto
+++ b/proto/note.proto
@@ -9,7 +9,8 @@ message NoteMetadata {
     account.AccountId sender = 1;
     uint32 note_type = 2;
     fixed32 tag = 3;
-    fixed64 aux = 4;
+    fixed64 execution_hint = 4;
+    fixed64 aux = 5;
 }
 
 message Note {


### PR DESCRIPTION
This fixes the faucet's and node build by doing the following:

- Adding the new NoteExecutionHint for all note's metadata
- Adding the new after_block_num field to note exports on the faucet
- Adding the `execution_hint` field to Notes table.

Closes #439 .

This PR is built on top of https://github.com/0xPolygonMiden/miden-base/pull/827 .

It is meant to be merged AFTER that PR.