### PR TITLE
docs: Update `responses.proto`

### DIFF
--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -72,7 +72,10 @@ pub struct SyncNoteResponse {
     /// Block header of the block with the first note matching the specified criteria
     #[prost(message, optional, tag = "2")]
     pub block_header: ::core::option::Option<super::block_header::BlockHeader>,
-    /// Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`
+    /// Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`.
+    ///
+    /// An MMR proof can be constructed for the leaf of index `block_header.block_num` of
+    /// an MMR of forest `chain_tip` with this path.
     #[prost(message, optional, tag = "3")]
     pub mmr_path: ::core::option::Option<super::merkle::MerklePath>,
     /// List of all notes together with the Merkle paths from `response.block_header.note_root`

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -72,12 +72,7 @@ pub struct SyncNoteResponse {
     /// Block header of the block with the first note matching the specified criteria
     #[prost(message, optional, tag = "2")]
     pub block_header: ::core::option::Option<super::block_header::BlockHeader>,
-    /// Proof for block header's MMR with respect to the chain tip.
-    ///
-    /// More specifically, the full proof consists of `forest`, `position` and `path` components. This
-    /// value constitutes the `path`. The other two components can be obtained as follows:
-    ///    - `position` is simply `resopnse.block_header.block_num`
-    ///    - `forest` is the same as `response.chain_tip + 1`
+    /// Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`
     #[prost(message, optional, tag = "3")]
     pub mmr_path: ::core::option::Option<super::merkle::MerklePath>,
     /// List of all notes together with the Merkle paths from `response.block_header.note_root`

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -69,12 +69,7 @@ message SyncNoteResponse {
     // Block header of the block with the first note matching the specified criteria
     block_header.BlockHeader block_header = 2;
 
-    // Proof for block header's MMR with respect to the chain tip.
-    //
-    // More specifically, the full proof consists of `forest`, `position` and `path` components. This
-    // value constitutes the `path`. The other two components can be obtained as follows: 
-    //   - `position` is simply `resopnse.block_header.block_num`
-    //   - `forest` is the same as `response.chain_tip + 1`
+    // Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`
     merkle.MerklePath mmr_path = 3;
 
     // List of all notes together with the Merkle paths from `response.block_header.note_root`

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -69,7 +69,10 @@ message SyncNoteResponse {
     // Block header of the block with the first note matching the specified criteria
     block_header.BlockHeader block_header = 2;
 
-    // Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`
+    // Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`.
+    //
+    // An MMR proof can be constructed for the leaf of index `block_header.block_num` of
+    // an MMR of forest `chain_tip` with this path.
     merkle.MerklePath mmr_path = 3;
 
     // List of all notes together with the Merkle paths from `response.block_header.note_root`

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -69,12 +69,7 @@ message SyncNoteResponse {
     // Block header of the block with the first note matching the specified criteria
     block_header.BlockHeader block_header = 2;
 
-    // Proof for block header's MMR with respect to the chain tip.
-    //
-    // More specifically, the full proof consists of `forest`, `position` and `path` components. This
-    // value constitutes the `path`. The other two components can be obtained as follows: 
-    //   - `position` is simply `resopnse.block_header.block_num`
-    //   - `forest` is the same as `response.chain_tip + 1`
+    // Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`
     merkle.MerklePath mmr_path = 3;
 
     // List of all notes together with the Merkle paths from `response.block_header.note_root`

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -69,7 +69,10 @@ message SyncNoteResponse {
     // Block header of the block with the first note matching the specified criteria
     block_header.BlockHeader block_header = 2;
 
-    // Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`
+    // Merkle path to verify the block's inclusion in the MMR at the returned `chain_tip`.
+    //
+    // An MMR proof can be constructed for the leaf of index `block_header.block_num` of
+    // an MMR of forest `chain_tip` with this path.
     merkle.MerklePath mmr_path = 3;
 
     // List of all notes together with the Merkle paths from `response.block_header.note_root`


### PR DESCRIPTION
Seems like the doc comments for the returned MMR path in the `SyncNoteResponse` was referring to an `MmrProof`, but a `MerklePath` is returned instead.