### PR TITLE
ci: add locking and remove extra nightly

### DIFF
--- a/.github/workflows/deb_packager.yml
+++ b/.github/workflows/deb_packager.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo clean
 
       - name: Building for amd64
-        run: cargo build --release
+        run: cargo build --release --path bin/node --locked
 
       - name: create package directories
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - name: Rustup
+        run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Build docs
-        run: |
-          rustup update --no-self-update stable
-          make doc
+        run: make doc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,48 +15,50 @@ concurrency:
 
 jobs:
   rustfmt:
-    name: rustfmt check nightly on ubuntu-latest
+    name: rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      - name: Rustfmt
+      - name: Rustup
         run: |
           rustup update --no-self-update nightly
           rustup +nightly component add rustfmt
-          make format-check
-
-  clippy:
-    name: clippy stable on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      - name: Install minimal Rust with clippy
-        run: |
-          rustup update --no-self-update nightly
-          rustup +nightly component add clippy
-          make clippy
+      - name: Fmt
+        run: make format-check
 
-  doc:
-    name: doc stable on ubuntu-latest
+  clippy:
+    name: clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - name: Rustup
+        run: |
+          rustup update --no-self-update
+          rustup component add clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Clippy
+        run: make clippy
+
+  doc:
+    name: doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Rustup
+        run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Build docs
-        run: |
-          rustup update --no-self-update
-          make doc
+        run: make doc
 
   version:
-    name: check rust version consistency
+    name: rust version consistency
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -71,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: Update rust toolchain
+      - name: Rustup
         run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,21 +15,16 @@ concurrency:
 
 jobs:
   test:
-    name: test ${{matrix.toolchain}} on ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
-        os: [ubuntu]
+    name: test
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@main
+      - name: Rustup
+        run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - uses: taiki-e/install-action@nextest 
-      - name: Perform tests
-        run: |
-          rustup update --no-self-update ${{matrix.toolchain}} 
-          make test
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_PROTO=BUILD_PROTO=1
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
+	cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings
 
 
 .PHONY: fix
@@ -38,7 +38,7 @@ lint: format fix clippy ## Runs all linting tasks at once (Clippy, fixing, forma
 
 .PHONY: doc
 doc: ## Generates & checks documentation
-	$(WARNINGS) cargo doc --all-features --keep-going --release
+	$(WARNINGS) cargo doc --all-features --keep-going --release --locked
 
 
 .PHONY: doc-serve
@@ -55,31 +55,31 @@ test:  ## Runs all tests
 
 .PHONY: check
 check: ## Check all targets and features for errors without code generation
-	${BUILD_PROTO} cargo check --all-features --all-targets
+	${BUILD_PROTO} cargo check --all-features --all-targets --locked
 
 # --- building ------------------------------------------------------------------------------------
 
 .PHONY: build
 build: ## Builds all crates and re-builds ptotobuf bindings for proto crates
-	${BUILD_PROTO} cargo build
+	${BUILD_PROTO} cargo build --locked
 
 # --- installing ----------------------------------------------------------------------------------
 
 .PHONY: install-node
 install-node: ## Installs node
-	${BUILD_PROTO} cargo install --path bin/node
+	${BUILD_PROTO} cargo install --path bin/node --locked
 
 .PHONY: install-faucet
 install-faucet: ## Installs faucet
-	${BUILD_PROTO} cargo install --path bin/faucet
+	${BUILD_PROTO} cargo install --path bin/faucet --locked
 
 .PHONY: install-node-testing
 install-node-testing: ## Installs node with testing feature enabled
-	${BUILD_PROTO} cargo install --features testing --path bin/node
+	${BUILD_PROTO} cargo install --features testing --path bin/node --locked
 
 .PHONY: install-faucet-testing
 install-faucet-testing: ## Installs faucet with testing feature enabled
-	${BUILD_PROTO} cargo install --features testing --path bin/faucet
+	${BUILD_PROTO} cargo install --features testing --path bin/faucet --locked
 
 # --- docker --------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ BUILD_PROTO=BUILD_PROTO=1
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo +nightly clippy --locked --workspace --all-targets --all-features -- -D warnings
+	cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
 
 
 .PHONY: fix
 fix: ## Runs Fix with configs
-	cargo +nightly fix --allow-staged --allow-dirty --all-targets --all-features
+	cargo fix --allow-staged --allow-dirty --all-targets --all-features
 
 
 .PHONY: format

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 WORKDIR /app
 COPY . .
 
-RUN cargo install --features testing --path bin/node
+RUN cargo install --features testing --path bin/node --locked
 RUN miden-node make-genesis --inputs-path config/genesis.toml
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
This PR adds `--locking` to all infrastructure files where applicable. It also removes all `nightly` toolchains from non-fmt workflows.

Closes #447.