### PR TITLE
feat(faucet): add `after_block_num` to the faucet

### DIFF
--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -78,14 +78,18 @@ impl FaucetClient {
 
         let current_block_number = 0;
 
-        Ok(Self {
+        let mut faucet_client = Self {
             data_store,
             rpc_api,
             executor,
             id,
             rng,
             current_block_number,
-        })
+        };
+
+        faucet_client.update_current_block_number().await?;
+
+        Ok(faucet_client)
     }
 
     /// Executes a mint transaction for the target account.

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -323,13 +323,15 @@ fn build_transaction_arguments(
 
     let tag = output_note.metadata().tag().inner();
     let aux = output_note.metadata().aux().inner();
+    let execution_hint = output_note.metadata().execution_hint().into();
 
     let script = &DISTRIBUTE_FUNGIBLE_ASSET_SCRIPT
         .replace("{recipient}", &recipient)
         .replace("{note_type}", &Felt::new(note_type as u64).to_string())
         .replace("{aux}", &Felt::new(aux).to_string())
         .replace("{tag}", &Felt::new(tag.into()).to_string())
-        .replace("{amount}", &Felt::new(asset.amount()).to_string());
+        .replace("{amount}", &Felt::new(asset.amount()).to_string())
+        .replace("{execution_hint}", &Felt::new(execution_hint).to_string());
 
     let script = TransactionScript::compile(script, vec![], TransactionKernel::assembler())
         .map_err(|err| {

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -45,7 +45,6 @@ pub struct FaucetClient {
     data_store: FaucetDataStore,
     id: AccountId,
     rng: RpoRandomCoin,
-    current_block_number: u32,
 }
 
 unsafe impl Send for FaucetClient {}
@@ -76,16 +75,7 @@ impl FaucetClient {
         let coin_seed: [u64; 4] = rng.gen();
         let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
 
-        let current_block_number = 0;
-
-        Ok(Self {
-            data_store,
-            rpc_api,
-            executor,
-            id,
-            rng,
-            current_block_number,
-        })
+        Ok(Self { data_store, rpc_api, executor, id, rng })
     }
 
     /// Executes a mint transaction for the target account.
@@ -161,12 +151,6 @@ impl FaucetClient {
 
     pub fn get_faucet_id(&self) -> AccountId {
         self.id
-    }
-
-    pub fn set_current_block_number(&mut self, new_block_height: u32) -> Result<(), FaucetError> {
-        self.current_block_number = new_block_height;
-
-        Ok(())
     }
 }
 

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -77,7 +77,7 @@ pub async fn get_tokens(
     // Ideally, we should export these note details with a more sensible `after_block_num`
     let bytes = NoteFile::NoteDetails {
         details: note_details,
-        after_block_num: 0,
+        after_block_num: client.get_chain_tip(),
         tag: Some(note_tag),
     }
     .to_bytes();

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -63,7 +63,7 @@ pub async fn get_tokens(
 
     // Run transaction prover & send transaction to node
     info!("Proving and submitting transaction.");
-    client.prove_and_submit_transaction(executed_tx).await?;
+    let block_height = client.prove_and_submit_transaction(executed_tx).await?;
 
     let note_id: NoteId = created_note.id();
     let note_details =
@@ -73,14 +73,14 @@ pub async fn get_tokens(
         .expect("failed to build note tag for local execution");
 
     // Serialize note into bytes
-    // NOTE: Because this client does not sync, it always effectively executes against block 0.
-    // Ideally, we should export these note details with a more sensible `after_block_num`
     let bytes = NoteFile::NoteDetails {
         details: note_details,
-        after_block_num: client.get_chain_tip(),
+        after_block_num: block_height,
         tag: Some(note_tag),
     }
     .to_bytes();
+
+    client.set_current_block_number(block_height)?;
 
     info!("A new note has been created: {}", note_id);
 

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -80,8 +80,6 @@ pub async fn get_tokens(
     }
     .to_bytes();
 
-    client.set_current_block_number(block_height)?;
-
     info!("A new note has been created: {}", note_id);
 
     // Send generated note to user

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -4,7 +4,7 @@ mod errors;
 mod handlers;
 mod state;
 
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{fs::File, io::Write, path::PathBuf, sync::Arc, thread, time::Duration};
 
 use actix_cors::Cors;
 use actix_web::{
@@ -27,6 +27,7 @@ use crate::{
 
 const COMPONENT: &str = "miden-faucet";
 const FAUCET_CONFIG_FILE_PATH: &str = "miden-faucet.toml";
+const CHAIN_TIP_UPDATER_INTERVAL: u64 = 5;
 
 // COMMANDS
 // ================================================================================================
@@ -71,6 +72,26 @@ async fn main() -> Result<(), FaucetError> {
             let faucet_state = FaucetState::new(config.clone()).await?;
 
             info!(target: COMPONENT, %config, "Initializing server");
+
+            let client_state_clone = Arc::clone(&faucet_state.client);
+
+            info!("Initializing chain tip updater");
+            thread::spawn(move || {
+                let sys = actix_web::rt::System::new();
+                sys.block_on(async move {
+                    loop {
+                        let state_clone_inner = Arc::clone(&client_state_clone);
+                        actix_web::rt::spawn(async move {
+                            let mut state = state_clone_inner.lock().await;
+                            state.update_current_block_number().await.unwrap();
+                        })
+                        .await
+                        .unwrap();
+
+                        thread::sleep(Duration::from_secs(CHAIN_TIP_UPDATER_INTERVAL));
+                    }
+                });
+            });
 
             info!("Server is now running on: {}", config.endpoint_url());
 

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -73,21 +73,6 @@ async fn main() -> Result<(), FaucetError> {
 
             info!(target: COMPONENT, %config, "Initializing server");
 
-            let client_state_clone = Arc::clone(&faucet_state.client);
-
-            info!("Initializing chain tip updater");
-            actix_web::rt::spawn(async move {
-                let mut interval =
-                    actix_web::rt::time::interval(Duration::from_secs(CHAIN_TIP_UPDATER_INTERVAL));
-                loop {
-                    let state_clone_inner = Arc::clone(&client_state_clone);
-                    let mut state = state_clone_inner.lock().await;
-                    state.update_current_block_number().await.unwrap();
-
-                    interval.tick().await;
-                }
-            });
-
             info!("Server is now running on: {}", config.endpoint_url());
 
             HttpServer::new(move || {

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -4,7 +4,7 @@ mod errors;
 mod handlers;
 mod state;
 
-use std::{fs::File, io::Write, path::PathBuf, sync::Arc, time::Duration};
+use std::{fs::File, io::Write, path::PathBuf};
 
 use actix_cors::Cors;
 use actix_web::{
@@ -27,7 +27,6 @@ use crate::{
 
 const COMPONENT: &str = "miden-faucet";
 const FAUCET_CONFIG_FILE_PATH: &str = "miden-faucet.toml";
-const CHAIN_TIP_UPDATER_INTERVAL: u64 = 5;
 
 // COMMANDS
 // ================================================================================================

--- a/bin/faucet/src/transaction_scripts/distribute_fungible_asset.masm
+++ b/bin/faucet/src/transaction_scripts/distribute_fungible_asset.masm
@@ -3,6 +3,7 @@ use.miden::contracts::auth::basic->auth_tx
 
 begin
     push.{recipient}
+    push.{execution_hint}
     push.{note_type}
     push.{aux}
     push.{tag}
@@ -10,5 +11,5 @@ begin
     call.faucet::distribute
 
     call.auth_tx::auth_tx_rpo_falcon512
-    dropw dropw
+    drop dropw dropw
 end

--- a/crates/block-producer/src/server/api.rs
+++ b/crates/block-producer/src/server/api.rs
@@ -66,11 +66,12 @@ where
         );
         debug!(target: COMPONENT, proof = ?tx.proof());
 
-        self.queue
+        let block_height = self.queue
             .add_transaction(tx)
             .await
-            .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?;
+            .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?
+            .ok_or(Status::internal("Missing block height"))?;
 
-        Ok(tonic::Response::new(SubmitProvenTransactionResponse { block_height: 0 }))
+        Ok(tonic::Response::new(SubmitProvenTransactionResponse { block_height }))
     }
 }

--- a/crates/block-producer/src/server/api.rs
+++ b/crates/block-producer/src/server/api.rs
@@ -71,6 +71,6 @@ where
             .await
             .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?;
 
-        Ok(tonic::Response::new(SubmitProvenTransactionResponse {}))
+        Ok(tonic::Response::new(SubmitProvenTransactionResponse { block_height: 0 }))
     }
 }

--- a/crates/block-producer/src/server/api.rs
+++ b/crates/block-producer/src/server/api.rs
@@ -70,8 +70,7 @@ where
             .queue
             .add_transaction(tx)
             .await
-            .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?
-            .ok_or(Status::internal("Missing block height"))?;
+            .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?;
 
         Ok(tonic::Response::new(SubmitProvenTransactionResponse { block_height }))
     }

--- a/crates/block-producer/src/server/api.rs
+++ b/crates/block-producer/src/server/api.rs
@@ -66,7 +66,8 @@ where
         );
         debug!(target: COMPONENT, proof = ?tx.proof());
 
-        let block_height = self.queue
+        let block_height = self
+            .queue
             .add_transaction(tx)
             .await
             .map_err(|err| Status::invalid_argument(format!("{:?}", err)))?

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -65,10 +65,7 @@ where
     S: Store,
 {
     #[instrument(skip_all, err)]
-    async fn verify_tx(
-        &self,
-        candidate_tx: &ProvenTransaction,
-    ) -> Result<Option<u32>, VerifyTxError> {
+    async fn verify_tx(&self, candidate_tx: &ProvenTransaction) -> Result<u32, VerifyTxError> {
         if self.verify_tx_proofs {
             // Make sure that the transaction proof is valid and meets the required security level
             let tx_verifier = TransactionVerifier::new(MIN_PROOF_SECURITY_LEVEL);

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -65,7 +65,10 @@ where
     S: Store,
 {
     #[instrument(skip_all, err)]
-    async fn verify_tx(&self, candidate_tx: &ProvenTransaction) -> Result<Option<u32>, VerifyTxError> {
+    async fn verify_tx(
+        &self,
+        candidate_tx: &ProvenTransaction,
+    ) -> Result<Option<u32>, VerifyTxError> {
         if self.verify_tx_proofs {
             // Make sure that the transaction proof is valid and meets the required security level
             let tx_verifier = TransactionVerifier::new(MIN_PROOF_SECURITY_LEVEL);
@@ -95,7 +98,7 @@ where
         // of one of the inflight transactions)
         let mut tx_inputs = self.store.get_tx_inputs(candidate_tx).await?;
 
-        let current_block_height = tx_inputs.current_block_height.clone();
+        let current_block_height = tx_inputs.current_block_height;
 
         // The latest inflight account state takes precedence since this is the current block being
         // constructed.

--- a/crates/block-producer/src/state_view/tests/apply_block.rs
+++ b/crates/block-producer/src/state_view/tests/apply_block.rs
@@ -74,7 +74,7 @@ async fn test_apply_block_ab2() {
     // Verify transactions so it can be tracked in state view
     for tx in txs {
         let verify_tx_res = state_view.verify_tx(&tx).await;
-        assert_eq!(verify_tx_res, Ok(Some(0)));
+        assert_eq!(verify_tx_res, Ok(0));
     }
 
     // All except the first account will go into the block.
@@ -128,7 +128,7 @@ async fn test_apply_block_ab3() {
     // Verify transactions so it can be tracked in state view
     for tx in txs.clone() {
         let verify_tx_res = state_view.verify_tx(&tx).await;
-        assert_eq!(verify_tx_res, Ok(Some(0)));
+        assert_eq!(verify_tx_res, Ok(0));
     }
 
     let block = MockBlockBuilder::new(&store)

--- a/crates/block-producer/src/state_view/tests/apply_block.rs
+++ b/crates/block-producer/src/state_view/tests/apply_block.rs
@@ -74,7 +74,7 @@ async fn test_apply_block_ab2() {
     // Verify transactions so it can be tracked in state view
     for tx in txs {
         let verify_tx_res = state_view.verify_tx(&tx).await;
-        assert_eq!(verify_tx_res, Ok(()));
+        assert_eq!(verify_tx_res, Ok(Some(0)));
     }
 
     // All except the first account will go into the block.
@@ -128,7 +128,7 @@ async fn test_apply_block_ab3() {
     // Verify transactions so it can be tracked in state view
     for tx in txs.clone() {
         let verify_tx_res = state_view.verify_tx(&tx).await;
-        assert_eq!(verify_tx_res, Ok(()));
+        assert_eq!(verify_tx_res, Ok(Some(0)));
     }
 
     let block = MockBlockBuilder::new(&store)

--- a/crates/block-producer/src/state_view/tests/verify_tx.rs
+++ b/crates/block-producer/src/state_view/tests/verify_tx.rs
@@ -250,7 +250,7 @@ async fn test_verify_tx_dangling_note_found_in_inflight_notes() {
     let tx1 = MockProvenTxBuilder::with_account_index(1).output_notes(output_notes).build();
 
     let verify_tx1_result = state_view.verify_tx(&tx1).await;
-    assert_eq!(verify_tx1_result, Ok(Some(0)));
+    assert_eq!(verify_tx1_result, Ok(0));
 
     let tx2 = MockProvenTxBuilder::with_account_index(2)
         .unauthenticated_notes(dangling_notes.clone())
@@ -259,7 +259,7 @@ async fn test_verify_tx_dangling_note_found_in_inflight_notes() {
     let verify_tx2_result = state_view.verify_tx(&tx2).await;
     assert_eq!(
         verify_tx2_result,
-        Ok(Some(0)),
+        Ok(0),
         "Dangling unauthenticated notes must be found in the in-flight notes after previous tx verification"
     );
 }
@@ -300,7 +300,7 @@ async fn test_verify_tx_stored_unauthenticated_notes() {
     let verify_tx1_result = state_view.verify_tx(&tx1).await;
     assert_eq!(
         verify_tx1_result,
-        Ok(Some(0)),
+        Ok(0),
         "Dangling unauthenticated notes must be found in the store after block applying"
     );
 }

--- a/crates/block-producer/src/state_view/tests/verify_tx.rs
+++ b/crates/block-producer/src/state_view/tests/verify_tx.rs
@@ -250,7 +250,7 @@ async fn test_verify_tx_dangling_note_found_in_inflight_notes() {
     let tx1 = MockProvenTxBuilder::with_account_index(1).output_notes(output_notes).build();
 
     let verify_tx1_result = state_view.verify_tx(&tx1).await;
-    assert_eq!(verify_tx1_result, Ok(()));
+    assert_eq!(verify_tx1_result, Ok(Some(0)));
 
     let tx2 = MockProvenTxBuilder::with_account_index(2)
         .unauthenticated_notes(dangling_notes.clone())
@@ -259,7 +259,7 @@ async fn test_verify_tx_dangling_note_found_in_inflight_notes() {
     let verify_tx2_result = state_view.verify_tx(&tx2).await;
     assert_eq!(
         verify_tx2_result,
-        Ok(()),
+        Ok(Some(0)),
         "Dangling unauthenticated notes must be found in the in-flight notes after previous tx verification"
     );
 }
@@ -300,7 +300,7 @@ async fn test_verify_tx_stored_unauthenticated_notes() {
     let verify_tx1_result = state_view.verify_tx(&tx1).await;
     assert_eq!(
         verify_tx1_result,
-        Ok(()),
+        Ok(Some(0)),
         "Dangling unauthenticated notes must be found in the store after block applying"
     );
 }

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -86,7 +86,7 @@ pub struct TransactionInputs {
     /// List of unauthenticated notes that were not found in the store
     pub missing_unauthenticated_notes: Vec<NoteId>,
     /// The current block height
-    pub current_block_height: Option<u32>,
+    pub current_block_height: u32,
 }
 
 impl Display for TransactionInputs {

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -85,6 +85,8 @@ pub struct TransactionInputs {
     pub nullifiers: BTreeMap<Nullifier, Option<NonZeroU32>>,
     /// List of unauthenticated notes that were not found in the store
     pub missing_unauthenticated_notes: Vec<NoteId>,
+    /// The current block height
+    pub current_block_height: Option<u32>,
 }
 
 impl Display for TransactionInputs {
@@ -137,11 +139,14 @@ impl TryFrom<GetTransactionInputsResponse> for TransactionInputs {
             .map(|digest| Ok(RpoDigest::try_from(digest)?.into()))
             .collect::<Result<Vec<_>, ConversionError>>()?;
 
+        let current_block_height = response.block_height;
+
         Ok(Self {
             account_id,
             account_hash,
             nullifiers,
             missing_unauthenticated_notes,
+            current_block_height,
         })
     }
 }

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -285,7 +285,7 @@ impl Store for MockStoreSuccess {
             account_hash,
             nullifiers,
             missing_unauthenticated_notes,
-            current_block_height: Some(0),
+            current_block_height: 0,
         })
     }
 

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -285,6 +285,7 @@ impl Store for MockStoreSuccess {
             account_hash,
             nullifiers,
             missing_unauthenticated_notes,
+            current_block_height: Some(0),
         })
     }
 

--- a/crates/block-producer/src/txqueue/mod.rs
+++ b/crates/block-producer/src/txqueue/mod.rs
@@ -24,7 +24,7 @@ mod tests;
 /// it can determine when transactions are no longer in-flight.
 #[async_trait]
 pub trait TransactionValidator: Send + Sync + 'static {
-    /// Method to receive a `tx` for processing.
+    /// Method to receive a `tx` for processing and return the current block height.
     ///
     /// This method should:
     /// - Verify the transaction is valid, against the current's rollup state, and also against
@@ -144,7 +144,8 @@ where
         }
     }
 
-    /// Queues `tx` to be added in a batch and subsequently into a block.
+    /// Queues `tx` to be added in a batch and subsequently into a block and returns the current
+    /// block height.
     ///
     /// This method will validate the `tx` and ensure it is valid w.r.t. the rollup state, and the
     /// current in-flight transactions.

--- a/crates/block-producer/src/txqueue/mod.rs
+++ b/crates/block-producer/src/txqueue/mod.rs
@@ -149,10 +149,14 @@ where
     /// This method will validate the `tx` and ensure it is valid w.r.t. the rollup state, and the
     /// current in-flight transactions.
     #[instrument(target = "miden-block-producer", skip_all, err)]
-    pub async fn add_transaction(&self, tx: ProvenTransaction) -> Result<Option<u32>, AddTransactionError> {
+    pub async fn add_transaction(
+        &self,
+        tx: ProvenTransaction,
+    ) -> Result<Option<u32>, AddTransactionError> {
         info!(target: COMPONENT, tx_id = %tx.id().to_hex(), account_id = %tx.account_id().to_hex());
 
-        let block_height = self.tx_validator
+        let block_height = self
+            .tx_validator
             .verify_tx(&tx)
             .await
             .map_err(AddTransactionError::VerificationFailed)?;

--- a/crates/block-producer/src/txqueue/mod.rs
+++ b/crates/block-producer/src/txqueue/mod.rs
@@ -31,7 +31,7 @@ pub trait TransactionValidator: Send + Sync + 'static {
     ///   in-flight transactions.
     /// - Track the necessary state of the transaction until it is committed to the `store`, to
     ///   perform the check above.
-    async fn verify_tx(&self, tx: &ProvenTransaction) -> Result<Option<u32>, VerifyTxError>;
+    async fn verify_tx(&self, tx: &ProvenTransaction) -> Result<u32, VerifyTxError>;
 }
 
 // TRANSACTION QUEUE
@@ -150,10 +150,7 @@ where
     /// This method will validate the `tx` and ensure it is valid w.r.t. the rollup state, and the
     /// current in-flight transactions.
     #[instrument(target = "miden-block-producer", skip_all, err)]
-    pub async fn add_transaction(
-        &self,
-        tx: ProvenTransaction,
-    ) -> Result<Option<u32>, AddTransactionError> {
+    pub async fn add_transaction(&self, tx: ProvenTransaction) -> Result<u32, AddTransactionError> {
         info!(target: COMPONENT, tx_id = %tx.id().to_hex(), account_id = %tx.account_id().to_hex());
 
         let block_height = self

--- a/crates/block-producer/src/txqueue/tests/mod.rs
+++ b/crates/block-producer/src/txqueue/tests/mod.rs
@@ -11,8 +11,8 @@ struct TransactionValidatorSuccess;
 
 #[async_trait]
 impl TransactionValidator for TransactionValidatorSuccess {
-    async fn verify_tx(&self, _tx: &ProvenTransaction) -> Result<(), VerifyTxError> {
-        Ok(())
+    async fn verify_tx(&self, _tx: &ProvenTransaction) -> Result<Option<u32>, VerifyTxError> {
+        Ok(Some(0))
     }
 }
 
@@ -21,7 +21,7 @@ struct TransactionValidatorFailure;
 
 #[async_trait]
 impl TransactionValidator for TransactionValidatorFailure {
-    async fn verify_tx(&self, tx: &ProvenTransaction) -> Result<(), VerifyTxError> {
+    async fn verify_tx(&self, tx: &ProvenTransaction) -> Result<Option<u32>, VerifyTxError> {
         Err(VerifyTxError::InvalidTransactionProof(tx.id()))
     }
 }

--- a/crates/block-producer/src/txqueue/tests/mod.rs
+++ b/crates/block-producer/src/txqueue/tests/mod.rs
@@ -11,8 +11,8 @@ struct TransactionValidatorSuccess;
 
 #[async_trait]
 impl TransactionValidator for TransactionValidatorSuccess {
-    async fn verify_tx(&self, _tx: &ProvenTransaction) -> Result<Option<u32>, VerifyTxError> {
-        Ok(Some(0))
+    async fn verify_tx(&self, _tx: &ProvenTransaction) -> Result<u32, VerifyTxError> {
+        Ok(0)
     }
 }
 
@@ -21,7 +21,7 @@ struct TransactionValidatorFailure;
 
 #[async_trait]
 impl TransactionValidator for TransactionValidatorFailure {
-    async fn verify_tx(&self, tx: &ProvenTransaction) -> Result<Option<u32>, VerifyTxError> {
+    async fn verify_tx(&self, tx: &ProvenTransaction) -> Result<u32, VerifyTxError> {
         Err(VerifyTxError::InvalidTransactionProof(tx.id()))
     }
 }

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -155,7 +155,11 @@ pub struct GetTransactionInputsResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SubmitProvenTransactionResponse {}
+pub struct SubmitProvenTransactionResponse {
+    /// The node's current block height
+    #[prost(fixed32, tag = "1")]
+    pub block_height: u32,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNotesByIdResponse {

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -152,6 +152,8 @@ pub struct GetTransactionInputsResponse {
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierTransactionInputRecord>,
     #[prost(message, repeated, tag = "3")]
     pub missing_unauthenticated_notes: ::prost::alloc::vec::Vec<super::digest::Digest>,
+    #[prost(fixed32, optional, tag = "4")]
+    pub block_height: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -152,8 +152,8 @@ pub struct GetTransactionInputsResponse {
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierTransactionInputRecord>,
     #[prost(message, repeated, tag = "3")]
     pub missing_unauthenticated_notes: ::prost::alloc::vec::Vec<super::digest::Digest>,
-    #[prost(fixed32, optional, tag = "4")]
-    pub block_height: ::core::option::Option<u32>,
+    #[prost(fixed32, tag = "4")]
+    pub block_height: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -127,7 +127,7 @@ message GetTransactionInputsResponse {
     AccountTransactionInputRecord account_state = 1;
     repeated NullifierTransactionInputRecord nullifiers = 2;
     repeated digest.Digest missing_unauthenticated_notes = 3;
-    optional fixed32 block_height = 4;
+    fixed32 block_height = 4;
 }
 
 message SubmitProvenTransactionResponse {

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -127,6 +127,7 @@ message GetTransactionInputsResponse {
     AccountTransactionInputRecord account_state = 1;
     repeated NullifierTransactionInputRecord nullifiers = 2;
     repeated digest.Digest missing_unauthenticated_notes = 3;
+    optional fixed32 block_height = 4;
 }
 
 message SubmitProvenTransactionResponse {

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -129,7 +129,10 @@ message GetTransactionInputsResponse {
     repeated digest.Digest missing_unauthenticated_notes = 3;
 }
 
-message SubmitProvenTransactionResponse {}
+message SubmitProvenTransactionResponse {
+    // The node's current block height
+    fixed32 block_height = 1;
+}
 
 message GetNotesByIdResponse {
     // Lists Note's returned by the database

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -449,6 +449,13 @@ impl api_server::Api for StoreApi {
             .await
             .map_err(internal_error)?;
 
+        let (block_header, _ ) = self.state.get_block_header(None, false).await.map_err(internal_error)?;
+
+        let block_height = match block_header {
+            Some(block_header) => Some(block_header.block_num()),
+            None => None,
+        };
+
         Ok(Response::new(GetTransactionInputsResponse {
             account_state: Some(AccountTransactionInputRecord {
                 account_id: Some(account_id.into()),
@@ -467,6 +474,7 @@ impl api_server::Api for StoreApi {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            block_height,
         }))
     }
 

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -449,10 +449,7 @@ impl api_server::Api for StoreApi {
             .await
             .map_err(internal_error)?;
 
-        let (block_header, _) =
-            self.state.get_block_header(None, false).await.map_err(internal_error)?;
-
-        let block_height = block_header.map(|block_header| block_header.block_num());
+        let block_height = Some(self.state.latest_block_num().await);
 
         Ok(Response::new(GetTransactionInputsResponse {
             account_state: Some(AccountTransactionInputRecord {

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -449,12 +449,10 @@ impl api_server::Api for StoreApi {
             .await
             .map_err(internal_error)?;
 
-        let (block_header, _ ) = self.state.get_block_header(None, false).await.map_err(internal_error)?;
+        let (block_header, _) =
+            self.state.get_block_header(None, false).await.map_err(internal_error)?;
 
-        let block_height = match block_header {
-            Some(block_header) => Some(block_header.block_num()),
-            None => None,
-        };
+        let block_height = block_header.map(|block_header| block_header.block_num());
 
         Ok(Response::new(GetTransactionInputsResponse {
             account_state: Some(AccountTransactionInputRecord {

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -449,7 +449,7 @@ impl api_server::Api for StoreApi {
             .await
             .map_err(internal_error)?;
 
-        let block_height = Some(self.state.latest_block_num().await);
+        let block_height = self.state.latest_block_num().await;
 
         Ok(Response::new(GetTransactionInputsResponse {
             account_state: Some(AccountTransactionInputRecord {

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -127,7 +127,7 @@ message GetTransactionInputsResponse {
     AccountTransactionInputRecord account_state = 1;
     repeated NullifierTransactionInputRecord nullifiers = 2;
     repeated digest.Digest missing_unauthenticated_notes = 3;
-    optional fixed32 block_height = 4;
+    fixed32 block_height = 4;
 }
 
 message SubmitProvenTransactionResponse {

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -127,6 +127,7 @@ message GetTransactionInputsResponse {
     AccountTransactionInputRecord account_state = 1;
     repeated NullifierTransactionInputRecord nullifiers = 2;
     repeated digest.Digest missing_unauthenticated_notes = 3;
+    optional fixed32 block_height = 4;
 }
 
 message SubmitProvenTransactionResponse {

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -129,7 +129,10 @@ message GetTransactionInputsResponse {
     repeated digest.Digest missing_unauthenticated_notes = 3;
 }
 
-message SubmitProvenTransactionResponse {}
+message SubmitProvenTransactionResponse {
+    // The node's current block height
+    fixed32 block_height = 1;
+}
 
 message GetNotesByIdResponse {
     // Lists Note's returned by the database


### PR DESCRIPTION
This PR introduces a `current_block_number` to the `FaucetClient` and spawns a thread while running the faucet that is in charge of updating the `current_block_number` after `CHAIN_TIP_UPDATER_INTERVAL` time.

This PR also addresses an issue with the `.masm` file adding the execution hint field.

Closes #440 

