### PR TITLE
chore(block-producer): drop store depedency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,6 @@ dependencies = [
  "miden-air",
  "miden-lib",
  "miden-node-proto",
- "miden-node-store",
  "miden-node-test-macro",
  "miden-node-utils",
  "miden-objects",

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -19,7 +19,6 @@ async-trait = { version = "0.1" }
 figment = { version = "0.10", features = ["toml", "env"] }
 itertools = { version = "0.13" }
 miden-node-proto = { workspace = true }
-miden-node-store = { workspace = true }
 miden-node-utils = { workspace = true }
 miden-objects = { workspace = true }
 miden-processor = { workspace = true }

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -3,7 +3,7 @@ use std::{
     mem,
 };
 
-use miden_node_store::state::NoteAuthenticationInfo;
+use miden_node_proto::domain::notes::NoteAuthenticationInfo;
 use miden_objects::{
     accounts::{delta::AccountUpdateDetails, AccountId},
     batches::BatchNoteTree,

--- a/crates/block-producer/src/block.rs
+++ b/crates/block-producer/src/block.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
 use miden_node_proto::{
+    domain::notes::NoteAuthenticationInfo,
     errors::{ConversionError, MissingFieldHelper},
     generated::responses::GetBlockInputsResponse,
     AccountInputRecord, NullifierWitness,
 };
-use miden_node_store::state::NoteAuthenticationInfo;
 use miden_objects::{
     accounts::AccountId,
     crypto::merkle::{MerklePath, MmrPeaks, SmtProof},

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use async_trait::async_trait;
 use itertools::Itertools;
 use miden_node_proto::{
+    domain::notes::NoteAuthenticationInfo,
     errors::{ConversionError, MissingFieldHelper},
     generated::{
         digest,
@@ -19,7 +20,6 @@ use miden_node_proto::{
     },
     AccountState,
 };
-use miden_node_store::state::NoteAuthenticationInfo;
 use miden_node_utils::formatting::format_opt;
 use miden_objects::{
     accounts::AccountId,

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -5,8 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use miden_node_proto::domain::blocks::BlockInclusionProof;
-use miden_node_store::state::NoteAuthenticationInfo;
+use miden_node_proto::domain::{blocks::BlockInclusionProof, notes::NoteAuthenticationInfo};
 use miden_objects::{
     block::{Block, NoteBatch},
     crypto::merkle::{Mmr, SimpleSmt, Smt, ValuePath},

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use miden_node_proto::{
     convert,
+    domain::notes::NoteAuthenticationInfo,
     errors::ConversionError,
     generated::{
         self,
@@ -38,11 +39,7 @@ use miden_objects::{
 use tonic::{Response, Status};
 use tracing::{debug, info, instrument};
 
-use crate::{
-    state::{NoteAuthenticationInfo, State},
-    types::AccountId,
-    COMPONENT,
-};
+use crate::{state::State, types::AccountId, COMPONENT};
 
 // STORE API
 // ================================================================================================


### PR DESCRIPTION
Decouple `store` from `block-producer`. The only remaining item was `NoteAuthenticationInfo` which I moved into the `proto` crate.

Closes #455