### PR TITLE
Removed note details from sync responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `GetNoteAuthenticationInfo` endpoint (#421).
 - Added `SyncNotes` endpoint (#424).
 - Added `execution_hint` field to the `Notes` table (#441).
+- Optimized state synchronizations by removing unnecessary fetching and parsing of note details (#462).
 
 ### Changes
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use deadpool_sqlite::{Config as SqliteConfig, Hook, HookError, Pool, Runtime};
 use miden_node_proto::{
     domain::accounts::{AccountInfo, AccountSummary},
-    generated::note::Note as NotePb,
+    generated::note::{Note as NotePb, NoteSyncRecord as NoteSyncRecordPb},
 };
 use miden_objects::{
     accounts::AccountDelta,
@@ -83,7 +83,7 @@ impl From<NoteRecord> for NotePb {
 
 #[derive(Debug, PartialEq)]
 pub struct StateSyncUpdate {
-    pub notes: Vec<NoteRecord>,
+    pub notes: Vec<NoteSyncRecord>,
     pub block_header: BlockHeader,
     pub chain_tip: BlockNumber,
     pub account_updates: Vec<AccountSummary>,
@@ -93,9 +93,41 @@ pub struct StateSyncUpdate {
 
 #[derive(Debug, PartialEq)]
 pub struct NoteSyncUpdate {
-    pub notes: Vec<NoteRecord>,
+    pub notes: Vec<NoteSyncRecord>,
     pub block_header: BlockHeader,
     pub chain_tip: BlockNumber,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoteSyncRecord {
+    pub block_num: BlockNumber,
+    pub note_index: BlockNoteIndex,
+    pub note_id: RpoDigest,
+    pub metadata: NoteMetadata,
+    pub merkle_path: MerklePath,
+}
+
+impl From<NoteSyncRecord> for NoteSyncRecordPb {
+    fn from(note: NoteSyncRecord) -> Self {
+        Self {
+            note_index: note.note_index.to_absolute_index(),
+            note_id: Some(note.note_id.into()),
+            metadata: Some(note.metadata.into()),
+            merkle_path: Some(Into::into(&note.merkle_path)),
+        }
+    }
+}
+
+impl From<NoteRecord> for NoteSyncRecord {
+    fn from(note: NoteRecord) -> Self {
+        Self {
+            block_num: note.block_num,
+            note_index: note.note_index,
+            note_id: note.note_id,
+            metadata: note.metadata,
+            merkle_path: note.merkle_path,
+        }
+    }
 }
 
 impl Db {

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -896,7 +896,7 @@ fn test_notes() {
     let res =
         sql::select_notes_since_block_by_tag_and_sender(&mut conn, &[tag], &[], block_num_1 - 1)
             .unwrap();
-    assert_eq!(res, vec![note.clone()]);
+    assert_eq!(res, vec![note.clone().into()]);
 
     let block_num_2 = note.block_num + 1;
     create_block(&mut conn, block_num_2);
@@ -919,12 +919,12 @@ fn test_notes() {
     let res =
         sql::select_notes_since_block_by_tag_and_sender(&mut conn, &[tag], &[], block_num_1 - 1)
             .unwrap();
-    assert_eq!(res, vec![note.clone()]);
+    assert_eq!(res, vec![note.clone().into()]);
 
     // only the second note is returned
     let res = sql::select_notes_since_block_by_tag_and_sender(&mut conn, &[tag], &[], block_num_1)
         .unwrap();
-    assert_eq!(res, vec![note2.clone()]);
+    assert_eq!(res, vec![note2.clone().into()]);
 
     // test query notes by id
     let notes = vec![note, note2];

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -7,7 +7,7 @@ use miden_node_proto::{
     generated::{
         self,
         account::AccountSummary,
-        note::{NoteAuthenticationInfo as NoteAuthenticationInfoProto, NoteSyncRecord},
+        note::NoteAuthenticationInfo as NoteAuthenticationInfoProto,
         requests::{
             ApplyBlockRequest, CheckNullifiersByPrefixRequest, CheckNullifiersRequest,
             GetAccountDetailsRequest, GetAccountStateDeltaRequest, GetBlockByNumberRequest,
@@ -190,16 +190,7 @@ impl api_server::Api for StoreApi {
             })
             .collect();
 
-        let notes = state
-            .notes
-            .into_iter()
-            .map(|note| NoteSyncRecord {
-                note_index: note.note_index.to_absolute_index(),
-                note_id: Some(note.note_id.into()),
-                metadata: Some(note.metadata.into()),
-                merkle_path: Some(Into::into(&note.merkle_path)),
-            })
-            .collect();
+        let notes = state.notes.into_iter().map(Into::into).collect();
 
         let nullifiers = state
             .nullifiers
@@ -241,16 +232,7 @@ impl api_server::Api for StoreApi {
             .await
             .map_err(internal_error)?;
 
-        let notes = state
-            .notes
-            .into_iter()
-            .map(|note| NoteSyncRecord {
-                note_index: note.note_index.to_absolute_index(),
-                note_id: Some(note.note_id.into()),
-                metadata: Some(note.metadata.into()),
-                merkle_path: Some((&note.merkle_path).into()),
-            })
-            .collect();
+        let notes = state.notes.into_iter().map(Into::into).collect();
 
         Ok(Response::new(SyncNoteResponse {
             chain_tip: state.chain_tip,


### PR DESCRIPTION
Resolves https://github.com/0xPolygonMiden/miden-node/issues/309

Introduced `NoteSyncRecord` domain type which omits note details unnecessary for state synchronizations. Refactored code, removed excessive function (`select_notes_since_block_by_tag_and_sender` can work as `select_notes_since_block_by_tag` if we provide empty sender list).