### PR TITLE
ci: reorganize packaging and release workflows

### DIFF
--- a/.github/actions/debian-packages/action.yml
+++ b/.github/actions/debian-packages/action.yml
@@ -1,0 +1,18 @@
+
+name: 'Build Debian packages'
+description: 'Builds miden-node and miden-faucet Debian packages'
+inputs:
+  suffix:
+    required: true
+outputs:
+  node-package:
+    description: "Path to the miden-node package"
+    value: ${{ steps.some-step.outputs.node-package }} 
+  faucet-package:
+    description: "Path to the miden-faucet package"
+    value: ${{ steps.some-step.outputs.faucet-package }} 
+runs:
+  using: "composite"
+  steps:
+    - name: Do the thing
+      run: echo "copy over existing packaging stuff"

--- a/.github/actions/debian-packages/action.yml
+++ b/.github/actions/debian-packages/action.yml
@@ -1,4 +1,3 @@
-
 name: 'Build Debian packages'
 description: 'Builds miden-node and miden-faucet Debian packages'
 inputs:
@@ -6,13 +5,14 @@ inputs:
     required: true
 outputs:
   node-package:
-    description: "Path to the miden-node package"
+    description: "Path to the miden-node debian package."
     value: ${{ steps.some-step.outputs.node-package }} 
   faucet-package:
-    description: "Path to the miden-faucet package"
+    description: "Path to the miden-faucet debian package."
     value: ${{ steps.some-step.outputs.faucet-package }} 
 runs:
   using: "composite"
   steps:
     - name: Do the thing
       run: echo "copy over existing packaging stuff"
+      shell: bash

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -41,5 +41,5 @@ runs:
       shell: bash
       run: |
         echo "test data" > testfile
-        scp testfile ${{ inputs.instance-id}}:/tmp/testfile
+        scp testfile ${{ inputs.instance-id}}:testfile
         

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -11,8 +11,10 @@ inputs:
     required: true
   node-package:
     required: true
+    description: "Path to the miden-node debian package."
   faucet-package:
     required: true
+    description: "Path to the miden-faucet debian package."
 runs:
   using: "composite"
   steps:
@@ -22,6 +24,8 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.role-to-assume }}
         role-session-name: GithubActionsSession
+      shell: bash
 
     - name: Rest of the owl
       run: echo "The rest of the stuff should be copy pasted in, but use the **-package filepaths to scm the packages across."
+      shell: bash

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -24,9 +24,9 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.role-to-assume }}
         role-session-name: GithubActionsSession
-      shell: bash
 
     - name: Configure ssh for scp access
+      shell: bash
       run: |
         # Ensure ssh config file exists.
         touch ~/.ssh/config
@@ -43,6 +43,7 @@ runs:
         command: "ls /tmp"
 
     - name: Test scp
+      shell: bash
       run: |
         echo "test data" > testfile
         scp testfile ${{ inputs.instance-id}}:/tmp/testfile

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,0 +1,27 @@
+# This action should deploy the given node and faucet packages to the provided aws instance using ssm and scp.
+
+name: 'Deploy node and faucet'
+description: 'Deploys the node and faucet Debian packages to an aws instance.'
+inputs:
+  role-to-assume:
+    required: true
+  aws-region:
+    required: true
+  instance-id:
+    required: true
+  node-package:
+    required: true
+  faucet-package:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-session-name: GithubActionsSession
+
+    - name: Rest of the owl
+      run: echo "The rest of the stuff should be copy pasted in, but use the **-package filepaths to scm the packages across."

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -9,12 +9,12 @@ inputs:
     required: true
   instance-id:
     required: true
-  node-package:
-    required: true
-    description: "Path to the miden-node debian package."
-  faucet-package:
-    required: true
-    description: "Path to the miden-faucet debian package."
+  # node-package:
+  #   required: true
+  #   description: "Path to the miden-node debian package."
+  # faucet-package:
+  #   required: true
+  #   description: "Path to the miden-faucet debian package."
 runs:
   using: "composite"
   steps:

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -18,12 +18,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-session-name: GithubActionsSession
+    # - name: Configure AWS credentials
+    #   uses: aws-actions/configure-aws-credentials@v4
+    #   with:
+    #     aws-region: ${{ inputs.aws-region }}
+    #     role-to-assume: ${{ inputs.role-to-assume }}
+    #     role-session-name: GithubActionsSession
 
     - name: Configure ssh for scp access
       shell: bash
@@ -36,11 +36,6 @@ runs:
         echo "host i-* mi-*" >> ~/.ssh/config
         echo "    ProxyCommand sh -c \"aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'\"" >> ~/.ssh/config
 
-    - name: ls before
-      uses: ../ssm-send-command
-      with:
-        instance-id: ${{ inputs.instance-id }}
-        command: "ls /tmp"
 
     - name: Test scp
       shell: bash
@@ -48,14 +43,3 @@ runs:
         echo "test data" > testfile
         scp testfile ${{ inputs.instance-id}}:/tmp/testfile
         
-    - name: ls after
-      uses: ../ssm-send-command
-      with:
-        instance-id: ${{ inputs.instance-id }}
-        command: "ls /tmp"
-
-    - name: cat after
-      uses: ../ssm-send-command
-      with:
-        instance-id: ${{ inputs.instance-id }}
-        command: "cat /tmp/testfile"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -26,6 +26,35 @@ runs:
         role-session-name: GithubActionsSession
       shell: bash
 
-    - name: Rest of the owl
-      run: echo "The rest of the stuff should be copy pasted in, but use the **-package filepaths to scm the packages across."
-      shell: bash
+    - name: Configure ssh for scp access
+      run: |
+        # Ensure ssh config file exists.
+        touch ~/.ssh/config
+        # Follow instructions from:
+        # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html
+        echo "# SSH over Session Manager" >> ~/.ssh/config
+        echo "host i-* mi-*" >> ~/.ssh/config
+        echo "    ProxyCommand sh -c \"aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'\"" >> ~/.ssh/config
+
+    - name: ls before
+      uses: ../ssm-send-command
+      with:
+        instance-id: ${{ inputs.instance-id }}
+        command: "ls /tmp"
+
+    - name: Test scp
+      run: |
+        echo "test data" > testfile
+        scp testfile ${{ inputs.instance-id}}:/tmp/testfile
+        
+    - name: ls after
+      uses: ../ssm-send-command
+      with:
+        instance-id: ${{ inputs.instance-id }}
+        command: "ls /tmp"
+
+    - name: cat after
+      uses: ../ssm-send-command
+      with:
+        instance-id: ${{ inputs.instance-id }}
+        command: "cat /tmp/testfile"

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -19,7 +19,7 @@ runs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ inputs.instance_id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["echo internal"]}' \
+            --parameters '{"commands": ["ls -l"]}' \
             --output text \
             --query "Command.CommandId")
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -1,0 +1,60 @@
+
+# This action should deploy the given node and faucet packages to the provided aws instance using ssm and scp.
+
+name: SSM send-command wrapper
+description: 'Runs the given commands using aws ssm send-command as a shell script. The logs and status are monitored for success.'
+inputs:
+  instance-id:
+    required: true
+  command:
+    required: true
+    description: 'A single command only'
+runs:
+  using: "composite"
+  steps:
+    - name: Execute command
+      run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids ${{ inputs.instance_id }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters '{"commands":[${{ inputs.command }}]}' \
+            --output text \
+            --query "Command.CommandId")
+          echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+    - name: Monitor command logs and status
+      run: |
+        echo "Waiting for command to complete"
+        while true; do
+            STATUS=$(aws ssm list-command-invocations \
+                --command-id ${{ steps.stop_services.outputs.command_id }} \
+                --details \
+                --query "CommandInvocations[0].Status" \
+                --output text)
+
+            # Print a progress `.` token until the command completes.
+            case $STATUS in
+              Pending | InProgress | Delayed)
+                echo -n .
+                sleep 5
+                ;; 
+              *) 
+                echo; # add a newline to end the progress line print. 
+                break ;;
+            esac
+        done
+
+        # Grab the command output. Unfortunately this gets truncated at 2500 characters so its
+        # note terribly useful for debugging but such is life.
+        OUTPUT=$(aws ssm list-command-invocations \
+            --command-id ${{ steps.stop_services.outputs.command_id }} \
+            --details \
+            --query "CommandInvocations[0].CommandPlugins[0].Output" \
+            --output text)
+        echo "Command output: $OUTPUT"
+
+        echo "Command status: $STATUS"
+            
+        if [ "$STATUS" != "Success" ]; then
+              exit 1
+        fi

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -17,12 +17,41 @@ runs:
       id: run-command
       run: |
           COMMAND_ID=$(aws ssm send-command \
-            --instance-ids ${{ inputs.instance_id }} \
+            --instance-ids ${{ inputs.instance-id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands": ["ls -l"]}' \
+            --parameters '{"commands":["ls -l"]}' \
             --output text \
             --query "Command.CommandId")
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+    - name: Check stop services command status and retrieve output
+      shell: bash
+      run: |
+        while true; do
+          STATUS=$(aws ssm list-command-invocations \
+              --command-id ${{ steps.run-command.outputs.command-id }} \
+              --details \
+              --query "CommandInvocations[0].Status" \
+              --output text)
+          echo "Command Status: $STATUS"
+          
+          OUTPUT=$(aws ssm list-command-invocations \
+              --command-id ${{ steps.run-command.outputs.command-id }} \
+              --details \
+              --query "CommandInvocations[0].CommandPlugins[0].Output" \
+              --output text)
+          echo "Command Output: $OUTPUT"
+          
+          if [ "$STATUS" == "Success" ]; then
+            echo "Command completed successfully."
+            break
+          elif [ "$STATUS" == "Failed" ] || [ "$STATUS" == "Cancelled" ]; then
+            echo "Command failed with status: $STATUS"
+            exit 1
+          else
+            sleep 10  # Wait for 30 seconds before checking again
+          fi
+        done
 
     - name: Wait for command completion
       shell: bash
@@ -36,6 +65,8 @@ runs:
                 --details \
                 --query "CommandInvocations[0].Status" \
                 --output text)
+
+            echo "status is $STATUS"
 
             # Print a progress `.` token until the command completes.
             case $STATUS in

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -31,7 +31,7 @@ runs:
         while true; do
             STATUS=$(aws ssm list-command-invocations \
                 --command-id ${{ steps.run-command.outputs.command-id }} \
-                --instance-id ${{ inputs.instance_id }} \
+                --instance-id ${{ inputs.instance-id }} \
                 --details \
                 --query "CommandInvocations[0].Status" \
                 --output text)
@@ -54,7 +54,7 @@ runs:
         # not terribly useful for debugging but such is life.
         OUTPUT=$(aws ssm list-command-invocations \
             --command-id ${{ steps.run-command.outputs.command-id }} \
-            --instance-id ${{ inputs.instance_id }} \
+            --instance-id ${{ inputs.instance-id }} \
             --details \
             --query "CommandInvocations[0].CommandPlugins[0].Output" \
             --output text)

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -64,7 +64,8 @@ runs:
             --details \
             --query "CommandInvocations[0].CommandPlugins[0].Output" \
             --output text)
-        echo "Command output:\n$OUTPUT"
+        echo "Command logs:"
+        echo "$OUTPUT"
             
         echo "Command status: ${{ env.STATUS }}"
         if [ ${{ env.STATUS }} != "Success" ]; then

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -19,7 +19,7 @@ runs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ inputs.instance_id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["${{ inputs.command }}"]}' \
+            --parameters '{"commands":["echo internal"]}' \
             --output text \
             --query "Command.CommandId")
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT
@@ -37,8 +37,8 @@ runs:
 
             # Print a progress `.` token until the command completes.
             case $STATUS in
-              Pending | InProgress | Delayed | None)
-                echo -n .
+              Pending | InProgress | Delayed )
+                echo .
                 sleep 5
                 ;; 
               *) 

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -31,9 +31,12 @@ runs:
         while true; do
             STATUS=$(aws ssm list-command-invocations \
                 --command-id ${{ steps.run-command.outputs.command-id }} \
+                --instance-id ${{ inputs.instance_id }} \
                 --details \
                 --query "CommandInvocations[0].Status" \
                 --output text)
+
+            echo "Command status: $STATUS"
 
             # Print a progress `.` token until the command completes.
             case $STATUS in
@@ -48,9 +51,10 @@ runs:
         done
 
         # Grab the command output. Unfortunately this gets truncated at 2500 characters so its
-        # note terribly useful for debugging but such is life.
+        # not terribly useful for debugging but such is life.
         OUTPUT=$(aws ssm list-command-invocations \
             --command-id ${{ steps.run-command.outputs.command-id }} \
+            --instance-id ${{ inputs.instance_id }} \
             --details \
             --query "CommandInvocations[0].CommandPlugins[0].Output" \
             --output text)

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -12,6 +12,47 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Stop services
+      shell: bash
+      id: stop_services
+      run: |
+        COMMAND_ID=$(aws ssm send-command \
+          --instance-ids ${{ inputs.instance-id }} \
+          --document-name "AWS-RunShellScript" \
+          --parameters '{"commands":["ls -l"]}' \
+          --output text \
+          --query "Command.CommandId")
+        echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+    - name: Check stop services command status and retrieve output
+      shell: bash
+      run: |
+        while true; do
+          STATUS=$(aws ssm list-command-invocations \
+              --command-id ${{ steps.stop_services.outputs.command_id }} \
+              --details \
+              --query "CommandInvocations[0].Status" \
+              --output text)
+          echo "Command Status: $STATUS"
+          
+          OUTPUT=$(aws ssm list-command-invocations \
+              --command-id ${{ steps.stop_services.outputs.command_id }} \
+              --details \
+              --query "CommandInvocations[0].CommandPlugins[0].Output" \
+              --output text)
+          echo "Command Output: $OUTPUT"
+          
+          if [ "$STATUS" == "Success" ]; then
+            echo "Command completed successfully."
+            break
+          elif [ "$STATUS" == "Failed" ] || [ "$STATUS" == "Cancelled" ]; then
+            echo "Command failed with status: $STATUS"
+            exit 1
+          else
+            sleep 5 # Wait for 30 seconds before checking again
+          fi
+        done
+
     - name: Execute command
       shell: bash
       id: run-command

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -46,6 +46,7 @@ runs:
                 ;; 
               *) 
                 echo; # add a newline to end the progress line print. 
+                echo "status is $STATUS"
                 echo "status=$STATUS" >> $GITHUB_OUTPUT
                 break ;;
             esac

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -18,7 +18,7 @@ runs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ inputs.instance_id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":[${{ inputs.command }}]}' \
+            --parameters '{"commands":["${{ inputs.command }}"]}' \
             --output text \
             --query "Command.CommandId")
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -2,7 +2,7 @@
 # and additionally fails if the command failed.
 
 name: SSM send-command wrapper
-description: 'Runs the given commands using aws ssm send-command as a shell script. The logs and status are monitored for success.'
+description: 'Runs the given command using aws ssm send-command as a shell script. The logs and status are monitored for success.'
 inputs:
   instance-id:
     required: true

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -37,7 +37,7 @@ runs:
 
             # Print a progress `.` token until the command completes.
             case $STATUS in
-              Pending | InProgress | Delayed)
+              Pending | InProgress | Delayed | None)
                 echo -n .
                 sleep 5
                 ;; 

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -1,5 +1,5 @@
-
-# This action should deploy the given node and faucet packages to the provided aws instance using ssm and scp.
+# This action wraps ssm send-command by waiting for command completion and writing output logs
+# and additionally fails if the command failed.
 
 name: SSM send-command wrapper
 description: 'Runs the given commands using aws ssm send-command as a shell script. The logs and status are monitored for success.'
@@ -19,39 +19,10 @@ runs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ inputs.instance-id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["ls -l"]}' \
+            --parameters '{"commands":["${{ inputs.command }}"]}' \
             --output text \
             --query "Command.CommandId")
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT
-
-    - name: Check stop services command status and retrieve output
-      shell: bash
-      run: |
-        while true; do
-          STATUS=$(aws ssm list-command-invocations \
-              --command-id ${{ steps.run-command.outputs.command-id }} \
-              --details \
-              --query "CommandInvocations[0].Status" \
-              --output text)
-          echo "Command Status: $STATUS"
-          
-          OUTPUT=$(aws ssm list-command-invocations \
-              --command-id ${{ steps.run-command.outputs.command-id }} \
-              --details \
-              --query "CommandInvocations[0].CommandPlugins[0].Output" \
-              --output text)
-          echo "Command Output: $OUTPUT"
-          
-          if [ "$STATUS" == "Success" ]; then
-            echo "Command completed successfully."
-            break
-          elif [ "$STATUS" == "Failed" ] || [ "$STATUS" == "Cancelled" ]; then
-            echo "Command failed with status: $STATUS"
-            exit 1
-          else
-            sleep 10  # Wait for 30 seconds before checking again
-          fi
-        done
 
     - name: Wait for command completion
       shell: bash
@@ -66,8 +37,6 @@ runs:
                 --query "CommandInvocations[0].Status" \
                 --output text)
 
-            echo "status is $STATUS"
-
             # Print a progress `.` token until the command completes.
             case $STATUS in
               Pending | InProgress | Delayed )
@@ -77,7 +46,6 @@ runs:
                 ;; 
               *) 
                 echo; # add a newline to end the progress line print. 
-                echo "status is $STATUS"
                 echo "status=$STATUS" >> $GITHUB_OUTPUT
                 break ;;
             esac
@@ -96,7 +64,7 @@ runs:
             --details \
             --query "CommandInvocations[0].CommandPlugins[0].Output" \
             --output text)
-        echo "Command output: $OUTPUT"
+        echo "Command output:\n$OUTPUT"
             
         echo "Command status: ${{ env.STATUS }}"
         if [ ${{ env.STATUS }} != "Success" ]; then

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -13,6 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Execute command
+      shell: bash
       run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ inputs.instance_id }} \
@@ -23,6 +24,7 @@ runs:
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT
 
     - name: Monitor command logs and status
+      shell: bash
       run: |
         echo "Waiting for command to complete"
         while true; do

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -12,47 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Stop services
-      shell: bash
-      id: stop_services
-      run: |
-        COMMAND_ID=$(aws ssm send-command \
-          --instance-ids ${{ inputs.instance-id }} \
-          --document-name "AWS-RunShellScript" \
-          --parameters '{"commands":["ls -l"]}' \
-          --output text \
-          --query "Command.CommandId")
-        echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
-
-    - name: Check stop services command status and retrieve output
-      shell: bash
-      run: |
-        while true; do
-          STATUS=$(aws ssm list-command-invocations \
-              --command-id ${{ steps.stop_services.outputs.command_id }} \
-              --details \
-              --query "CommandInvocations[0].Status" \
-              --output text)
-          echo "Command Status: $STATUS"
-          
-          OUTPUT=$(aws ssm list-command-invocations \
-              --command-id ${{ steps.stop_services.outputs.command_id }} \
-              --details \
-              --query "CommandInvocations[0].CommandPlugins[0].Output" \
-              --output text)
-          echo "Command Output: $OUTPUT"
-          
-          if [ "$STATUS" == "Success" ]; then
-            echo "Command completed successfully."
-            break
-          elif [ "$STATUS" == "Failed" ] || [ "$STATUS" == "Cancelled" ]; then
-            echo "Command failed with status: $STATUS"
-            exit 1
-          else
-            sleep 5 # Wait for 30 seconds before checking again
-          fi
-        done
-
     - name: Execute command
       shell: bash
       id: run-command
@@ -65,8 +24,9 @@ runs:
             --query "Command.CommandId")
           echo "command-id=$COMMAND_ID" >> $GITHUB_OUTPUT
 
-    - name: Monitor command logs and status
+    - name: Wait for command completion
       shell: bash
+      id: poll-status
       run: |
         echo "Waiting for command to complete"
         while true; do
@@ -77,20 +37,25 @@ runs:
                 --query "CommandInvocations[0].Status" \
                 --output text)
 
-            echo "Command status: $STATUS"
-
             # Print a progress `.` token until the command completes.
             case $STATUS in
               Pending | InProgress | Delayed )
                 echo .
                 sleep 5
+                continue
                 ;; 
               *) 
                 echo; # add a newline to end the progress line print. 
+                echo "status=$STATUS" >> $GITHUB_OUTPUT
                 break ;;
             esac
         done
 
+    - name: Log output and status
+      shell: bash
+      env:
+        STATUS: ${{ steps.poll-status.outputs.status }}
+      run: |
         # Grab the command output. Unfortunately this gets truncated at 2500 characters so its
         # not terribly useful for debugging but such is life.
         OUTPUT=$(aws ssm list-command-invocations \
@@ -100,9 +65,8 @@ runs:
             --query "CommandInvocations[0].CommandPlugins[0].Output" \
             --output text)
         echo "Command output: $OUTPUT"
-
-        echo "Command status: $STATUS"
             
-        if [ "$STATUS" != "Success" ]; then
+        echo "Command status: ${{ env.STATUS }}"
+        if [ ${{ env.STATUS }} != "Success" ]; then
               exit 1
         fi

--- a/.github/actions/ssm-send-command/action.yml
+++ b/.github/actions/ssm-send-command/action.yml
@@ -14,6 +14,7 @@ runs:
   steps:
     - name: Execute command
       shell: bash
+      id: run-command
       run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ inputs.instance_id }} \
@@ -29,7 +30,7 @@ runs:
         echo "Waiting for command to complete"
         while true; do
             STATUS=$(aws ssm list-command-invocations \
-                --command-id ${{ steps.stop_services.outputs.command_id }} \
+                --command-id ${{ steps.run-command.outputs.command-id }} \
                 --details \
                 --query "CommandInvocations[0].Status" \
                 --output text)
@@ -49,7 +50,7 @@ runs:
         # Grab the command output. Unfortunately this gets truncated at 2500 characters so its
         # note terribly useful for debugging but such is life.
         OUTPUT=$(aws ssm list-command-invocations \
-            --command-id ${{ steps.stop_services.outputs.command_id }} \
+            --command-id ${{ steps.run-command.outputs.command-id }} \
             --details \
             --query "CommandInvocations[0].CommandPlugins[0].Output" \
             --output text)

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -23,15 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@main
 
-      - name: Set version
-        id: version
-        run: echo "version=$(git describe)" >> $GITHUB_OUTPUT
+      # - name: Set version
+      #   id: version
+      #   run: echo "version=$(git describe)" >> $GITHUB_OUTPUT
 
-      - name: Build Debian packages
-        id: build
-        uses: ./.github/actions/debian-packages
-        with:
-          suffix: ${{ steps.version.outputs.version }}-arm64
+      # - name: Build Debian packages
+      #   id: build
+      #   uses: ./.github/actions/debian-packages
+      #   with:
+      #     suffix: ${{ steps.version.outputs.version }}-arm64
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
@@ -39,5 +39,5 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.account-id }}:role/midendev-GithubActionsRole
           aws-region: us-west-1
           instance-id: ${{ secrets.instance-id }}
-          node-package: ${{ steps.build.outputs.node-package }}
-          faucet-package: ${{ steps.build.outputs.faucet-package }}
+          # node-package: ${{ steps.build.outputs.node-package }}
+          # faucet-package: ${{ steps.build.outputs.faucet-package }}

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ inputs.instance-id }}
-          command: "ls /tmp"
+          command: "ls"
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
@@ -59,10 +59,10 @@ jobs:
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ inputs.instance-id }}
-          command: "ls /tmp"
+          command: "ls"
 
       - name: cat after
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ inputs.instance-id }}
-          command: "cat /tmp/testfile"
+          command: "cat testfile"

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -16,28 +16,28 @@ jobs:
       labels: ubuntu22-arm-4core
 
     # Required for devnet instance access.
-    env:
+    secrets:
       account-id: "${{ secrets.MIDEN_DEV_ACCOUNT_ID }}"
       instance-id: "${{ secrets.DEVNET_INSTANCE_ID }}"
 
     steps:
       - uses: actions/checkout@main
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::${{ env.account-id }}:role/midendev-GithubActionsRole
-          role-session-name: GithubActionsSession
+      - name: Set version
+        id: version
+        run: echo "version=$(git describe)" >> $GITHUB_OUTPUT
 
-      - name: ssm basic echo
-        uses: ./.github/actions/ssm-send-command
+      - name: Build Debian packages
+        id: build
+        uses: ./.github/actions/debian-packages
         with:
-          instance-id: ${{ env.instance-id }}
-          command: "echo hello there"
+          suffix: ${{ steps.version.outputs.version }}-arm64
 
-      - name: ssm failure
-        uses: ./.github/actions/ssm-send-command
+      - name: Deploy packages
+        uses: ./.github/actions/deploy
         with:
-          instance-id: ${{ env.instance-id }}
-          command: "exit 511"
+          role-to-assume: arn:aws:iam::${{ secrets.account-id }}:role/midendev-GithubActionsRole
+          aws-region: us-west-1
+          instance-id: ${{ secrets.instance-id }}
+          node-package: ${{ steps.build.outputs.node-package }}
+          faucet-package: ${{ steps.build.outputs.faucet-package }}

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ env.instance-id }}
-          command: "echo 'hello there'"
+          command: "echo hello there"
 
       - name: ssm failure
         uses: ./.github/actions/ssm-send-command

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ env.instance-id }}
-          command: "ls /tmp"
+          command: "ls"
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
@@ -59,10 +59,10 @@ jobs:
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ env.instance-id }}
-          command: "ls /tmp"
+          command: "ls"
 
       - name: cat after
         uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ env.instance-id }}
-          command: "cat /tmp/testfile"
+          command: "cat testfile"

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -33,6 +33,19 @@ jobs:
       #   with:
       #     suffix: ${{ steps.version.outputs.version }}-arm64
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.account-id }}:role/midendev-GithubActionsRole
+          aws-region: us-west-1
+          role-session-name: GithubActionsSession
+
+      - name: ls before
+        uses: ../ssm-send-command
+        with:
+          instance-id: ${{ inputs.instance-id }}
+          command: "ls /tmp"
+
       - name: Deploy packages
         uses: ./.github/actions/deploy
         with:
@@ -41,3 +54,15 @@ jobs:
           instance-id: ${{ env.instance-id }}
           # node-package: ${{ steps.build.outputs.node-package }}
           # faucet-package: ${{ steps.build.outputs.faucet-package }}
+
+      - name: ls after
+        uses: ../ssm-send-command
+        with:
+          instance-id: ${{ inputs.instance-id }}
+          command: "ls /tmp"
+
+      - name: cat after
+        uses: ../ssm-send-command
+        with:
+          instance-id: ${{ inputs.instance-id }}
+          command: "cat /tmp/testfile"

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -16,7 +16,7 @@ jobs:
       labels: ubuntu22-arm-4core
 
     # Required for devnet instance access.
-    secrets:
+    env:
       account-id: "${{ secrets.MIDEN_DEV_ACCOUNT_ID }}"
       instance-id: "${{ secrets.DEVNET_INSTANCE_ID }}"
 
@@ -36,8 +36,8 @@ jobs:
       - name: Deploy packages
         uses: ./.github/actions/deploy
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.account-id }}:role/midendev-GithubActionsRole
+          role-to-assume: arn:aws:iam::${{ env.account-id }}:role/midendev-GithubActionsRole
           aws-region: us-west-1
-          instance-id: ${{ secrets.instance-id }}
+          instance-id: ${{ env.instance-id }}
           # node-package: ${{ steps.build.outputs.node-package }}
           # faucet-package: ${{ steps.build.outputs.faucet-package }}

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -43,8 +43,8 @@ jobs:
       - name: ls before
         uses: ./.github/actions/ssm-send-command
         with:
-          instance-id: ${{ inputs.instance-id }}
-          command: "ls"
+          instance-id: ${{ env.instance-id }}
+          command: "ls /tmp"
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
@@ -58,11 +58,11 @@ jobs:
       - name: ls after
         uses: ./.github/actions/ssm-send-command
         with:
-          instance-id: ${{ inputs.instance-id }}
-          command: "ls"
+          instance-id: ${{ env.instance-id }}
+          command: "ls /tmp"
 
       - name: cat after
         uses: ./.github/actions/ssm-send-command
         with:
-          instance-id: ${{ inputs.instance-id }}
-          command: "cat testfile"
+          instance-id: ${{ env.instance-id }}
+          command: "cat /tmp/testfile"

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -25,13 +25,13 @@ jobs:
 
       - name: Set version
         id: version
-        run: echo "VERSION=$(git describe)" >> $GITHUB_OUTPUT
+        run: echo "version=$(git describe)" >> $GITHUB_OUTPUT
 
       - name: Build Debian packages
         id: build
         uses: ./.github/actions/debian-packages
         with:
-          version: ${{ steps.version.outputs.VERSION }}
+          version: ${{ steps.version.outputs.version }}
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
@@ -39,5 +39,5 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.account_id }}:role/midendev-GithubActionsRole
           aws-region: us-west-1
           instance-id: ${{ secrets.instance_id }}
-          node_package: ${{ steps.build.outputs.NODE_PATH }}
-          faucet_package: ${{ steps.build.outputs.FAUCET_PATH }}
+          node_package: ${{ steps.build.outputs.node_path }}
+          faucet_package: ${{ steps.build.outputs.faucet_path }}

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -41,7 +41,7 @@ jobs:
           role-session-name: GithubActionsSession
 
       - name: ls before
-        uses: ../ssm-send-command
+        uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ inputs.instance-id }}
           command: "ls /tmp"
@@ -56,13 +56,13 @@ jobs:
           # faucet-package: ${{ steps.build.outputs.faucet-package }}
 
       - name: ls after
-        uses: ../ssm-send-command
+        uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ inputs.instance-id }}
           command: "ls /tmp"
 
       - name: cat after
-        uses: ../ssm-send-command
+        uses: ./.github/actions/ssm-send-command
         with:
           instance-id: ${{ inputs.instance-id }}
           command: "cat /tmp/testfile"

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -1,5 +1,3 @@
-name: devnet deploy
-
 on:
   push:
     branches:
@@ -12,10 +10,34 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy to testnet
-    uses: ./.github/workflows/deploy_workflow.yml
-    with:
-      build_prefix: --branch next
+    name: Deploy devnet
+    # Our devnet instance is arm based.
+    runs-on:
+      labels: ubuntu22-arm-4core
+
+    # Required for devnet instance access.
     secrets:
       account_id: "${{ secrets.MIDEN_DEV_ACCOUNT_ID }}"
       instance_id: "${{ secrets.DEVNET_INSTANCE_ID }}"
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Set version
+        id: version
+        run: echo "VERSION=$(git describe)" >> $GITHUB_OUTPUT
+
+      - name: Build Debian packages
+        id: build
+        uses: ./.github/actions/debian-packages
+        with:
+          version: ${{ steps.version.outputs.VERSION }}
+
+      - name: Deploy packages
+        uses: ./.github/actions/deploy
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.account_id }}:role/midendev-GithubActionsRole
+          aws-region: us-west-1
+          instance-id: ${{ secrets.instance_id }}
+          node_package: ${{ steps.build.outputs.NODE_PATH }}
+          faucet_package: ${{ steps.build.outputs.FAUCET_PATH }}

--- a/.github/workflows/deploy_devnet.yml
+++ b/.github/workflows/deploy_devnet.yml
@@ -16,28 +16,28 @@ jobs:
       labels: ubuntu22-arm-4core
 
     # Required for devnet instance access.
-    secrets:
-      account_id: "${{ secrets.MIDEN_DEV_ACCOUNT_ID }}"
-      instance_id: "${{ secrets.DEVNET_INSTANCE_ID }}"
+    env:
+      account-id: "${{ secrets.MIDEN_DEV_ACCOUNT_ID }}"
+      instance-id: "${{ secrets.DEVNET_INSTANCE_ID }}"
 
     steps:
       - uses: actions/checkout@main
 
-      - name: Set version
-        id: version
-        run: echo "version=$(git describe)" >> $GITHUB_OUTPUT
-
-      - name: Build Debian packages
-        id: build
-        uses: ./.github/actions/debian-packages
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          version: ${{ steps.version.outputs.version }}
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::${{ env.account-id }}:role/midendev-GithubActionsRole
+          role-session-name: GithubActionsSession
 
-      - name: Deploy packages
-        uses: ./.github/actions/deploy
+      - name: ssm basic echo
+        uses: ./.github/actions/ssm-send-command
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.account_id }}:role/midendev-GithubActionsRole
-          aws-region: us-west-1
-          instance-id: ${{ secrets.instance_id }}
-          node_package: ${{ steps.build.outputs.node_path }}
-          faucet_package: ${{ steps.build.outputs.faucet_path }}
+          instance-id: ${{ env.instance-id }}
+          command: "echo 'hello there'"
+
+      - name: ssm failure
+        uses: ./.github/actions/ssm-send-command
+        with:
+          instance-id: ${{ env.instance-id }}
+          command: "exit 511"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on:
       labels: ubuntu22-arm-4core
     outputs:
-      node_file: ${{ steps.build.outputs.node_file }}
-      faucet_file: ${{ steps.build.outputs.faucet_file }}
+      node-package: ${{ steps.build.outputs.node-package }}
+      faucet-package: ${{ steps.build.outputs.faucet-package }}
       # Unsure if this env call will work or if it must be outputs.
       version: $${{ env.TAG }}
       
@@ -38,7 +38,7 @@ jobs:
         id: build
         uses: ./.github/actions/debian-packages
         with:
-          version: ${{ env.TAG }}
+          suffix: ${{ env.TAG }}-arm64
 
       - name: Upload packages
         uses: softprops/action-gh-release@v1
@@ -46,10 +46,10 @@ jobs:
           tag_name: ${{ env.TAG }}
           prerelease: true
           files: |
-            ${{ steps.build.outputs.node_file }}
-            ${{ steps.build.outputs.node_file }}.checksum
-            ${{ steps.build.outputs.faucet_file }}
-            ${{ steps.build.outputs.faucet_file }}.checksum
+            ${{ steps.build.outputs.node-package }}
+            ${{ steps.build.outputs.node-package }}.checksum
+            ${{ steps.build.outputs.faucet-package }}
+            ${{ steps.build.outputs.faucet-package }}.checksum
 
   amd_package:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
         id: build
         uses: ./.github/actions/debian-packages
         with:
-          version: ${{ env.TAG }}
+          suffix: ${{ env.TAG }}-amd64
 
       - name: Upload packages
         uses: softprops/action-gh-release@v1
@@ -80,10 +80,10 @@ jobs:
           tag_name: ${{ env.TAG }}
           prerelease: true
           files: |
-            ${{ steps.build.outputs.node_file }}
-            ${{ steps.build.outputs.node_file }}.checksum
-            ${{ steps.build.outputs.faucet_file }}
-            ${{ steps.build.outputs.faucet_file }}.checksum
+            ${{ steps.build.outputs.node-package }}
+            ${{ steps.build.outputs.node-package }}.checksum
+            ${{ steps.build.outputs.faucet-package }}
+            ${{ steps.build.outputs.faucet-package }}.checksum
 
   deploy:
     name: Deploy testnet
@@ -94,33 +94,32 @@ jobs:
 
     # Required for testnet instance access.
     secrets:
-      account_id: "${{ secrets.MIDEN_TESTNET_ACCOUNT_ID }}"
-      instance_id: "${{ secrets.TESTNET_INSTANCE_ID }}"
+      account-id: "${{ secrets.MIDEN_TESTNET_ACCOUNT_ID }}"
+      instance-id: "${{ secrets.TESTNET_INSTANCE_ID }}"
 
     env:
       VERSION: ${{ needs.arm_package.outputs.version }}
-      NODE_FILE: ${{ needs.arm_package.outputs.node_file }} 
-      FAUCET_FILE: ${{ needs.arm_package.outputs.faucet_file }} 
+      NODE_PACKAGE: ${{ needs.arm_package.outputs.node-package }} 
+      FAUCET_PACKAGE: ${{ needs.arm_package.outputs.faucet-package }} 
 
     steps:
       - name: Download packages
-        id: download
         run: |
-          gh release ${{ env.VERSION }} download ${{ env.NODE_FILE }}
-          gh release ${{ env.VERSION }} download ${{ env.NODE_FILE }}.checksum
-          gh release ${{ env.VERSION }} download ${{ env.FAUCET_FILE }}
-          gh release ${{ env.VERSION }} download ${{ env.FAUCET_FILE }}.checksum
+          gh release ${{ env.VERSION }} download ${{ env.NODE_PACKAGE }}
+          gh release ${{ env.VERSION }} download ${{ env.NODE_PACKAGE }}.checksum
+          gh release ${{ env.VERSION }} download ${{ env.FAUCET_PACKAGE }}
+          gh release ${{ env.VERSION }} download ${{ env.FAUCET_PACKAGE }}.checksum
 
       - name: Verify checksums
         run: |
-          sha256 --check ${{ env.NODE_FILE }}.checksum
-          sha256 --check ${{ env.FAUCET_FILE }}.checksum
+          sha256 --check ${{ env.NODE_PACKAGE }}.checksum
+          sha256 --check ${{ env.FAUCET_PACKAGE }}.checksum
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.account_id }}:role/midendev-GithubActionsRole
+          role-to-assume: arn:aws:iam::${{ secrets.account-id }}:role/midendev-GithubActionsRole
           aws-region: us-west-1
-          instance-id: ${{ secrets.instance_id }}
-          node_package: ${{ env.NODE_FILE }}
-          faucet_package: ${{ env.FAUCET_FILE }}
+          instance-id: ${{ secrets.instance-id }}
+          node_package: ${{ env.NODE_PACKAGE }}
+          faucet_package: ${{ env.FAUCET_PACKAGE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+on:
+  workflow_dispatch:
+  # Disabled until we get this working properly.
+  #
+  # release:
+  #   types: [released, prereleased]
+        
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  package:
+    strategy:
+    matrix:
+      # This isn't quite correct, we need some weird combo of labels and normal runner which I'm unsure how to do.
+      # Worst case scenario we just duplicate this job for each.
+      runner: [ubuntu-latest, ubuntu22-arm-4core]
+
+    steps:
+
+    
+
+  
+  deploy:
+    name: Deploy testnet
+
+    # We need to wait for the arm debian packages to be created as these
+    # are the ones we are deploying.
+    needs: package-ubuntu22-arm-4core
+
+    # Required for testnet instance access.
+    secrets:
+      account_id: "${{ secrets.MIDEN_TESTNET_ACCOUNT_ID }}"
+      instance_id: "${{ secrets.TESTNET_INSTANCE_ID }}"
+
+    steps:
+      - name: Select latest version
+        id: version
+        run: echo "VERSION=gh release ls --exclude-drafts --limit 1 --json tagName | jq -e '.[0].tagName'" >> $GITHUB_OUTPUT
+      
+      - name: Download packages
+        id: download
+        run: |
+          # This would be possible to do without the version as by default gh release download chooses the latest version, 
+          # but then we wouldn't be sure what exactly the files are called. And it also interacts strangely with draft releases.
+          gh release ${{ steps.version.outputs.VERSION }} download miden-node-${{ steps.version.outputs.VERSION }}-arm64.deb
+          gh release ${{ steps.version.outputs.VERSION }} download miden-node-${{ steps.version.outputs.VERSION }}-arm64.deb.checksum
+          gh release ${{ steps.version.outputs.VERSION }} download miden-faucet-${{ steps.version.outputs.VERSION }}-arm64.deb
+          gh release ${{ steps.version.outputs.VERSION }} download miden-faucet-${{ steps.version.outputs.VERSION }}-arm64.deb.checksum
+
+          # Store the filepaths as outputs so only this step has to know about these things.
+          echo "NODE_FILE=miden-node-${{ steps.version.outputs.VERSION }}-arm64.deb" >> $GITHUB_OUTPUT
+          echo "FAUCET_FILE=miden-faucet-${{ steps.version.outputs.VERSION }}-arm64.deb" >> $GITHUB_OUTPUT
+
+      - name: Verify checksums
+        run: |
+          sha256 --check ${{ steps.download.outputs.NODE_FILE }}.checksum
+          sha256 --check ${{ steps.download.outputs.FAUCET_FILE }}.checksum
+
+      - name: Deploy packages
+        uses: ./.github/actions/deploy
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.account_id }}:role/midendev-GithubActionsRole
+          aws-region: us-west-1
+          instance-id: ${{ secrets.instance_id }}
+          node_package: ${{ steps.download.outputs.NODE_FILE }}
+          faucet_package: ${{ steps.download.outputs.FAUCET_FILE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,53 +10,111 @@ permissions:
   contents: write
 
 jobs:
-  package:
-    strategy:
-    matrix:
-      # This isn't quite correct, we need some weird combo of labels and normal runner which I'm unsure how to do.
-      # Worst case scenario we just duplicate this job for each.
-      runner: [ubuntu-latest, ubuntu22-arm-4core]
-
+  arm_package:
+    runs-on:
+      labels: ubuntu22-arm-4core
+    outputs:
+      node_file: ${{ steps.build.outputs.node_file }}
+      faucet_file: ${{ steps.build.outputs.faucet_file }}
+      # Unsure if this env call will work or if it must be outputs.
+      version: $${{ env.TAG }}
+      
     steps:
+      # This version selection is only required to handle workflow dispatch triggers, so we can simplify this once
+      # we are done testing and drop workflow dispatch trigger.
+      - name: Select version tag (release)
+        if: github.event_name == 'release'
+        run: echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
-    
+      - name: Select version tag (non-release)
+        if: github.event_name != 'release'
+        run: echo "TAG=gh release ls --exclude-drafts --limit 1 --json tagName | jq -e '.[0].tagName'" >> $GITHUB_ENV
 
-  
+      - uses: actions/checkout@main
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Build Debian packages
+        id: build
+        uses: ./.github/actions/debian-packages
+        with:
+          version: ${{ env.TAG }}
+
+      - name: Upload packages
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.TAG }}
+          prerelease: true
+          files: |
+            ${{ steps.build.outputs.node_file }}
+            ${{ steps.build.outputs.node_file }}.checksum
+            ${{ steps.build.outputs.faucet_file }}
+            ${{ steps.build.outputs.faucet_file }}.checksum
+
+  amd_package:
+    runs-on: ubuntu-latest
+    steps:
+      # This version selection is only required to handle workflow dispatch triggers, so we can simplify this once
+      # we are done testing and drop workflow dispatch trigger.
+      - name: Select version tag (release)
+        if: github.event_name == 'release'
+        run: echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+
+      - name: Select version tag (non-release)
+        if: github.event_name != 'release'
+        run: echo "TAG=gh release ls --exclude-drafts --limit 1 --json tagName | jq -e '.[0].tagName'" >> $GITHUB_ENV
+
+      - uses: actions/checkout@main
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Build Debian packages
+        id: build
+        uses: ./.github/actions/debian-packages
+        with:
+          version: ${{ env.TAG }}
+
+      - name: Upload packages
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.TAG }}
+          prerelease: true
+          files: |
+            ${{ steps.build.outputs.node_file }}
+            ${{ steps.build.outputs.node_file }}.checksum
+            ${{ steps.build.outputs.faucet_file }}
+            ${{ steps.build.outputs.faucet_file }}.checksum
+
   deploy:
     name: Deploy testnet
 
     # We need to wait for the arm debian packages to be created as these
     # are the ones we are deploying.
-    needs: package-ubuntu22-arm-4core
+    needs: arm_package
 
     # Required for testnet instance access.
     secrets:
       account_id: "${{ secrets.MIDEN_TESTNET_ACCOUNT_ID }}"
       instance_id: "${{ secrets.TESTNET_INSTANCE_ID }}"
 
+    env:
+      VERSION: ${{ needs.arm_package.outputs.version }}
+      NODE_FILE: ${{ needs.arm_package.outputs.node_file }} 
+      FAUCET_FILE: ${{ needs.arm_package.outputs.faucet_file }} 
+
     steps:
-      - name: Select latest version
-        id: version
-        run: echo "VERSION=gh release ls --exclude-drafts --limit 1 --json tagName | jq -e '.[0].tagName'" >> $GITHUB_OUTPUT
-      
       - name: Download packages
         id: download
         run: |
-          # This would be possible to do without the version as by default gh release download chooses the latest version, 
-          # but then we wouldn't be sure what exactly the files are called. And it also interacts strangely with draft releases.
-          gh release ${{ steps.version.outputs.VERSION }} download miden-node-${{ steps.version.outputs.VERSION }}-arm64.deb
-          gh release ${{ steps.version.outputs.VERSION }} download miden-node-${{ steps.version.outputs.VERSION }}-arm64.deb.checksum
-          gh release ${{ steps.version.outputs.VERSION }} download miden-faucet-${{ steps.version.outputs.VERSION }}-arm64.deb
-          gh release ${{ steps.version.outputs.VERSION }} download miden-faucet-${{ steps.version.outputs.VERSION }}-arm64.deb.checksum
-
-          # Store the filepaths as outputs so only this step has to know about these things.
-          echo "NODE_FILE=miden-node-${{ steps.version.outputs.VERSION }}-arm64.deb" >> $GITHUB_OUTPUT
-          echo "FAUCET_FILE=miden-faucet-${{ steps.version.outputs.VERSION }}-arm64.deb" >> $GITHUB_OUTPUT
+          gh release ${{ env.VERSION }} download ${{ env.NODE_FILE }}
+          gh release ${{ env.VERSION }} download ${{ env.NODE_FILE }}.checksum
+          gh release ${{ env.VERSION }} download ${{ env.FAUCET_FILE }}
+          gh release ${{ env.VERSION }} download ${{ env.FAUCET_FILE }}.checksum
 
       - name: Verify checksums
         run: |
-          sha256 --check ${{ steps.download.outputs.NODE_FILE }}.checksum
-          sha256 --check ${{ steps.download.outputs.FAUCET_FILE }}.checksum
+          sha256 --check ${{ env.NODE_FILE }}.checksum
+          sha256 --check ${{ env.FAUCET_FILE }}.checksum
 
       - name: Deploy packages
         uses: ./.github/actions/deploy
@@ -64,5 +122,5 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.account_id }}:role/midendev-GithubActionsRole
           aws-region: us-west-1
           instance-id: ${{ secrets.instance_id }}
-          node_package: ${{ steps.download.outputs.NODE_FILE }}
-          faucet_package: ${{ steps.download.outputs.FAUCET_FILE }}
+          node_package: ${{ env.NODE_FILE }}
+          faucet_package: ${{ env.FAUCET_FILE }}


### PR DESCRIPTION
This is a WIP meant to demonstrate a set of workflows which allows us to combine, re-use and separate testnet and devnet deployments.

⚠️ expect naming inconsistencies, typos and other gnarly minutia.

----------------------

The essence of this refactor is creating two actions:

#### 1. Package

This generates the `miden-node` and `miden-faucet` packages -- but notable only generates the files. No uploading or tagging etc. All meta-data like that should come in as an input.

#### 2. Deploy

This action takes in the aws ssm credentials and filepaths to the packages. It then uses `scp` to copy the packages across, and then `ssm` to do the deployment process similar to what is happening now.

----------------------

The workflows are now split into `release` and `deploy_devnet` using the above actions:

1. devnet generates the arm package and then deploys it.
2. release has 3 jobs
    1. generate and upload amd package
    2. generate and upload arm package
    3. wait for arm package to be available and deploy it to testnet

The nice thing is that the actions don't care about architecture or tags etc. That's up to the workflow to setup. And similarly we get to re-use the actions.

----------------------

⚠️ I haven't actually tested the scp via ssm but I believe it is possible according to the docs. And the actions are currently just stubs..

I'd also like an action to wrap the ssm command + polling loop nonsense but that's not super relevant here.