### PR TITLE
fix: type shadowing in proto file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.0 (TBD)
 
 - Optimized state synchronizations by removing unnecessary fetching and parsing of note details (#462).
+- [BREAKING] Changed `GetAccountDetailsResponse` field to `details` (#481).
 
 ## 0.5.0 (2024-08-27)
 

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -201,7 +201,7 @@ pub struct ListNotesResponse {
 pub struct GetAccountDetailsResponse {
     /// Account info (with details for on-chain accounts)
     #[prost(message, optional, tag = "1")]
-    pub account: ::core::option::Option<super::account::AccountInfo>,
+    pub details: ::core::option::Option<super::account::AccountInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -161,7 +161,7 @@ message ListNotesResponse {
 
 message GetAccountDetailsResponse {
     // Account info (with details for on-chain accounts)
-    account.AccountInfo account = 1;
+    account.AccountInfo details = 1;
 }
 
 message GetBlockByNumberResponse {

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -335,7 +335,7 @@ impl api_server::Api for StoreApi {
             .map_err(internal_error)?;
 
         Ok(Response::new(GetAccountDetailsResponse {
-            account: Some((&account_info).into()),
+            details: Some((&account_info).into()),
         }))
     }
 

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -161,7 +161,7 @@ message ListNotesResponse {
 
 message GetAccountDetailsResponse {
     // Account info (with details for on-chain accounts)
-    account.AccountInfo account = 1;
+    account.AccountInfo details = 1;
 }
 
 message GetBlockByNumberResponse {


### PR DESCRIPTION
When updating the dependencies in the client we started getting this error when generating the rust types from proto files:
```
Error:   × name 'account.AccountInfo' is shadowed
       ╭─[responses.proto:164:5]
   163 │     // Account info (with details for on-chain accounts)
   164 │     account.AccountInfo account = 1;
       ·     ─────────┬─────────
       ·              ╰── found here
   165 │ }
       ╰────
    help: 'account.AccountInfo' is is resolved to
          'responses.GetAccountDetailsResponse.account.AccountInfo',
          which is not defined. The innermost scope is searched first
          in name resolution. Consider using a leading '.'(i.e.,
          '.account.AccountInfo') to start from the outermost scope.
```

It seems the name of the field `account` is shadowing the name of the import `account`. As it is recommended in the message, this can be fixed by specifying the root. 