### PR TITLE
feat: component startup is now coherent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.1 (TBD)
+
+### Enhancements
+
+- Node component server startup is now coherent instead of requiring an arbitrary sleep amount (#488).
+
 ## 0.5.0 (2024-08-27)
 
 ### Enhancements
@@ -13,7 +19,6 @@
 - Added `GetNoteAuthenticationInfo` endpoint (#421).
 - Added `SyncNotes` endpoint (#424).
 - Added `execution_hint` field to the `Notes` table (#441).
-- Node component server startup is now coherent instead of requiring an arbitrary sleep amount (#488).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `GetNoteAuthenticationInfo` endpoint (#421).
 - Added `SyncNotes` endpoint (#424).
 - Added `execution_hint` field to the `Notes` table (#441).
+- Node component server startup is now coherent instead of requiring an arbitrary sleep amount (#488).
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,6 +1902,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,7 @@ dependencies = [
  "prost",
  "serde",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "tonic-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ miden-processor = { version = "0.10" }
 miden-stdlib = { version = "0.10", default-features = false }
 miden-tx = { version = "0.5" }
 thiserror = { version = "1.0" }
+tokio = { version = "1.38" }
 tonic = { version = "0.11" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt",  "json",  "env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ miden-stdlib = { version = "0.10", default-features = false }
 miden-tx = { version = "0.5" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.38" }
+tokio-stream = { version = "0.1" }
 tonic = { version = "0.11" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt",  "json",  "env-filter"] }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -28,7 +28,7 @@ miden-node-utils = { workspace = true }
 miden-objects = { workspace = true }
 rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.38", features = ["rt-multi-thread", "net", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros"] }
 toml = { version = "0.8" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/bin/node/src/commands/start.rs
+++ b/bin/node/src/commands/start.rs
@@ -15,16 +15,16 @@ pub async fn start_node(config: NodeConfig) -> Result<()> {
     let mut join_set = JoinSet::new();
 
     // Start store. The store endpoint is available after loading completes.
-    let store = Store::load(store).await.context("Loading store")?;
+    let store = Store::init(store).await.context("Loading store")?;
     join_set.spawn(async move { store.serve().await.context("Serving store") });
 
     // Start block-producer. The block-producer's endpoint is available after loading completes.
     let block_producer =
-        BlockProducer::load(block_producer).await.context("Loading block-producer")?;
+        BlockProducer::init(block_producer).await.context("Loading block-producer")?;
     join_set.spawn(async move { block_producer.serve().await.context("Serving block-producer") });
 
     // Start RPC component.
-    let rpc = Rpc::load(rpc).await.context("Loading RPC")?;
+    let rpc = Rpc::init(rpc).await.context("Loading RPC")?;
     join_set.spawn(async move { rpc.serve().await.context("Serving RPC") });
 
     // block on all tasks

--- a/bin/node/src/commands/start.rs
+++ b/bin/node/src/commands/start.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use miden_node_block_producer::{config::BlockProducerConfig, server as block_producer_server};
 use miden_node_rpc::{config::RpcConfig, server as rpc_server};
-use miden_node_store::{config::StoreConfig, server as store_server};
+use miden_node_store::server::Store;
 use tokio::task::JoinSet;
 
 use crate::config::NodeConfig;
@@ -16,11 +16,11 @@ pub async fn start_node(config: NodeConfig) -> Result<()> {
 
     let mut join_set = JoinSet::new();
 
-    // Start store
-    join_set.spawn(start_store(store));
+    // Start store. The store endpoint is available after loading completes.
+    let store = Store::load(store).await.context("Loading store")?;
+    join_set.spawn(async move { store.serve().await.context("Serving store") });
 
     // Wait for store to start & start block-producer
-    tokio::time::sleep(Duration::from_secs(1)).await;
     join_set.spawn(start_block_producer(block_producer));
 
     // Wait for block-producer to start & start rpc
@@ -48,14 +48,6 @@ pub async fn start_rpc(config: RpcConfig) -> Result<()> {
     rpc_server::serve(config)
         .await
         .map_err(|err| anyhow!("Failed to serve rpc: {}", err))?;
-
-    Ok(())
-}
-
-pub async fn start_store(config: StoreConfig) -> Result<()> {
-    store_server::serve(config)
-        .await
-        .map_err(|err| anyhow!("Failed to serve store: {}", err))?;
 
     Ok(())
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -2,11 +2,9 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
-use commands::{
-    init::init_config_files,
-    start::{start_node, start_rpc},
-};
+use commands::{init::init_config_files, start::start_node};
 use miden_node_block_producer::server::BlockProducer;
+use miden_node_rpc::server::Rpc;
 use miden_node_store::server::Store;
 use miden_node_utils::config::load_config;
 
@@ -105,7 +103,12 @@ async fn main() -> anyhow::Result<()> {
             },
             StartCommand::Rpc => {
                 let config = load_config(config).context("Loading configuration file")?;
-                start_rpc(config).await
+                Rpc::load(config)
+                    .await
+                    .context("Loading RPC")?
+                    .serve()
+                    .await
+                    .context("Serving RPC")
             },
             StartCommand::Store => {
                 let config = load_config(config).context("Loading configuration file")?;

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
             },
             StartCommand::BlockProducer => {
                 let config = load_config(config).context("Loading configuration file")?;
-                BlockProducer::load(config)
+                BlockProducer::init(config)
                     .await
                     .context("Loading block-producer")?
                     .serve()
@@ -103,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
             },
             StartCommand::Rpc => {
                 let config = load_config(config).context("Loading configuration file")?;
-                Rpc::load(config)
+                Rpc::init(config)
                     .await
                     .context("Loading RPC")?
                     .serve()
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
             },
             StartCommand::Store => {
                 let config = load_config(config).context("Loading configuration file")?;
-                Store::load(config)
+                Store::init(config)
                     .await
                     .context("Loading store")?
                     .serve()

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -4,8 +4,9 @@ use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
 use commands::{
     init::init_config_files,
-    start::{start_block_producer, start_node, start_rpc},
+    start::{start_node, start_rpc},
 };
+use miden_node_block_producer::server::BlockProducer;
 use miden_node_store::server::Store;
 use miden_node_utils::config::load_config;
 
@@ -95,7 +96,12 @@ async fn main() -> anyhow::Result<()> {
             },
             StartCommand::BlockProducer => {
                 let config = load_config(config).context("Loading configuration file")?;
-                start_block_producer(config).await
+                BlockProducer::load(config)
+                    .await
+                    .context("Loading block-producer")?
+                    .serve()
+                    .await
+                    .context("Serving block-producer")
             },
             StartCommand::Rpc => {
                 let config = load_config(config).context("Loading configuration file")?;

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -4,8 +4,9 @@ use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
 use commands::{
     init::init_config_files,
-    start::{start_block_producer, start_node, start_rpc, start_store},
+    start::{start_block_producer, start_node, start_rpc},
 };
+use miden_node_store::server::Store;
 use miden_node_utils::config::load_config;
 
 mod commands;
@@ -102,7 +103,12 @@ async fn main() -> anyhow::Result<()> {
             },
             StartCommand::Store => {
                 let config = load_config(config).context("Loading configuration file")?;
-                start_store(config).await
+                Store::load(config)
+                    .await
+                    .context("Loading store")?
+                    .serve()
+                    .await
+                    .context("Serving store")
             },
         },
         Command::MakeGenesis { output_path, force, inputs_path } => {

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -27,6 +27,7 @@ miden-tx = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
+tokio-stream = { workspace = true, features = ["net"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -26,7 +26,7 @@ miden-stdlib = { workspace = true }
 miden-tx = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { version = "1.38", features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }
@@ -41,5 +41,5 @@ miden-objects = { workspace = true, features = ["testing"] }
 miden-tx = { workspace = true, features = ["testing"] }
 once_cell = { version = "1.18" }
 rand_chacha = { version = "0.3", default-features = false }
-tokio = { version = "1.38", features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 winterfell = { version = "0.9" }

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -40,7 +40,7 @@ impl BlockProducer {
     /// Performs all expensive initialization tasks, and notably begins listening on the rpc
     /// endpoint without serving the API yet. Incoming requests will be queued until
     /// [`serve`](Self::serve) is called.
-    pub async fn load(config: BlockProducerConfig) -> Result<Self, ApiError> {
+    pub async fn init(config: BlockProducerConfig) -> Result<Self, ApiError> {
         info!(target: COMPONENT, %config, "Initializing server");
 
         let store = Arc::new(DefaultStore::new(

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -19,27 +19,27 @@ use crate::{
 
 pub mod api;
 
+type Api = api::BlockProducerApi<
+    DefaultBatchBuilder<
+        DefaultStore,
+        DefaultBlockBuilder<DefaultStore, DefaultStateView<DefaultStore>>,
+    >,
+    DefaultStateView<DefaultStore>,
+>;
+
 /// Represents an initialized block-producer component where the RPC connection is open,
 /// but not yet actively responding to requests. Separating the connection binding
 /// from the server spawning allows the caller to connect other components to the
 /// store without resorting to sleeps or other mechanisms to spawn dependent components.
 pub struct BlockProducer {
-    api_service: api_server::ApiServer<
-        api::BlockProducerApi<
-            DefaultBatchBuilder<
-                DefaultStore,
-                DefaultBlockBuilder<DefaultStore, DefaultStateView<DefaultStore>>,
-            >,
-            DefaultStateView<DefaultStore>,
-        >,
-    >,
+    api_service: api_server::ApiServer<Api>,
     listener: TcpListener,
 }
 
 impl BlockProducer {
-    /// Performs all expensive initialization tasks, and notably begins listening on the rpc endpoint without
-    /// serving the API yet. Incoming requests will be queued until [`serve`](Self::serve) is
-    /// called.
+    /// Performs all expensive initialization tasks, and notably begins listening on the rpc
+    /// endpoint without serving the API yet. Incoming requests will be queued until
+    /// [`serve`](Self::serve) is called.
     pub async fn load(config: BlockProducerConfig) -> Result<Self, ApiError> {
         info!(target: COMPONENT, %config, "Initializing server");
 

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -2,7 +2,8 @@ use std::{net::ToSocketAddrs, sync::Arc};
 
 use miden_node_proto::generated::{block_producer::api_server, store::api_client as store_client};
 use miden_node_utils::errors::ApiError;
-use tonic::transport::Server;
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
 use tracing::info;
 
 use crate::{
@@ -18,59 +19,80 @@ use crate::{
 
 pub mod api;
 
-// BLOCK PRODUCER INITIALIZER
-// ================================================================================================
+pub struct BlockProducer {
+    api_service: api_server::ApiServer<
+        api::BlockProducerApi<
+            DefaultBatchBuilder<
+                DefaultStore,
+                DefaultBlockBuilder<DefaultStore, DefaultStateView<DefaultStore>>,
+            >,
+            DefaultStateView<DefaultStore>,
+        >,
+    >,
+    listener: TcpListener,
+}
 
-pub async fn serve(config: BlockProducerConfig) -> Result<(), ApiError> {
-    info!(target: COMPONENT, %config, "Initializing server");
+impl BlockProducer {
+    pub async fn load(config: BlockProducerConfig) -> Result<Self, ApiError> {
+        info!(target: COMPONENT, %config, "Initializing server");
 
-    let store = Arc::new(DefaultStore::new(
-        store_client::ApiClient::connect(config.store_url.to_string())
+        let store = Arc::new(DefaultStore::new(
+            store_client::ApiClient::connect(config.store_url.to_string())
+                .await
+                .map_err(|err| ApiError::DatabaseConnectionFailed(err.to_string()))?,
+        ));
+        let state_view =
+            Arc::new(DefaultStateView::new(Arc::clone(&store), config.verify_tx_proofs));
+
+        let block_builder = DefaultBlockBuilder::new(Arc::clone(&store), Arc::clone(&state_view));
+        let batch_builder_options = DefaultBatchBuilderOptions {
+            block_frequency: SERVER_BLOCK_FREQUENCY,
+            max_batches_per_block: SERVER_MAX_BATCHES_PER_BLOCK,
+        };
+        let batch_builder = Arc::new(DefaultBatchBuilder::new(
+            Arc::clone(&store),
+            Arc::new(block_builder),
+            batch_builder_options,
+        ));
+
+        let transaction_queue_options = TransactionQueueOptions {
+            build_batch_frequency: SERVER_BUILD_BATCH_FREQUENCY,
+            batch_size: SERVER_BATCH_SIZE,
+        };
+        let queue = Arc::new(TransactionQueue::new(
+            state_view,
+            Arc::clone(&batch_builder),
+            transaction_queue_options,
+        ));
+
+        let api_service =
+            api_server::ApiServer::new(api::BlockProducerApi::new(Arc::clone(&queue)));
+
+        tokio::spawn(async move { queue.run().await });
+        tokio::spawn(async move { batch_builder.run().await });
+
+        let addr = config
+            .endpoint
+            .to_socket_addrs()
+            .map_err(ApiError::EndpointToSocketFailed)?
+            .next()
+            .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))?;
+
+        let listener = TcpListener::bind(addr).await?;
+
+        info!(target: COMPONENT, "Server initialized");
+
+        Ok(Self { api_service, listener })
+    }
+
+    /// Serves the block-producers's RPC API.
+    ///
+    /// Note: this will block until the server dies.
+    pub async fn serve(self) -> Result<(), ApiError> {
+        tonic::transport::Server::builder()
+            .add_service(self.api_service)
+            .serve_with_incoming(TcpListenerStream::new(self.listener))
             .await
-            .map_err(|err| ApiError::DatabaseConnectionFailed(err.to_string()))?,
-    ));
-    let state_view = Arc::new(DefaultStateView::new(Arc::clone(&store), config.verify_tx_proofs));
-
-    let block_builder = DefaultBlockBuilder::new(Arc::clone(&store), Arc::clone(&state_view));
-    let batch_builder_options = DefaultBatchBuilderOptions {
-        block_frequency: SERVER_BLOCK_FREQUENCY,
-        max_batches_per_block: SERVER_MAX_BATCHES_PER_BLOCK,
-    };
-    let batch_builder = Arc::new(DefaultBatchBuilder::new(
-        Arc::clone(&store),
-        Arc::new(block_builder),
-        batch_builder_options,
-    ));
-
-    let transaction_queue_options = TransactionQueueOptions {
-        build_batch_frequency: SERVER_BUILD_BATCH_FREQUENCY,
-        batch_size: SERVER_BATCH_SIZE,
-    };
-    let queue = Arc::new(TransactionQueue::new(
-        state_view,
-        Arc::clone(&batch_builder),
-        transaction_queue_options,
-    ));
-
-    let block_producer = api_server::ApiServer::new(api::BlockProducerApi::new(Arc::clone(&queue)));
-
-    tokio::spawn(async move { queue.run().await });
-    tokio::spawn(async move { batch_builder.run().await });
-
-    info!(target: COMPONENT, "Server initialized");
-
-    let addr = config
-        .endpoint
-        .to_socket_addrs()
-        .map_err(ApiError::EndpointToSocketFailed)?
-        .next()
-        .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))?;
-
-    Server::builder()
-        .add_service(block_producer)
-        .serve(addr)
-        .await
-        .map_err(ApiError::ApiServeFailed)?;
-
-    Ok(())
+            .map_err(ApiError::ApiServeFailed)
+    }
 }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -24,6 +24,7 @@ miden-tx = { workspace = true }
 prost = { version = "0.12" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros"] }
+tokio-stream = { workspace = true, features = ["net"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tonic-web = { version = "0.11" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -23,7 +23,7 @@ miden-objects = { workspace = true }
 miden-tx = { workspace = true }
 prost = { version = "0.12" }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.38", features = ["rt-multi-thread", "net", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tonic-web = { version = "0.11" }

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -1,40 +1,57 @@
 use std::net::ToSocketAddrs;
 
+use api::RpcApi;
 use miden_node_proto::generated::rpc::api_server;
 use miden_node_utils::errors::ApiError;
-use tonic::transport::Server;
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
 use tracing::info;
 
 use crate::{config::RpcConfig, COMPONENT};
 
 mod api;
 
-// RPC INITIALIZER
-// ================================================================================================
+/// Represents an initialized rpc component where the RPC connection is open,
+/// but not yet actively responding to requests. Separating the connection binding
+/// from the server spawning allows the caller to connect other components to the
+/// store without resorting to sleeps or other mechanisms to spawn dependent components.
+pub struct Rpc {
+    api_service: api_server::ApiServer<RpcApi>,
+    listener: TcpListener,
+}
 
-pub async fn serve(config: RpcConfig) -> Result<(), ApiError> {
-    info!(target: COMPONENT, %config, "Initializing server");
+impl Rpc {
+    pub async fn load(config: RpcConfig) -> Result<Self, ApiError> {
+        info!(target: COMPONENT, %config, "Initializing server");
 
-    let api = api::RpcApi::from_config(&config)
-        .await
-        .map_err(|err| ApiError::ApiInitialisationFailed(err.to_string()))?;
-    let rpc = api_server::ApiServer::new(api);
+        let api = api::RpcApi::from_config(&config)
+            .await
+            .map_err(|err| ApiError::ApiInitialisationFailed(err.to_string()))?;
+        let api_service = api_server::ApiServer::new(api);
 
-    info!(target: COMPONENT, "Server initialized");
+        let addr = config
+            .endpoint
+            .to_socket_addrs()
+            .map_err(ApiError::EndpointToSocketFailed)?
+            .next()
+            .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))?;
 
-    let addr = config
-        .endpoint
-        .to_socket_addrs()
-        .map_err(ApiError::EndpointToSocketFailed)?
-        .next()
-        .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))?;
+        let listener = TcpListener::bind(addr).await?;
 
-    Server::builder()
-        .accept_http1(true)
-        .add_service(tonic_web::enable(rpc))
-        .serve(addr)
-        .await
-        .map_err(ApiError::ApiServeFailed)?;
+        info!(target: COMPONENT, "Server initialized");
 
-    Ok(())
+        Ok(Self { api_service, listener })
+    }
+
+    /// Serves the RPC API.
+    ///
+    /// Note: this blocks until the server dies.
+    pub async fn serve(self) -> Result<(), ApiError> {
+        tonic::transport::Server::builder()
+            .accept_http1(true)
+            .add_service(tonic_web::enable(self.api_service))
+            .serve_with_incoming(TcpListenerStream::new(self.listener))
+            .await
+            .map_err(ApiError::ApiServeFailed)
+    }
 }

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -21,7 +21,7 @@ pub struct Rpc {
 }
 
 impl Rpc {
-    pub async fn load(config: RpcConfig) -> Result<Self, ApiError> {
+    pub async fn init(config: RpcConfig) -> Result<Self, ApiError> {
         info!(target: COMPONENT, %config, "Initializing server");
 
         let api = api::RpcApi::from_config(&config)

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -26,7 +26,7 @@ rusqlite = { version = "0.31", features = ["array", "buildtime_bindgen", "bundle
 rusqlite_migration = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { version = "1.38", features = ["fs", "net", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "net", "macros", "rt-multi-thread"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -27,6 +27,7 @@ rusqlite_migration = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "net", "macros", "rt-multi-thread"] }
+tokio-stream = { workspace = true, features = ["net"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -56,7 +56,7 @@ impl Store {
 
     /// Serves the store's RPC API.
     ///
-    /// Note: this will block until the server dies.
+    /// Note: this blocks until the server dies.
     pub async fn serve(self) -> Result<(), ApiError> {
         tonic::transport::Server::builder()
             .add_service(self.api_service)

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -23,7 +23,7 @@ impl Store {
     /// Loads the required database data and initializes the TCP listener without
     /// serving the API yet. Incoming requests will be queued until [`serve`](Self::serve) is
     /// called.
-    pub async fn load(config: StoreConfig) -> Result<Self, ApiError> {
+    pub async fn init(config: StoreConfig) -> Result<Self, ApiError> {
         info!(target: COMPONENT, %config, "Loading database");
 
         let block_store = Arc::new(BlockStore::new(config.blockstore_dir.clone()).await?);


### PR DESCRIPTION
I need a better word for `coherent` I think.

This PR improves the node component startup procedure. Instead of 
> spawning a component's rpc server and then waiting an arbitrary amount of time before deciding the server is "probably up"

we now separate out an initialization step before spawning the server. This init step includes binding a listener on the endpoint so that dependent components can begin connecting after init, but before serving has been spawned. In this way we can now know that after `Component::load` completes that we are safe to depend on the endpoint. 

Fixes #486.

Note: this is PR'd into `main` and not `next` as we require this fix for v0.5.1 as existing instances are currently unable to be restarted (see #483).

I manually tested this by inserting a 5s sleep before the store serve is invoked and it seems to work. Of course the real answer will be trying it on the larger blockchain instances.