### PR TITLE
fix: update `miden-base` branch in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=polydez-note-tree-refactor#48e5f4743c4ff2e842296a963be25fc8b071d0f6"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#76a6635593ca168eda4517061ee0b4b845ad1c0f"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=polydez-note-tree-refactor#48e5f4743c4ff2e842296a963be25fc8b071d0f6"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#76a6635593ca168eda4517061ee0b4b845ad1c0f"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=polydez-note-tree-refactor#48e5f4743c4ff2e842296a963be25fc8b071d0f6"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#76a6635593ca168eda4517061ee0b4b845ad1c0f"
 dependencies = [
  "miden-lib",
  "miden-objects",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 miden-air = { version = "0.10", default-features = false }
-miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "polydez-note-tree-refactor"}
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next"}
 miden-node-block-producer = { path = "crates/block-producer", version = "0.6" }
 miden-node-faucet = { path = "bin/faucet", version = "0.6" }
 miden-node-proto = { path = "crates/proto", version = "0.6" }
@@ -35,10 +35,10 @@ miden-node-rpc-proto = { path = "crates/rpc-proto", version = "0.6" }
 miden-node-store = { path = "crates/store", version = "0.6" }
 miden-node-test-macro = { path = "crates/test-macro" }
 miden-node-utils = { path = "crates/utils", version = "0.6" }
-miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "polydez-note-tree-refactor" }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 miden-processor = { version = "0.10" }
 miden-stdlib = { version = "0.10", default-features = false }
-miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "polydez-note-tree-refactor" }
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 prost = { version = "0.13" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.40" }


### PR DESCRIPTION
This PR updates the `miden-base` branch as the old one (`polydez-note-tree-refactor`) no longer exists.