### PR TITLE
Save/restore faucet state and keypair to/from files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http",
@@ -236,6 +237,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1466,6 +1478,7 @@ dependencies = [
 name = "miden-faucet"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "axum",
  "clap",
  "figment",

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -17,7 +17,8 @@ repository.workspace = true
 testing = ["miden-objects/testing", "miden-lib/testing"]
 
 [dependencies]
-axum = { version = "0.7", features = ["tokio"] }
+anyhow = "1.0"
+axum = { version = "0.7", features = ["tokio", "macros"] }
 clap = { version = "4.5", features = ["derive", "string"] }
 figment = { version = "0.10", features = ["toml", "env"] }
 http = "1.1"
@@ -33,7 +34,7 @@ rand_chacha = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 static-files = "0.2"
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 toml = { version = "0.8" }
 tonic = { workspace = true }
 tower = "0.5"

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    path::PathBuf,
+};
 
 use miden_node_utils::config::{Endpoint, DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT};
 use serde::{Deserialize, Serialize};
@@ -6,12 +9,18 @@ use serde::{Deserialize, Serialize};
 // Faucet config
 // ================================================================================================
 
+/// Default path to the secret key file
+const DEFAULT_SECRET_KEY_PATH: &str = "faucet-secret.key";
+
+/// Default path to the storage directory
+const DEFAULT_STORAGE_PATH: &str = "faucet-storage";
+
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FaucetConfig {
     /// Endpoint of the faucet
     pub endpoint: Endpoint,
-    /// Node RPC gRPC endpoint in the format `http://<host>[:<port>]`.
+    /// Node RPC gRPC endpoint in the format `http://<host>[:<port>]`
     pub node_url: String,
     /// Timeout for RPC requests in milliseconds
     pub timeout_ms: u64,
@@ -23,6 +32,10 @@ pub struct FaucetConfig {
     pub decimals: u8,
     /// Maximum supply of the generated fungible asset
     pub max_supply: u64,
+    /// Path to the key store file
+    pub secret_key_path: PathBuf,
+    /// Path to the storage directory
+    pub storage_path: PathBuf,
 }
 
 impl Display for FaucetConfig {
@@ -44,6 +57,8 @@ impl Default for FaucetConfig {
             token_symbol: "POL".to_string(),
             decimals: 8,
             max_supply: 1000000,
+            secret_key_path: DEFAULT_SECRET_KEY_PATH.into(),
+            storage_path: DEFAULT_STORAGE_PATH.into(),
         }
     }
 }

--- a/bin/faucet/src/state.rs
+++ b/bin/faucet/src/state.rs
@@ -5,9 +5,8 @@ use static_files::Resource;
 use tokio::sync::Mutex;
 use tracing::info;
 
-use crate::{
-    client::FaucetClient, config::FaucetConfig, errors::InitError, static_resources, COMPONENT,
-};
+use crate::{client::FaucetClient, config::FaucetConfig, static_resources, COMPONENT};
+
 // FAUCET STATE
 // ================================================================================================
 
@@ -24,8 +23,8 @@ pub struct FaucetState {
 }
 
 impl FaucetState {
-    pub async fn new(config: FaucetConfig) -> Result<Self, InitError> {
-        let client = FaucetClient::new(config.clone()).await?;
+    pub async fn new(config: FaucetConfig) -> anyhow::Result<Self> {
+        let client = FaucetClient::new(&config).await?;
         let id = client.get_faucet_id();
         let client = Arc::new(Mutex::new(client));
         let static_files = Arc::new(static_resources::generate());

--- a/bin/faucet/src/store.rs
+++ b/bin/faucet/src/store.rs
@@ -1,0 +1,182 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, RwLock},
+};
+
+use anyhow::{bail, Context};
+use miden_objects::{
+    accounts::{Account, AccountId},
+    crypto::hash::rpo::RpoDigest,
+    notes::NoteId,
+    transaction::{ChainMmr, InputNotes, TransactionInputs},
+    utils::{Deserializable, Serializable},
+    BlockHeader, Word,
+};
+use miden_tx::{DataStore, DataStoreError};
+
+use crate::errors::{ErrorHelper, HandlerError};
+
+const FAUCET_ACCOUNT_FILENAME: &str = "faucet-account.bin";
+
+#[derive(Clone)]
+pub struct FaucetDataStore {
+    storage_path: PathBuf,
+    faucet_account: Arc<RwLock<Account>>,
+    seed: Word,
+    block_header: BlockHeader,
+    chain_mmr: ChainMmr,
+}
+
+// FAUCET DATA STORE
+// ================================================================================================
+
+impl FaucetDataStore {
+    pub fn new(
+        storage_path: PathBuf,
+        faucet_account: Arc<RwLock<Account>>,
+        seed: Word,
+        root_block_header: BlockHeader,
+        root_chain_mmr: ChainMmr,
+    ) -> Self {
+        Self {
+            storage_path,
+            faucet_account,
+            seed,
+            block_header: root_block_header,
+            chain_mmr: root_chain_mmr,
+        }
+    }
+
+    /// Returns the stored faucet account.
+    pub fn faucet_account(&self) -> Account {
+        self.faucet_account.read().expect("Poisoned lock").clone()
+    }
+
+    /// Saves the next faucet state to file.
+    pub async fn save_next_faucet_state(
+        &self,
+        next_faucet_state: &Account,
+    ) -> Result<(), HandlerError> {
+        tokio::fs::create_dir_all(&self.storage_path)
+            .await
+            .or_fail("Failed to create directory for storage")?;
+
+        tokio::fs::write(next_faucet_state_path(&self.storage_path), next_faucet_state.to_bytes())
+            .await
+            .or_fail("Failed to save faucet account to file")
+    }
+
+    /// Switches file storage to the next faucet state.
+    pub async fn switch_to_next_faucet_state(&self) -> Result<(), HandlerError> {
+        tokio::fs::rename(
+            next_faucet_state_path(&self.storage_path),
+            faucet_state_path(&self.storage_path),
+        )
+        .await
+        .or_fail("Failed to rename next faucet account file to the current one")
+    }
+
+    /// Updates the stored faucet account with the new one.
+    pub async fn update_faucet_state(
+        &mut self,
+        new_faucet_state: Account,
+    ) -> Result<(), HandlerError> {
+        self.switch_to_next_faucet_state().await?;
+        *self.faucet_account.write().expect("Poisoned lock") = new_faucet_state;
+
+        Ok(())
+    }
+}
+
+impl DataStore for FaucetDataStore {
+    fn get_transaction_inputs(
+        &self,
+        account_id: AccountId,
+        _block_ref: u32,
+        _notes: &[NoteId],
+    ) -> Result<TransactionInputs, DataStoreError> {
+        let account = self.faucet_account.read().expect("Poisoned lock");
+        if account_id != account.id() {
+            return Err(DataStoreError::AccountNotFound(account_id));
+        }
+
+        let empty_input_notes =
+            InputNotes::new(Vec::new()).map_err(DataStoreError::InvalidTransactionInput)?;
+
+        TransactionInputs::new(
+            account.clone(),
+            account.is_new().then_some(self.seed),
+            self.block_header,
+            self.chain_mmr.clone(),
+            empty_input_notes,
+        )
+        .map_err(DataStoreError::InvalidTransactionInput)
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Tries to restore the faucet state from current and/or next file(s).
+///
+/// If the faucet state with the expected hash is not found in either file, an error is returned.
+pub async fn resolve_faucet_state(
+    storage_path: impl AsRef<Path>,
+    expected_hash: RpoDigest,
+) -> anyhow::Result<Account> {
+    if !faucet_state_path(&storage_path).exists() {
+        bail!("Faucet state file does not exist");
+    }
+
+    let current_state = load_current_faucet_state(&storage_path)
+        .await
+        .context("Failed to restore current faucet state")?;
+
+    if current_state.hash() == expected_hash {
+        return Ok(current_state);
+    }
+
+    if !next_faucet_state_path(&storage_path).exists() {
+        bail!("Next faucet state file does not exist");
+    }
+
+    let next_state = load_next_faucet_state(&storage_path)
+        .await
+        .context("Failed to restore next faucet state")?;
+
+    if next_state.hash() == expected_hash {
+        return Ok(next_state);
+    }
+
+    bail!(
+        "Failed to restore faucet state from files. Could not find file with expected state hash."
+    );
+}
+
+/// Loads the current faucet state from file.
+pub async fn load_current_faucet_state(storage_path: impl AsRef<Path>) -> anyhow::Result<Account> {
+    load_faucet_state_internal(faucet_state_path(storage_path)).await
+}
+
+/// Loads the next faucet state from file.
+pub async fn load_next_faucet_state(storage_path: impl AsRef<Path>) -> anyhow::Result<Account> {
+    load_faucet_state_internal(next_faucet_state_path(storage_path)).await
+}
+
+/// Loads the faucet state from file with the given path.
+async fn load_faucet_state_internal(path: impl AsRef<Path>) -> anyhow::Result<Account> {
+    let bytes = tokio::fs::read(path).await.context("Failed to read faucet account from file")?;
+
+    Account::read_from_bytes(&bytes)
+        .map_err(|err| anyhow::anyhow!("Failed to deserialize faucet account from bytes: {err}"))
+}
+
+/// Returns path to the faucet state file.
+fn faucet_state_path(storage_path: impl AsRef<Path>) -> PathBuf {
+    storage_path.as_ref().join(FAUCET_ACCOUNT_FILENAME)
+}
+
+/// Returns path to the next faucet state file.
+fn next_faucet_state_path(storage_path: impl AsRef<Path>) -> PathBuf {
+    faucet_state_path(storage_path).with_extension("next")
+}


### PR DESCRIPTION
Resolves https://github.com/0xPolygonMiden/miden-node/issues/504

Save secret key and faucet account state to files and restore them on restart.

Actually we keep current state until the end of the calling `submit_proven_transaction`. This will help to restore even if faucet breaks in the middle of request. But there is still be possible for block producer to fail building block with this transaction. Need to investigate it more and decide whether to make more complex solution for that case.