### PR TITLE
feat(store): improve errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `GetAccountProofs` endpoint (#506).
 - Migrated faucet from actix-web to axum (#511).
 - Changed the `BlockWitness` to pass the inputs to the VM using only advice provider (#516).
+- [BREAKING] Improved store API errors (return "not found" instead of "internal error" status if requested account(s) not found) (#518).
 
 ## 0.5.1 (2024-09-12)
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -679,8 +679,8 @@ impl State {
         self.db.select_account(id).await
     }
 
-    /// Returns account states with details for public accounts.
-    pub async fn get_account_states(
+    /// Returns account proofs with optional account and storage headers.
+    pub async fn get_account_proofs(
         &self,
         account_ids: Vec<AccountId>,
         include_headers: bool,


### PR DESCRIPTION
In this PR we improve error statuses returned by the some store API.

Initially it was needed by https://github.com/0xPolygonMiden/miden-node/issues/504 (I wanted to be able to process "account not in DB" errors), but finally it became unused due to changed solution. But it might make our API better, so I propose to keep these changes.