### PR TITLE
feat(block-producer): fix dangling review comments

### DIFF
--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -25,6 +25,7 @@ miden-objects = { workspace = true }
 miden-processor = { workspace = true }
 miden-stdlib = { workspace = true }
 miden-tx = { workspace = true }
+rand = { version = "0.8.5" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
@@ -41,7 +42,6 @@ miden-lib = { workspace = true, features = ["testing"] }
 miden-node-test-macro = { path = "../test-macro" }
 miden-objects = { workspace = true, features = ["testing"] }
 miden-tx = { workspace = true, features = ["testing"] }
-rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3", default-features = false }
 tokio = { workspace = true, features = ["test-util"] }
 winterfell = { version = "0.9" }

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -22,8 +22,7 @@ pub type BatchId = Blake3Digest<32>;
 // TRANSACTION BATCH
 // ================================================================================================
 
-/// A batch of transactions that share a common proof. For any given account, at most 1 transaction
-/// in the batch must be addressing that account (issue: #186).
+/// A batch of transactions that share a common proof.
 ///
 /// Note: Until recursive proofs are available in the Miden VM, we don't include the common proof.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -283,14 +283,11 @@ impl WorkerPool {
 }
 
 impl BatchProducer {
-    /// Starts the [BlockProducer], infinitely producing blocks at the configured interval.
+    /// Starts the [BatchProducer], creating and proving batches at the configured interval.
     ///
-    /// Block production is sequential and consists of
-    ///
-    ///   1. Pulling the next set of batches from the [Mempool]
-    ///   2. Compiling these batches into the next block
-    ///   3. Proving the block (this is not yet implemented)
-    ///   4. Committing the block to the store
+    /// A pool of batch-proving workers is spawned, which are fed new batch jobs periodically.
+    /// A batch is skipped if there are no available workers, or if there are no transactions
+    /// available to batch.
     pub async fn run(self) {
         let mut interval = tokio::time::interval(self.batch_interval);
         interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -230,8 +230,7 @@ pub struct BatchProducer {
     pub workers: NonZeroUsize,
     pub mempool: Arc<Mutex<Mempool>>,
     pub tx_per_batch: usize,
-    /// Used to simulate batch proving by sleeping for
-    /// a random duration selected from this range.
+    /// Used to simulate batch proving by sleeping for a random duration selected from this range.
     pub simulated_proof_time: Range<Duration>,
     /// Simulated block failure rate as a percentage.
     ///

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -155,8 +155,7 @@ struct BlockProducer<BB> {
     pub mempool: Arc<Mutex<Mempool>>,
     pub block_interval: Duration,
     pub block_builder: BB,
-    /// Used to simulate block proving by sleeping for
-    /// a random duration selected from this range.
+    /// Used to simulate block proving by sleeping for a random duration selected from this range.
     pub simulated_proof_time: Range<Duration>,
 
     /// Simulated block failure rate as a percentage.

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -156,6 +156,14 @@ struct BlockProducer<BB> {
 }
 
 impl<BB: BlockBuilder> BlockProducer<BB> {
+    /// Starts the [BlockProducer], infinitely producing blocks at the configured interval.
+    ///
+    /// Block production is sequential and consists of
+    ///
+    ///   1. Pulling the next set of batches from the [Mempool]
+    ///   2. Compiling these batches into the next block
+    ///   3. Proving the block (this is simulated using random sleeps)
+    ///   4. Committing the block to the store
     pub async fn run(self) {
         let mut interval = tokio::time::interval(self.block_interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -149,6 +149,9 @@ pub enum BuildBatchError {
         error: AccountDeltaError,
         txs: Vec<ProvenTransaction>,
     },
+
+    #[error("Nothing actually went wrong, failure was injected on purpose")]
+    InjectedFailure(Vec<ProvenTransaction>),
 }
 
 impl BuildBatchError {
@@ -164,6 +167,7 @@ impl BuildBatchError {
             BuildBatchError::UnauthenticatedNotesNotFound(_, txs) => txs,
             BuildBatchError::NoteHashesMismatch { txs, .. } => txs,
             BuildBatchError::AccountUpdateError { txs, .. } => txs,
+            BuildBatchError::InjectedFailure(txs) => txs,
         }
     }
 }
@@ -239,11 +243,13 @@ pub enum BuildBlockError {
     UnauthenticatedNotesNotFound(Vec<NoteId>),
     #[error("too many batches in block. Got: {0}, max: {MAX_BATCHES_PER_BLOCK}")]
     TooManyBatchesInBlock(usize),
-    #[error("Failed to merge transaction delta into account {account_id}: {error}")]
+    #[error("failed to merge transaction delta into account {account_id}: {error}")]
     AccountUpdateError {
         account_id: AccountId,
         error: AccountDeltaError,
     },
+    #[error("nothing actually went wrong, failure was injected on purpose")]
+    InjectedFailure,
 }
 
 // Transaction inputs errors


### PR DESCRIPTION
This PR 

- fixes several unaddressed review comments from #515 
- distributes batch and block proving times randomly
- injects random failures into batch and block proving

Specifically, addresses [this](https://github.com/0xPolygonMiden/miden-node/pull/515#discussion_r1811182793), [this](https://github.com/0xPolygonMiden/miden-node/pull/515#discussion_r1811216651) and [this](https://github.com/0xPolygonMiden/miden-node/pull/515#discussion_r1811217975) comment.

Proving times are distributed normally from within a configurable range.

Failure rates are also similarly configurable, which completes one task from #519.