### PR TITLE
Migrate to `miden-vm` v0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Migrated faucet from actix-web to axum (#511).
 - Changed the `BlockWitness` to pass the inputs to the VM using only advice provider (#516).
 - [BREAKING] Improved store API errors (return "not found" instead of "internal error" status if requested account(s) not found) (#518).
+- [BREAKING] Migrated to v0.11 version of Miden VM (#528).
 
 ## 0.5.1 (2024-09-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,6 @@ dependencies = [
  "tower 0.5.1",
  "tower-http 0.6.1",
  "tracing",
- "winter-maybe-async 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -70,36 +70,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -496,9 +496,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "constant_time_eq"
@@ -1402,7 +1402,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "miden-air"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "miden-core",
  "miden-thiserror",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "lock_api",
  "loom",
@@ -1491,6 +1491,7 @@ dependencies = [
  "tower 0.5.1",
  "tower-http 0.6.1",
  "tracing",
+ "winter-maybe-async 0.10.1",
 ]
 
 [[package]]
@@ -1505,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#ebd7e17a68e5887107362c6c42cbe908fe492bfa"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#d497bf53e3609c2f3d1cc595e4964fda33d5c933"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1699,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#ebd7e17a68e5887107362c6c42cbe908fe492bfa"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#d497bf53e3609c2f3d1cc595e4964fda33d5c933"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1713,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.10.6"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1724,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -1739,7 +1740,7 @@ version = "0.6.0"
 [[package]]
 name = "miden-stdlib"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "miden-assembly",
 ]
@@ -1767,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#ebd7e17a68e5887107362c6c42cbe908fe492bfa"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#d497bf53e3609c2f3d1cc595e4964fda33d5c933"
 dependencies = [
  "async-trait",
  "miden-assembly",
@@ -1786,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "miden-verifier"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
 dependencies = [
  "miden-air",
  "miden-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arrayref"
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -276,9 +276,9 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -345,9 +345,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -357,9 +357,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "camino"
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -648,18 +648,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -847,33 +847,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -940,7 +940,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -961,6 +961,12 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hashlink"
@@ -1025,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -1037,9 +1043,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1135,12 +1141,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1205,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1234,7 +1240,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1262,9 +1268,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -1346,7 +1352,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "syn",
 ]
 
@@ -1396,8 +1402,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "miden-air"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2702f8adb96844e3521f49149f6c3d4773ecdd2a96a3169e3c025a2e3ee32b5e"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "miden-core",
  "miden-thiserror",
@@ -1408,8 +1413,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae9cef4fbafb4fe26da18574bcdbd78815857cfe1099760782701ababb076c2"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1426,8 +1430,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3f6db878d6b56c1566cd5b832908675566d3919b9a3523d630dfb5e2f7422d"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "lock_api",
  "loom",
@@ -1445,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825fc5d2e4c951f45da54da2d0d23071918d966133f85dbc219694e0b9a1e141"
+checksum = "1e0ca714c8242f329b9ea6f1a5bf0e93f1490f348f982e3a606d91b884254308"
 dependencies = [
  "blake3",
  "cc",
@@ -1502,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#9dc06d705b8f4cae86ff08a293f379c206f13421"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#ebd7e17a68e5887107362c6c42cbe908fe492bfa"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1696,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#9dc06d705b8f4cae86ff08a293f379c206f13421"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#ebd7e17a68e5887107362c6c42cbe908fe492bfa"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1710,8 +1713,7 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a128e20400086c9a985f4e5702e438ba781338fb0bdf9acff16d996c640087"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1722,8 +1724,7 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680d9203cee09b3cee6f79dc952a15f18a1eb47744ffac4f4e559d02bfcdee7a"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -1738,8 +1739,7 @@ version = "0.6.0"
 [[package]]
 name = "miden-stdlib"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41623ad4f4ea6449760f70ab8928c682c3824d735d3e330f07e3d24d1ad20bfa"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "miden-assembly",
 ]
@@ -1767,8 +1767,10 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#9dc06d705b8f4cae86ff08a293f379c206f13421"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#ebd7e17a68e5887107362c6c42cbe908fe492bfa"
 dependencies = [
+ "async-trait",
+ "miden-assembly",
  "miden-lib",
  "miden-objects",
  "miden-processor",
@@ -1776,14 +1778,15 @@ dependencies = [
  "miden-verifier",
  "rand",
  "rand_chacha",
- "winter-maybe-async 0.10.0",
+ "regex",
+ "walkdir",
+ "winter-maybe-async 0.10.1",
 ]
 
 [[package]]
 name = "miden-verifier"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8144a126ecb1941122e8261e85f2e8e94c0b82740bc23879c0a14263f48797"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=al-migrate-new-padding-rule#0b10225edc6eb0b5b7f8e9ff729e0c64b5c3a499"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2009,18 +2012,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "option-ext"
@@ -2114,7 +2117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -2128,18 +2131,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2148,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2187,9 +2190,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2197,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2231,7 +2234,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2406,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags",
 ]
@@ -2426,14 +2429,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2447,13 +2450,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2464,9 +2467,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rusqlite"
@@ -2537,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -2606,18 +2609,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2626,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -2797,9 +2800,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2819,10 +2822,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
-name = "tempfile"
-version = "3.12.0"
+name = "target-triple"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+
+[[package]]
+name = "tempfile"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2874,18 +2883,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2946,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3022,7 +3031,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3269,15 +3278,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
 dependencies = [
  "dissimilar",
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
  "toml",
 ]
@@ -3305,12 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-ident"
@@ -3456,9 +3463,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3467,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -3482,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3492,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3505,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "winapi"
@@ -3828,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77eafc7944188b941c90759b938b8377247ee6e440952a0a7c4dbde7edc4ecbb"
+checksum = "be43529f43f70306437d2c2c9f9e2b3a4d39b42e86702d8d7577f2357ea32fa6"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "a00419de735aac21d53b0de5ce2c03bd3627277cf471300f27ebc89f7d828047"
 
 [[package]]
 name = "libredox"
@@ -1402,7 +1402,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "miden-air"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "miden-core",
  "miden-thiserror",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "lock_api",
  "loom",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#d497bf53e3609c2f3d1cc595e4964fda33d5c933"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#b624d0810b1b3813f106aa38b796b9d62a39265d"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#d497bf53e3609c2f3d1cc595e4964fda33d5c933"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#b624d0810b1b3813f106aa38b796b9d62a39265d"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.10.6"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -1739,7 +1739,7 @@ version = "0.6.0"
 [[package]]
 name = "miden-stdlib"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "miden-assembly",
 ]
@@ -1767,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.6.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=andrew-migrate-to-new-padding-rule#d497bf53e3609c2f3d1cc595e4964fda33d5c933"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#b624d0810b1b3813f106aa38b796b9d62a39265d"
 dependencies = [
  "async-trait",
  "miden-assembly",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "miden-verifier"
 version = "0.10.5"
-source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#ae34c56f53ae3194af4368da3e67370a116f9cd7"
+source = "git+https://github.com/0xPolygonMiden/miden-vm.git?branch=next#9f9cc63b709d8b7c83841d8e421701dcd33792bb"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2527,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno",
@@ -2609,18 +2609,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 miden-air = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next" }
-miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.6" }
 miden-node-faucet = { path = "bin/faucet", version = "0.6" }
 miden-node-proto = { path = "crates/proto", version = "0.6" }
@@ -35,10 +35,10 @@ miden-node-rpc-proto = { path = "crates/rpc-proto", version = "0.6" }
 miden-node-store = { path = "crates/store", version = "0.6" }
 miden-node-test-macro = { path = "crates/test-macro" }
 miden-node-utils = { path = "crates/utils", version = "0.6" }
-miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next" }
 miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 prost = { version = "0.13" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.40", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [".github/"]
 readme = "README.md"
 
 [workspace.dependencies]
-miden-air = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "al-migrate-new-padding-rule" }
+miden-air = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next" }
 miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.6" }
 miden-node-faucet = { path = "bin/faucet", version = "0.6" }
@@ -36,8 +36,8 @@ miden-node-store = { path = "crates/store", version = "0.6" }
 miden-node-test-macro = { path = "crates/test-macro" }
 miden-node-utils = { path = "crates/utils", version = "0.6" }
 miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
-miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "al-migrate-new-padding-rule" }
-miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "al-migrate-new-padding-rule", default-features = false }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next" }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
 prost = { version = "0.13" }
 thiserror = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.82"
 version = "0.6.0"
 license = "MIT"
 authors = ["Miden contributors"]
@@ -25,8 +25,8 @@ exclude = [".github/"]
 readme = "README.md"
 
 [workspace.dependencies]
-miden-air = { version = "0.10", default-features = false }
-miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next"}
+miden-air = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "al-migrate-new-padding-rule" }
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.6" }
 miden-node-faucet = { path = "bin/faucet", version = "0.6" }
 miden-node-proto = { path = "crates/proto", version = "0.6" }
@@ -35,10 +35,10 @@ miden-node-rpc-proto = { path = "crates/rpc-proto", version = "0.6" }
 miden-node-store = { path = "crates/store", version = "0.6" }
 miden-node-test-macro = { path = "crates/test-macro" }
 miden-node-utils = { path = "crates/utils", version = "0.6" }
-miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
-miden-processor = { version = "0.10" }
-miden-stdlib = { version = "0.10", default-features = false }
-miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "al-migrate-new-padding-rule" }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "al-migrate-new-padding-rule", default-features = false }
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "andrew-migrate-to-new-padding-rule" }
 prost = { version = "0.13" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.40", features = ["rt-multi-thread"] }

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_PROTO=BUILD_PROTO=1
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+	cargo clippy --locked --workspace --all-targets --all-features -- -D warnings --allow clippy::arc_with_non_send_sync
 
 
 .PHONY: fix

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -39,7 +39,6 @@ tonic = { workspace = true }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "set-header", "trace"] }
 tracing = { workspace = true }
-winter-maybe-async = { version = "0.10" }
 
 [build-dependencies]
 # Required to inject build metadata.

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -39,6 +39,7 @@ tonic = { workspace = true }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "set-header", "trace"] }
 tracing = { workspace = true }
+winter-maybe-async = { version = "0.10" }
 
 [build-dependencies]
 # Required to inject build metadata.

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -63,7 +63,6 @@ impl FaucetClient {
             initialize_faucet_client(config.clone()).await?;
 
         let (faucet_account, account_seed, secret) = build_account(config.clone())?;
-        let faucet_account = faucet_account;
         let id = faucet_account.id();
 
         let data_store = Arc::new(FaucetDataStore::new(
@@ -195,7 +194,7 @@ impl FaucetDataStore {
     fn update_faucet_account(&self, delta: &AccountDelta) -> Result<(), ProcessError> {
         self.faucet_account
             .lock()
-            .unwrap()
+            .expect("Poisoned lock")
             .apply_delta(delta)
             .map_err(|err| ProcessError::InternalServerError(err.to_string()))
     }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -25,7 +25,7 @@ use miden_objects::{
     BlockHeader, Felt, Word,
 };
 use miden_tx::{
-    auth::{BasicAuthenticator, TransactionAuthenticator},
+    auth::BasicAuthenticator,
     utils::Serializable,
     DataStore, DataStoreError, LocalTransactionProver, ProvingOptions, TransactionExecutor,
     TransactionInputs, TransactionProver,
@@ -76,7 +76,7 @@ impl FaucetClient {
         let authenticator = Arc::new(BasicAuthenticator::<StdRng>::new(&[(
             secret.public_key().into(),
             AuthSecretKey::RpoFalcon512(secret),
-        )])) as Arc<dyn TransactionAuthenticator>;
+        )]));
         let executor = TransactionExecutor::new(data_store.clone(), Some(authenticator));
 
         let mut rng = thread_rng();

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -30,7 +30,6 @@ use miden_tx::{
 use rand::{rngs::StdRng, thread_rng, Rng};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use tonic::transport::Channel;
-use winter_maybe_async::*;
 
 use crate::{
     config::FaucetConfig,
@@ -204,9 +203,7 @@ impl FaucetDataStore {
 unsafe impl Send for FaucetDataStore {}
 unsafe impl Sync for FaucetDataStore {}
 
-#[maybe_async_trait]
 impl DataStore for FaucetDataStore {
-    #[maybe_async]
     fn get_transaction_inputs(
         &self,
         account_id: AccountId,

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -207,7 +207,7 @@ impl DataStore for FaucetDataStore {
         _block_ref: u32,
         _notes: &[NoteId],
     ) -> Result<TransactionInputs, DataStoreError> {
-        let account = self.faucet_account.lock().unwrap();
+        let account = self.faucet_account.lock().expect("Poisoned lock");
         if account_id != account.id() {
             return Err(DataStoreError::AccountNotFound(account_id));
         }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -25,10 +25,9 @@ use miden_objects::{
     BlockHeader, Felt, Word,
 };
 use miden_tx::{
-    auth::BasicAuthenticator,
-    utils::Serializable,
-    DataStore, DataStoreError, LocalTransactionProver, ProvingOptions, TransactionExecutor,
-    TransactionInputs, TransactionProver,
+    auth::BasicAuthenticator, utils::Serializable, DataStore, DataStoreError,
+    LocalTransactionProver, ProvingOptions, TransactionExecutor, TransactionInputs,
+    TransactionProver,
 };
 use rand::{rngs::StdRng, thread_rng, Rng};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};

--- a/crates/block-producer/src/block_builder/prover/asm/block_kernel.masm
+++ b/crates/block-producer/src/block_builder/prover/asm/block_kernel.masm
@@ -6,6 +6,7 @@
 
 use.std::collections::smt
 use.std::collections::mmr
+use.std::sys
 
 const.ACCOUNT_TREE_DEPTH=64
 const.BLOCK_NOTES_BATCH_TREE_DEPTH=6
@@ -237,4 +238,7 @@ begin
     # Load output on stack
     padw mem_loadw.2 padw mem_loadw.1 padw mem_loadw.0
     # => [ACCOUNT_ROOT, NOTE_ROOT, NULLIFIER_ROOT, CHAIN_MMR_ROOT]
+
+    # truncate the stack
+    exec.sys::truncate_stack
 end

--- a/crates/block-producer/src/block_builder/prover/mod.rs
+++ b/crates/block-producer/src/block_builder/prover/mod.rs
@@ -88,7 +88,7 @@ impl BlockProver {
             let advice_provider = MemAdviceProvider::from(advice_inputs);
 
             let mut host = DefaultHost::new(advice_provider);
-            host.load_mast_forest(StdLibrary::default().into());
+            host.load_mast_forest(StdLibrary::default().mast_forest().clone());
 
             host
         };

--- a/crates/block-producer/src/block_builder/prover/tests.rs
+++ b/crates/block-producer/src/block_builder/prover/tests.rs
@@ -843,7 +843,7 @@ async fn test_compute_chain_mmr_root_mmr_17_peaks() {
             mmr.add(Digest::default());
         }
 
-        assert_eq!(mmr.peaks(mmr.forest()).unwrap().peaks().len(), 17);
+        assert_eq!(mmr.peaks().peaks().len(), 17);
 
         mmr
     };

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -49,7 +49,7 @@ pub async fn build_expected_block_header(
 
         store_chain_mmr.add(last_block_header.hash());
 
-        store_chain_mmr.peaks(store_chain_mmr.forest()).unwrap().hash_peaks()
+        store_chain_mmr.peaks().hash_peaks()
     };
 
     let note_created_smt = note_created_smt_from_note_batches(block_output_notes(batches.iter()));
@@ -157,7 +157,7 @@ impl MockBlockBuilder {
             0,
             self.last_block_header.hash(),
             self.last_block_header.block_num() + 1,
-            self.store_chain_mmr.peaks(self.store_chain_mmr.forest()).unwrap().hash_peaks(),
+            self.store_chain_mmr.peaks().hash_peaks(),
             self.store_accounts.root(),
             Digest::default(),
             note_created_smt_from_note_batches(created_notes.iter()).root(),

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -121,7 +121,7 @@ impl MockStoreSuccessBuilder {
             0,
             Digest::default(),
             block_num,
-            chain_mmr.peaks(chain_mmr.forest()).unwrap().hash_peaks(),
+            chain_mmr.peaks().hash_peaks(),
             accounts_smt.root(),
             nullifiers_smt.root(),
             note_root,
@@ -301,7 +301,7 @@ impl Store for MockStoreSuccess {
 
         let chain_peaks = {
             let locked_chain_mmr = self.chain_mmr.read().await;
-            locked_chain_mmr.peaks(locked_chain_mmr.forest()).unwrap()
+            locked_chain_mmr.peaks()
         };
 
         let accounts = {
@@ -329,15 +329,13 @@ impl Store for MockStoreSuccess {
             *locked_headers.iter().max_by_key(|(block_num, _)| *block_num).unwrap().1;
 
         let locked_chain_mmr = self.chain_mmr.read().await;
-        let mmr_forest = locked_chain_mmr.forest();
         let chain_length = latest_header.block_num();
         let block_proofs = note_proofs
             .values()
             .map(|note_proof| {
                 let block_num = note_proof.location().block_num();
                 let block_header = *locked_headers.get(&block_num).unwrap();
-                let mmr_path =
-                    locked_chain_mmr.open(block_num as usize, mmr_forest).unwrap().merkle_path;
+                let mmr_path = locked_chain_mmr.open(block_num as usize).unwrap().merkle_path;
 
                 BlockInclusionProof { block_header, mmr_path, chain_length }
             })
@@ -376,7 +374,7 @@ impl Store for MockStoreSuccess {
                 let block_num = note_proof.location().block_num();
                 let block_header = *locked_headers.get(&block_num).unwrap();
                 let mmr_path = locked_chain_mmr
-                    .open(block_num as usize, latest_header.block_num() as usize)
+                    .open_at(block_num as usize, latest_header.block_num() as usize)
                     .unwrap()
                     .merkle_path;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80"
+channel = "1.82"
 components = ["rustfmt", "rust-src", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This PR updates the code of the `miden-node` to work with a next v0.11 version of the `miden-vm` and next version of `miden-base`.