### PR TITLE
feat(block-producer): refactor batch graph to use dependency graph

### DIFF
--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -3,7 +3,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use miden_objects::transaction::TransactionId;
 use miden_tx::utils::collections::KvMap;
 
-use super::BatchJobId;
+use super::{
+    dependency_graph::{DependencyGraph, GraphError},
+    BatchJobId,
+};
 use crate::batch_builder::batch::TransactionBatch;
 
 // BATCH GRAPH
@@ -11,11 +14,12 @@ use crate::batch_builder::batch::TransactionBatch;
 
 #[derive(Default, Clone)]
 pub struct BatchGraph {
-    nodes: BTreeMap<BatchJobId, Node>,
-    roots: BTreeSet<BatchJobId>,
+    inner: DependencyGraph<BatchJobId, TransactionBatch>,
 
     /// Allows for reverse lookup of transaction -> batch.
     transactions: BTreeMap<TransactionId, BatchJobId>,
+
+    batches: BTreeMap<BatchJobId, Vec<TransactionId>>,
 }
 
 impl BatchGraph {
@@ -24,7 +28,7 @@ impl BatchGraph {
         id: BatchJobId,
         transactions: Vec<TransactionId>,
         parents: BTreeSet<TransactionId>,
-    ) {
+    ) -> Result<(), GraphError<BatchJobId>> {
         // Reverse lookup parent transaction batches.
         let parents = parents
             .into_iter()
@@ -32,34 +36,14 @@ impl BatchGraph {
             .copied()
             .collect();
 
-        // Inform parents of their new child.
-        for parent in &parents {
-            self.nodes
-                .get_mut(parent)
-                .expect("Parent batch must be present")
-                .children
-                .insert(id);
-        }
+        self.inner.insert_pending(id, parents)?;
 
-        // Insert transactions for reverse lookup.
         for tx in &transactions {
-            self.transactions.insert(*tx, id);
+            self.transactions.insert(tx.clone(), id);
         }
+        self.batches.insert(id, transactions);
 
-        // Insert the new node into the graph.
-        let batch = Node {
-            status: Status::Queued,
-            transactions,
-            parents,
-            children: Default::default(),
-        };
-        self.nodes.insert(id, batch);
-
-        // New node might be a root.
-        //
-        // This could be optimized by inlining this inside the parent loop. This would prevent the
-        // double iteration over parents, at the cost of some code duplication.
-        self.try_make_root(id);
+        Ok(())
     }
 
     /// Removes the batches and all their descendants from the graph.
@@ -68,147 +52,67 @@ impl BatchGraph {
     pub fn purge_subgraphs(
         &mut self,
         batches: BTreeSet<BatchJobId>,
-    ) -> BTreeMap<BatchJobId, Vec<TransactionId>> {
-        let mut removed = BTreeMap::new();
+    ) -> Result<BTreeMap<BatchJobId, Vec<TransactionId>>, GraphError<BatchJobId>> {
+        let batches = self.inner.purge_subgraphs(batches)?;
 
-        let mut to_process = batches;
+        let batches = batches
+            .into_iter()
+            .map(|batch| (batch, self.batches.remove(&batch).expect("Malformed graph")))
+            .collect::<BTreeMap<_, _>>();
 
-        while let Some(node_id) = to_process.pop_first() {
-            // Its possible for a node to already have been removed as part of this subgraph
-            // removal.
-            let Some(node) = self.nodes.remove(&node_id) else {
-                continue;
-            };
-
-            // All the child batches are also removed so no need to check for new roots. No new
-            // roots are possible as a result of this subgraph removal.
-            self.roots.remove(&node_id);
-
-            for transaction in &node.transactions {
-                self.transactions.remove(transaction);
-            }
-
-            // Inform parent that this child no longer exists.
-            //
-            // The same is not required for children of this batch as we will be removing those as
-            // well.
-            for parent in &node.parents {
-                // Parent could already be removed as part of this subgraph removal.
-                if let Some(parent) = self.nodes.get_mut(parent) {
-                    parent.children.remove(&node_id);
-                }
-            }
-
-            to_process.extend(node.children);
-            removed.insert(node_id, node.transactions);
+        for tx in batches.values().flatten() {
+            self.transactions.remove(tx);
         }
 
-        removed
+        Ok(batches)
     }
 
     /// Removes a set of batches from the graph without removing any descendants.
     ///
     /// This is intended to cull completed batches from stale blocs.
-    pub fn remove_committed(&mut self, batches: BTreeSet<BatchJobId>) -> Vec<TransactionId> {
+    pub fn remove_committed(
+        &mut self,
+        batches: BTreeSet<BatchJobId>,
+    ) -> Result<Vec<TransactionId>, GraphError<BatchJobId>> {
+        self.inner.prune_processed(batches.clone())?;
         let mut transactions = Vec::new();
 
-        for batch in batches {
-            let node = self.nodes.remove(&batch).expect("Node must be in graph");
-            assert_eq!(node.status, Status::Processed);
-
-            // Remove batch from graph. No need to update parents as they should be removed in this
-            // call as well.
-            for child in node.children {
-                // Its possible for the child to part of this same set of batches and therefore
-                // already removed.
-                if let Some(child) = self.nodes.get_mut(&child) {
-                    child.parents.remove(&batch);
-                }
-            }
-
-            transactions.extend_from_slice(&node.transactions);
+        for batch in &batches {
+            transactions.extend(self.batches.remove(batch).into_iter().flatten());
         }
 
-        transactions
+        for tx in &transactions {
+            self.transactions.remove(tx);
+        }
+
+        Ok(transactions)
     }
 
     /// Mark a batch as proven if it exists.
-    pub fn mark_proven(&mut self, id: BatchJobId, batch: TransactionBatch) {
-        // Its possible for inflight batches to have been removed as part of another batches
-        // failure.
-        if let Some(node) = self.nodes.get_mut(&id) {
-            assert!(node.status == Status::Queued);
-            node.status = Status::Proven(batch);
-            self.try_make_root(id);
-        }
+    pub fn mark_proven(
+        &mut self,
+        id: BatchJobId,
+        batch: TransactionBatch,
+    ) -> Result<(), GraphError<BatchJobId>> {
+        self.inner.promote_pending(id, batch)
     }
 
-    /// Returns at most `count` __indepedent__ batches which are ready for inclusion in a block.
+    /// Returns at most `count` batches which are ready for inclusion in a block.
     pub fn select_block(&mut self, count: usize) -> BTreeMap<BatchJobId, TransactionBatch> {
         let mut batches = BTreeMap::new();
 
-        // Track children so we can evaluate them for root afterwards.
-        let mut children = BTreeSet::new();
-
-        for batch_id in &self.roots {
-            let mut node = self.nodes.get_mut(batch_id).expect("Root node must be in graph");
-
-            // Filter out batches which have dependencies in our selection so far.
-            if node.parents.iter().any(|parent| batches.contains_key(parent)) {
-                continue;
-            }
-
-            let Status::Proven(batch) = node.status.clone() else {
-                unreachable!("Root batch must be in proven state.");
+        for _ in 0..count {
+            let Some(batch_id) = self.inner.roots().first().copied() else {
+                break;
             };
 
-            batches.insert(*batch_id, batch);
-            node.status = Status::Processed;
-
-            if batches.len() == count {
-                break;
-            }
-        }
-
-        // Performing this outside the main loop has two benefits:
-        //   1. We avoid checking the same child multiple times.
-        //   2. We avoid evaluating children for selection (they're dependents).
-        for child in children {
-            self.try_make_root(child);
+            self.inner.process_root(batch_id).expect("This is a root");
+            batches.insert(
+                batch_id,
+                self.inner.get(&batch_id).expect("Root batch must have a value").clone(),
+            );
         }
 
         batches
     }
-
-    fn try_make_root(&mut self, id: BatchJobId) {
-        let node = self.nodes.get_mut(&id).expect("Node must be in graph");
-
-        for parent in node.parents.clone() {
-            let parent = self.nodes.get(&parent).expect("Parent must be in pool");
-
-            if parent.status != Status::Processed {
-                return;
-            }
-        }
-        self.roots.insert(id);
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Node {
-    status: Status,
-    transactions: Vec<TransactionId>,
-    parents: BTreeSet<BatchJobId>,
-    children: BTreeSet<BatchJobId>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Status {
-    /// The batch is a busy being proven.
-    Queued,
-    /// The batch is proven. It may be placed in a block
-    /// __IFF__ all of its parents are already in a block.
-    Proven(TransactionBatch),
-    /// Batch is part of a block.
-    Processed,
 }

--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -27,6 +27,30 @@ use crate::batch_builder::batch::TransactionBatch;
 ///
 /// Batches may also be outright [purged](Self::purge_subgraphs) from the graph. This is useful for
 /// batches which may have become invalid due to external considerations e.g. expired transactions.
+///
+/// # Batch lifecycle
+/// ```
+///                           │                           
+///                     insert│                           
+///                     ┌─────▼─────┐                     
+///                     │  pending  ┼────┐                
+///                     └─────┬─────┘    │                
+///                           │          │                
+///               submit_proof│          │                
+///                     ┌─────▼─────┐    │                
+///                     │   proved  ┼────┤                
+///                     └─────┬─────┘    │                
+///                           │          │                
+///               select_block│          │                
+///                     ┌─────▼─────┐    │                
+///                     │ committed ┼────┤                
+///                     └─────┬─────┘    │                
+///                           │          │                
+///            prune_committed│          │purge_subgraphs
+///                     ┌─────▼─────┐    │                
+///                     │  <null>   ◄────┘                
+///                     └───────────┘                     
+/// ```
 #[derive(Default, Clone)]
 pub struct BatchGraph {
     /// Tracks the interdependencies between batches.

--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -12,43 +12,101 @@ use crate::batch_builder::batch::TransactionBatch;
 // BATCH GRAPH
 // ================================================================================================
 
+/// Tracks the dependencies between batches, transactions and their parents.
+///
+/// Batches are inserted with their transaction, and parent transaction sets which form the edges of
+/// the dependency graph. Batches are initially inserted in a pending state while we wait on their
+/// proofs to be generated. The dependencies are still tracked in this state.
+///
+/// Batches can then be promoted to ready by [submitting their proofs](Self::submit_proof) once
+/// available. Proven batches are considered for inclusion in blocks once _all_ parent batches have
+/// been selected.
+///
+/// Committed batches (i.e. included in blocks) may be [pruned](Self::prune_committed) from the
+/// graph to bound the graph's size.
+///
+/// Batches may also be outright [purged](Self::purge_subgraphs) from the graph. This is useful for
+/// batches which may have become invalid due to external considerations e.g. expired transactions.
 #[derive(Default, Clone)]
 pub struct BatchGraph {
+    /// Tracks the interdependencies between batches.
     inner: DependencyGraph<BatchJobId, TransactionBatch>,
 
-    /// Allows for reverse lookup of transaction -> batch.
+    /// Maps each transaction to its batch, allowing for reverse lookups.
+    ///
+    /// Incoming batches are defined entirely in terms of transactions, including parent edges.
+    /// This let's us transform these parent transactions into the relevant parent batches.
     transactions: BTreeMap<TransactionId, BatchJobId>,
 
+    /// Maps each batch to its transaction set.
+    ///
+    /// Required because the dependency graph is defined in terms of batches. This let's us
+    /// translate between batches and their transactions when required.
     batches: BTreeMap<BatchJobId, Vec<TransactionId>>,
 }
 
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum BatchInsertError {
+    #[error("Transactions are already in the graph: {0:?}")]
+    DuplicateTransactions(BTreeSet<TransactionId>),
+    #[error("Unknown parent transaction {0}")]
+    UknownParentTransaction(TransactionId),
+    #[error(transparent)]
+    GraphError(#[from] GraphError<BatchJobId>),
+}
+
 impl BatchGraph {
+    /// Inserts a new batch into the graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///   - the batch ID is already in use
+    ///   - any transactions are already in the graph
+    ///   - any parent transactions are _not_ in the graph
     pub fn insert(
         &mut self,
         id: BatchJobId,
         transactions: Vec<TransactionId>,
         parents: BTreeSet<TransactionId>,
-    ) -> Result<(), GraphError<BatchJobId>> {
-        // Reverse lookup parent transaction batches.
-        let parents = parents
-            .into_iter()
-            .map(|tx| self.transactions.get(&tx).expect("Parent transaction must be in a batch"))
+    ) -> Result<(), BatchInsertError> {
+        let duplicates = transactions
+            .iter()
+            .filter(|tx| self.transactions.contains_key(tx))
             .copied()
-            .collect();
+            .collect::<BTreeSet<_>>();
+        if !duplicates.is_empty() {
+            return Err(BatchInsertError::DuplicateTransactions(duplicates));
+        }
 
-        self.inner.insert_pending(id, parents)?;
+        // Reverse lookup parent transaction batches.
+        let parent_batches = parents
+            .into_iter()
+            .map(|tx| {
+                self.transactions
+                    .get(&tx)
+                    .copied()
+                    .ok_or(BatchInsertError::UknownParentTransaction(tx))
+            })
+            .collect::<Result<_, _>>()?;
 
-        for tx in &transactions {
-            self.transactions.insert(tx.clone(), id);
+        self.inner.insert_pending(id, parent_batches)?;
+
+        for tx in transactions.iter().copied() {
+            self.transactions.insert(tx, id);
         }
         self.batches.insert(id, transactions);
 
         Ok(())
     }
 
-    /// Removes the batches and all their descendants from the graph.
+    /// Removes the batches and their descendants from the graph.
     ///
     /// Returns all removed batches and their transactions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the batches are not currently in the graph.
     pub fn purge_subgraphs(
         &mut self,
         batches: BTreeSet<BatchJobId>,
@@ -67,10 +125,21 @@ impl BatchGraph {
         Ok(batches)
     }
 
-    /// Removes a set of batches from the graph without removing any descendants.
+    /// Removes set set of committed batches from the graph.
     ///
-    /// This is intended to cull completed batches from stale blocs.
-    pub fn remove_committed(
+    /// The batches _must_ have been previously selected for inclusion in a block using
+    /// [`select_block`](Self::select_block). This is intended for limiting the size of the graph by
+    /// culling committed data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if
+    ///   - any batch was not previously selected for inclusion in a block
+    ///   - any batch is unknown
+    ///   - any parent batch would be left dangling in the graph
+    ///
+    /// The last point implies that batches should be removed in block order.
+    pub fn prune_committed(
         &mut self,
         batches: BTreeSet<BatchJobId>,
     ) -> Result<Vec<TransactionId>, GraphError<BatchJobId>> {
@@ -88,8 +157,13 @@ impl BatchGraph {
         Ok(transactions)
     }
 
-    /// Mark a batch as proven if it exists.
-    pub fn mark_proven(
+    /// Submits a proof for the given batch, promoting it from pending to ready for inclusion in a
+    /// block once all its parents have themselves been included.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the batch is not in the graph or if it was already previously proven.
+    pub fn submit_proof(
         &mut self,
         id: BatchJobId,
         batch: TransactionBatch,
@@ -102,15 +176,19 @@ impl BatchGraph {
         let mut batches = BTreeMap::new();
 
         for _ in 0..count {
+            // This strategy just selects arbitrary roots for now. This is valid but not very
+            // interesting or efficient.
             let Some(batch_id) = self.inner.roots().first().copied() else {
                 break;
             };
 
-            self.inner.process_root(batch_id).expect("This is a root");
-            batches.insert(
-                batch_id,
-                self.inner.get(&batch_id).expect("Root batch must have a value").clone(),
-            );
+            // SAFETY: This is definitely a root since we just selected it from the set of roots.
+            self.inner.process_root(batch_id).unwrap();
+            // SAFETY: Since it was a root batch, it must definitely have a processed batch
+            // associated with it.
+            let batch = self.inner.get(&batch_id).unwrap();
+
+            batches.insert(batch_id, batch.clone());
         }
 
         batches

--- a/crates/block-producer/src/mempool/dependency_graph.rs
+++ b/crates/block-producer/src/mempool/dependency_graph.rs
@@ -12,6 +12,10 @@ use miden_tx::utils::collections::KvMap;
 /// once all parent nodes have been processed.
 ///
 /// Forms the basis of our transaction and batch dependency graphs.
+///
+/// # Node lifecycle
+/// ```
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyGraph<K, V> {
     /// Node's who's data is still pending.
@@ -122,7 +126,7 @@ impl<K: Ord + Copy + Display + std::fmt::Debug, V: Clone> DependencyGraph<K, V> 
             return Err(GraphError::InvalidPendingNode(key));
         }
 
-        self.vertices.insert(key.clone(), value);
+        self.vertices.insert(key, value);
         self.try_make_root(key);
 
         Ok(())
@@ -167,10 +171,10 @@ impl<K: Ord + Copy + Display + std::fmt::Debug, V: Clone> DependencyGraph<K, V> 
                 .into_iter()
                 .flatten()
                 // We should not revert children which are pending.
-                .filter(|child| self.vertices.contains_key(&child))
+                .filter(|child| self.vertices.contains_key(child))
                 .copied();
 
-            to_revert.extend(dbg!(unprocessed_children));
+            to_revert.extend(unprocessed_children);
 
             reverted.insert(key);
         }

--- a/crates/block-producer/src/mempool/dependency_graph.rs
+++ b/crates/block-producer/src/mempool/dependency_graph.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Display,
+};
 
 use miden_tx::utils::collections::KvMap;
 
@@ -11,6 +14,9 @@ use miden_tx::utils::collections::KvMap;
 /// Forms the basis of our transaction and batch dependency graphs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyGraph<K, V> {
+    /// Node's who's data is still pending.
+    pending: BTreeSet<K>,
+
     /// Each node's data.
     vertices: BTreeMap<K, V>,
 
@@ -49,8 +55,11 @@ pub enum GraphError<K> {
     #[error("Nodes would be left dangling: {0:?}")]
     DanglingNodes(BTreeSet<K>),
 
-    #[error("Node {0} is not ready to be processed")]
-    NotARootNode(K),
+    #[error("Node {0} is not a root node")]
+    InvalidRootNode(K),
+
+    #[error("Node {0} is not a pending node")]
+    InvalidPendingNode(K),
 }
 
 /// This cannot be derived without enforcing `Default` bounds on K and V.
@@ -58,6 +67,7 @@ impl<K, V> Default for DependencyGraph<K, V> {
     fn default() -> Self {
         Self {
             vertices: Default::default(),
+            pending: Default::default(),
             parents: Default::default(),
             children: Default::default(),
             roots: Default::default(),
@@ -66,22 +76,22 @@ impl<K, V> Default for DependencyGraph<K, V> {
     }
 }
 
-impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
-    /// Inserts a new node into the graph.
+impl<K: Ord + Copy + Display + std::fmt::Debug, V: Clone> DependencyGraph<K, V> {
+    /// Inserts a new pending node into the graph.
     ///
     /// # Errors
     ///
     /// Errors if the node already exists, or if any of the parents are not part of the graph.
     ///
     /// This method is atomic.
-    pub fn insert(&mut self, key: K, value: V, parents: BTreeSet<K>) -> Result<(), GraphError<K>> {
-        if self.vertices.contains_key(&key) {
+    pub fn insert_pending(&mut self, key: K, parents: BTreeSet<K>) -> Result<(), GraphError<K>> {
+        if self.contains(&key) {
             return Err(GraphError::DuplicateKey(key));
         }
 
         let missing_parents = parents
             .iter()
-            .filter(|parent| !self.vertices.contains_key(parent))
+            .filter(|parent| !self.contains(parent))
             .copied()
             .collect::<BTreeSet<_>>();
         if !missing_parents.is_empty() {
@@ -92,16 +102,35 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
         for parent in &parents {
             self.children.entry(*parent).or_default().insert(key);
         }
-        self.vertices.insert(key, value);
+        self.pending.insert(key);
         self.parents.insert(key, parents);
         self.children.insert(key, Default::default());
 
+        Ok(())
+    }
+
+    /// Promotes a pending node, associating it with the provided value and allowing it to be
+    /// considered for processing.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the given node is not pending.
+    ///
+    /// This method is atomic.
+    pub fn promote_pending(&mut self, key: K, value: V) -> Result<(), GraphError<K>> {
+        if !self.pending.remove(&key) {
+            return Err(GraphError::InvalidPendingNode(key));
+        }
+
+        self.vertices.insert(key.clone(), value);
         self.try_make_root(key);
 
         Ok(())
     }
 
     /// Reverts the nodes __and their descendents__, requeueing them for processing.
+    ///
+    /// Descendents which are pending remain unchanged.
     ///
     /// # Errors
     ///
@@ -137,9 +166,11 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
                 .map(|children| children.difference(&reverted))
                 .into_iter()
                 .flatten()
+                // We should not revert children which are pending.
+                .filter(|child| self.vertices.contains_key(&child))
                 .copied();
 
-            to_revert.extend(unprocessed_children);
+            to_revert.extend(dbg!(unprocessed_children));
 
             reverted.insert(key);
         }
@@ -173,11 +204,8 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
     ///
     /// This method is atomic.
     pub fn prune_processed(&mut self, keys: BTreeSet<K>) -> Result<Vec<V>, GraphError<K>> {
-        let missing_nodes = keys
-            .iter()
-            .filter(|key| !self.vertices.contains_key(key))
-            .copied()
-            .collect::<BTreeSet<_>>();
+        let missing_nodes =
+            keys.iter().filter(|key| !self.contains(key)).copied().collect::<BTreeSet<_>>();
         if !missing_nodes.is_empty() {
             return Err(GraphError::UnknownNodes(missing_nodes));
         }
@@ -221,37 +249,32 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
     }
 
     /// Removes the set of nodes __and all descendents__ from the graph, returning all removed
-    /// values.
+    /// nodes. This __includes__ pending nodes.
     ///
     /// # Returns
     ///
-    /// Returns a mapping of each removed key to its value.
+    /// All nodes removed.
     ///
     /// # Errors
     ///
     /// Returns an error if any of the given nodes does not exist.
     ///
     /// This method is atomic.
-    pub fn purge_subgraphs(&mut self, keys: BTreeSet<K>) -> Result<BTreeMap<K, V>, GraphError<K>> {
-        let missing_nodes = keys
-            .iter()
-            .filter(|key| !self.vertices.contains_key(key))
-            .copied()
-            .collect::<BTreeSet<_>>();
+    pub fn purge_subgraphs(&mut self, keys: BTreeSet<K>) -> Result<BTreeSet<K>, GraphError<K>> {
+        let missing_nodes =
+            keys.iter().filter(|key| !self.contains(key)).copied().collect::<BTreeSet<_>>();
         if !missing_nodes.is_empty() {
             return Err(GraphError::UnknownNodes(missing_nodes));
         }
 
         let mut visited = keys.clone();
         let mut to_remove = keys;
-        let mut removed = BTreeMap::new();
+        let mut removed = BTreeSet::new();
 
         while let Some(key) = to_remove.pop_first() {
-            let value = self
-                .vertices
-                .remove(&key)
-                .expect("Node was checked in precondition and must therefore exist");
-            removed.insert(key, value);
+            self.vertices.remove(&key);
+            self.pending.remove(&key);
+            removed.insert(key);
 
             self.processed.remove(&key);
             self.roots.remove(&key);
@@ -280,7 +303,17 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
     ///
     /// This method assumes the node exists. Caller is responsible for ensuring this is true.
     fn try_make_root(&mut self, key: K) {
-        debug_assert!(self.vertices.contains_key(&key), "Potential root must exist in the graph");
+        if self.pending.contains(&key) {
+            return;
+        }
+        debug_assert!(
+            self.vertices.contains_key(&key),
+            "Potential root {key} must exist in the graph"
+        );
+        debug_assert!(
+            !self.processed.contains(&key),
+            "Potential root {key} cannot already be processed"
+        );
 
         let all_parents_processed = self
             .parents
@@ -312,7 +345,7 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
     /// This method is atomic.
     pub fn process_root(&mut self, key: K) -> Result<(), GraphError<K>> {
         if !self.roots.remove(&key) {
-            return Err(GraphError::NotARootNode(key));
+            return Err(GraphError::InvalidRootNode(key));
         }
 
         self.processed.insert(key);
@@ -336,6 +369,11 @@ impl<K: Ord + Copy, V: Clone> DependencyGraph<K, V> {
     pub fn parents(&self, key: &K) -> Option<&BTreeSet<K>> {
         self.parents.get(key)
     }
+
+    /// Returns true if the node exists, in either the pending or non-pending sets.
+    fn contains(&self, key: &K) -> bool {
+        self.pending.contains(key) || self.vertices.contains_key(key)
+    }
 }
 
 // TESTS
@@ -354,7 +392,7 @@ mod tests {
 
     impl TestGraph {
         /// Alias for inserting a node with no parents.
-        fn insert_root(&mut self, node: u32) -> Result<(), GraphError<u32>> {
+        fn insert_with_no_parents(&mut self, node: u32) -> Result<(), GraphError<u32>> {
             self.insert_with_parents(node, Default::default())
         }
 
@@ -369,7 +407,21 @@ mod tests {
             node: u32,
             parents: BTreeSet<u32>,
         ) -> Result<(), GraphError<u32>> {
-            self.insert(node, node, parents)
+            self.insert_pending(node, parents)
+        }
+
+        /// Alias for promoting nodes with the same value as the key.
+        fn promote(&mut self, nodes: impl IntoIterator<Item = u32>) -> Result<(), GraphError<u32>> {
+            for node in nodes {
+                self.promote_pending(node, node)?;
+            }
+            Ok(())
+        }
+
+        /// Promotes all nodes in the pending list with value=key.
+        fn promote_all(&mut self) {
+            /// SAFETY: these are definitely pending nodes.
+            self.promote(self.pending.clone()).unwrap();
         }
 
         /// Calls process_root until all nodes have been processed.
@@ -381,12 +433,12 @@ mod tests {
         }
     }
 
-    // INSERT TESTS
+    // PROMOTE TESTS
     // ================================================================================================
 
     #[test]
-    fn inserted_nodes_are_considered_for_root() {
-        //! Ensure that an inserted node is added to the root list if all parents are already
+    fn promoted_nodes_are_considered_for_root() {
+        //! Ensure that a promoted node is added to the root list if all parents are already
         //! processed.
         let parent_a = 1;
         let parent_b = 2;
@@ -395,8 +447,9 @@ mod tests {
         let child_c = 5;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(parent_a).unwrap();
-        uut.insert_root(parent_b).unwrap();
+        uut.insert_with_no_parents(parent_a).unwrap();
+        uut.insert_with_no_parents(parent_b).unwrap();
+        uut.promote_all();
 
         // Only process one parent so that some children remain unrootable.
         uut.process_root(parent_a).unwrap();
@@ -404,6 +457,8 @@ mod tests {
         uut.insert_with_parent(child_a, parent_a).unwrap();
         uut.insert_with_parent(child_b, parent_b).unwrap();
         uut.insert_with_parents(child_c, [parent_a, parent_b].into()).unwrap();
+
+        uut.promote_all();
 
         // Only child_a should be added (in addition to the parents), since the other children
         // are dependent on parent_b which is incomplete.
@@ -413,6 +468,69 @@ mod tests {
     }
 
     #[test]
+    fn unpromoted_nodes_are_not_considered_for_root() {
+        //! Ensure that an unpromoted node is _not_ added to the root list even if all parents are
+        //! already processed.
+        let parent_a = 1;
+        let parent_b = 2;
+        let child_a = 3;
+        let child_b = 4;
+        let child_c = 5;
+
+        let mut uut = TestGraph::default();
+        uut.insert_with_no_parents(parent_a).unwrap();
+        uut.insert_with_no_parents(parent_b).unwrap();
+        uut.promote_all();
+        uut.process_all();
+
+        uut.insert_with_parent(child_a, parent_a).unwrap();
+        uut.insert_with_parent(child_b, parent_b).unwrap();
+        uut.insert_with_parents(child_c, [parent_a, parent_b].into()).unwrap();
+
+        uut.promote([child_b]).unwrap();
+
+        // Only child b is valid as it was promoted.
+        let expected = [child_b].into();
+
+        assert_eq!(uut.roots, expected);
+    }
+
+    #[test]
+    fn promoted_nodes_are_moved() {
+        let mut uut = TestGraph::default();
+        uut.insert_with_no_parents(123).unwrap();
+
+        assert!(uut.pending.contains(&123));
+        assert!(!uut.vertices.contains_key(&123));
+
+        uut.promote_pending(123, 123);
+
+        assert!(!uut.pending.contains(&123));
+        assert!(uut.vertices.contains_key(&123));
+    }
+
+    #[test]
+    fn promote_rejects_already_promoted_nodes() {
+        let mut uut = TestGraph::default();
+        uut.insert_with_no_parents(123).unwrap();
+        uut.promote_all();
+
+        let err = uut.promote_pending(123, 123).unwrap_err();
+        let expected = GraphError::InvalidPendingNode(123);
+        assert_eq!(err, expected);
+    }
+
+    #[test]
+    fn promote_rejects_unknown_nodes() {
+        let err = TestGraph::default().promote_pending(123, 123).unwrap_err();
+        let expected = GraphError::InvalidPendingNode(123);
+        assert_eq!(err, expected);
+    }
+
+    // INSERT TESTS
+    // ================================================================================================
+
+    #[test]
     fn insert_with_known_parents_succeeds() {
         let parent_a = 10;
         let parent_b = 20;
@@ -420,8 +538,8 @@ mod tests {
         let uncle = 222;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(grandfather).unwrap();
-        uut.insert_root(parent_a).unwrap();
+        uut.insert_with_no_parents(grandfather).unwrap();
+        uut.insert_with_no_parents(parent_a).unwrap();
         uut.insert_with_parent(parent_b, grandfather).unwrap();
         uut.insert_with_parent(uncle, grandfather).unwrap();
         uut.insert_with_parents(1, [parent_a, parent_b].into()).unwrap();
@@ -434,14 +552,14 @@ mod tests {
         //!   - does not mutate the state (atomicity)
         const KEY: u32 = 123;
         let mut uut = TestGraph::default();
-        uut.insert_root(KEY).unwrap();
+        uut.insert_with_no_parents(KEY).unwrap();
 
-        let err = uut.insert_root(KEY).unwrap_err();
+        let err = uut.insert_with_no_parents(KEY).unwrap_err();
         let expected = GraphError::DuplicateKey(KEY);
         assert_eq!(err, expected);
 
         let mut atomic_reference = TestGraph::default();
-        atomic_reference.insert_root(KEY);
+        atomic_reference.insert_with_no_parents(KEY);
         assert_eq!(uut, atomic_reference);
     }
 
@@ -469,9 +587,9 @@ mod tests {
         const MISSING: u32 = 123;
         let mut uut = TestGraph::default();
 
-        uut.insert_root(1).unwrap();
-        uut.insert_root(2).unwrap();
-        uut.insert_root(3).unwrap();
+        uut.insert_with_no_parents(1).unwrap();
+        uut.insert_with_no_parents(2).unwrap();
+        uut.insert_with_no_parents(3).unwrap();
 
         let atomic_reference = uut.clone();
 
@@ -487,9 +605,10 @@ mod tests {
     #[test]
     fn reverting_unprocessed_nodes_is_rejected() {
         let mut uut = TestGraph::default();
-        uut.insert_root(1).unwrap();
-        uut.insert_root(2).unwrap();
-        uut.insert_root(3).unwrap();
+        uut.insert_with_no_parents(1).unwrap();
+        uut.insert_with_no_parents(2).unwrap();
+        uut.insert_with_no_parents(3).unwrap();
+        uut.promote_all();
         uut.process_root(1).unwrap();
 
         let err = uut.revert_subgraphs([1, 2, 3].into()).unwrap_err();
@@ -518,14 +637,16 @@ mod tests {
         let disjoint = 7;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(grandparent).unwrap();
-        uut.insert_root(disjoint).unwrap();
+        uut.insert_with_no_parents(grandparent).unwrap();
+        uut.insert_with_no_parents(disjoint).unwrap();
         uut.insert_with_parent(parent_a, grandparent).unwrap();
         uut.insert_with_parent(parent_b, grandparent).unwrap();
         uut.insert_with_parent(child_a, parent_a).unwrap();
         uut.insert_with_parent(child_b, parent_b).unwrap();
         uut.insert_with_parents(child_c, [parent_a, parent_b].into()).unwrap();
 
+        uut.promote([disjoint, grandparent, parent_a, parent_b, child_a, child_c])
+            .unwrap();
         uut.process_root(disjoint).unwrap();
 
         let reference = uut.clone();
@@ -552,16 +673,17 @@ mod tests {
 
         let mut uut = TestGraph::default();
         // This pair of nodes should not be impacted by the reverted subgraph.
-        uut.insert_root(disjoint_parent).unwrap();
+        uut.insert_with_no_parents(disjoint_parent).unwrap();
         uut.insert_with_parent(disjoint_child, disjoint_parent).unwrap();
 
-        uut.insert_root(parent_a).unwrap();
-        uut.insert_root(parent_b).unwrap();
+        uut.insert_with_no_parents(parent_a).unwrap();
+        uut.insert_with_no_parents(parent_b).unwrap();
         uut.insert_with_parent(child_a, parent_a);
         uut.insert_with_parent(child_b, parent_b);
         uut.insert_with_parents(partially_disjoin_child, [disjoint_parent, parent_a].into());
 
         // Since we are reverting the other parents, we expect the roots to match the current state.
+        uut.promote_all();
         uut.process_root(disjoint_parent).unwrap();
         let reference = uut.roots().clone();
 
@@ -588,20 +710,22 @@ mod tests {
         let child_both = 5;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(ancestor_a).unwrap();
-        uut.insert_root(ancestor_b).unwrap();
+        uut.insert_with_no_parents(ancestor_a).unwrap();
+        uut.insert_with_no_parents(ancestor_b).unwrap();
         uut.insert_with_parent(child_a, ancestor_a).unwrap();
         uut.insert_with_parent(child_b, ancestor_b).unwrap();
         uut.insert_with_parents(child_both, [ancestor_a, ancestor_b].into()).unwrap();
+        uut.promote_all();
 
         uut.process_root(ancestor_a).unwrap();
         uut.process_root(ancestor_b).unwrap();
         uut.prune_processed([ancestor_a, ancestor_b].into()).unwrap();
 
         let mut reference = TestGraph::default();
-        reference.insert_root(child_a).unwrap();
-        reference.insert_root(child_b).unwrap();
-        reference.insert_root(child_both).unwrap();
+        reference.insert_with_no_parents(child_a).unwrap();
+        reference.insert_with_no_parents(child_b).unwrap();
+        reference.insert_with_no_parents(child_both).unwrap();
+        reference.promote_all();
 
         assert_eq!(uut, reference);
     }
@@ -616,7 +740,8 @@ mod tests {
     #[test]
     fn pruning_unprocessed_nodes_is_rejected() {
         let mut uut = TestGraph::default();
-        uut.insert_root(1).unwrap();
+        uut.insert_with_no_parents(1).unwrap();
+        uut.promote_all();
 
         let err = uut.prune_processed([1].into()).unwrap_err();
         let expected = GraphError::UnprocessedNodes([1].into());
@@ -630,8 +755,9 @@ mod tests {
         let dangling = 1;
         let pruned = 2;
         let mut uut = TestGraph::default();
-        uut.insert_root(dangling).unwrap();
+        uut.insert_with_no_parents(dangling).unwrap();
         uut.insert_with_parent(pruned, dangling).unwrap();
+        uut.promote_all();
         uut.process_all();
 
         let err = uut.prune_processed([pruned].into()).unwrap_err();
@@ -664,8 +790,8 @@ mod tests {
         let child_c = 6;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(ancestor_a).unwrap();
-        uut.insert_root(ancestor_b).unwrap();
+        uut.insert_with_no_parents(ancestor_a).unwrap();
+        uut.insert_with_no_parents(ancestor_b).unwrap();
         uut.insert_with_parent(parent_a, ancestor_a).unwrap();
         uut.insert_with_parent(parent_b, ancestor_b).unwrap();
         uut.insert_with_parents(child_a, [ancestor_a, parent_a].into()).unwrap();
@@ -675,8 +801,8 @@ mod tests {
         uut.purge_subgraphs([child_b, parent_a].into());
 
         let mut reference = TestGraph::default();
-        reference.insert_root(ancestor_a).unwrap();
-        reference.insert_root(ancestor_b).unwrap();
+        reference.insert_with_no_parents(ancestor_a).unwrap();
+        reference.insert_with_no_parents(ancestor_b).unwrap();
         reference.insert_with_parent(parent_b, ancestor_b).unwrap();
         reference.insert_with_parent(child_c, parent_b).unwrap();
 
@@ -694,8 +820,8 @@ mod tests {
         let child_c = 7;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(ancestor_a).unwrap();
-        uut.insert_root(ancestor_b).unwrap();
+        uut.insert_with_no_parents(ancestor_a).unwrap();
+        uut.insert_with_no_parents(ancestor_b).unwrap();
         uut.insert_with_parent(parent_a, ancestor_a).unwrap();
         uut.insert_with_parent(parent_b, ancestor_b).unwrap();
         uut.insert_with_parents(child_a, [ancestor_a, parent_a].into()).unwrap();
@@ -705,8 +831,8 @@ mod tests {
         uut.purge_subgraphs([parent_a].into()).unwrap();
 
         let mut reference = TestGraph::default();
-        reference.insert_root(ancestor_a).unwrap();
-        reference.insert_root(ancestor_b).unwrap();
+        reference.insert_with_no_parents(ancestor_a).unwrap();
+        reference.insert_with_no_parents(ancestor_b).unwrap();
         reference.insert_with_parent(parent_b, ancestor_b).unwrap();
         reference.insert_with_parent(child_c, parent_b).unwrap();
 
@@ -725,13 +851,13 @@ mod tests {
         let child_c = 5;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(parent_a).unwrap();
-        uut.insert_root(parent_b).unwrap();
+        uut.insert_with_no_parents(parent_a).unwrap();
+        uut.insert_with_no_parents(parent_b).unwrap();
         uut.insert_with_parent(child_a, parent_a).unwrap();
         uut.insert_with_parent(child_b, parent_b).unwrap();
         uut.insert_with_parents(child_c, [parent_a, parent_b].into()).unwrap();
+        uut.promote_all();
 
-        // This should promote only child_a to root, in addition to the remaining parent_b root.
         uut.process_root(parent_a).unwrap();
         assert_eq!(uut.roots(), &[parent_b, child_a].into());
     }
@@ -739,22 +865,24 @@ mod tests {
     #[test]
     fn process_root_rejects_non_root_node() {
         let mut uut = TestGraph::default();
-        uut.insert_root(1).unwrap();
+        uut.insert_with_no_parents(1).unwrap();
         uut.insert_with_parent(2, 1).unwrap();
+        uut.promote_all();
 
         let err = uut.process_root(2).unwrap_err();
-        let expected = GraphError::NotARootNode(2);
+        let expected = GraphError::InvalidRootNode(2);
         assert_eq!(err, expected);
     }
 
     #[test]
     fn process_root_cannot_reprocess_same_node() {
         let mut uut = TestGraph::default();
-        uut.insert_root(1).unwrap();
+        uut.insert_with_no_parents(1).unwrap();
+        uut.promote_all();
         uut.process_root(1).unwrap();
 
         let err = uut.process_root(1).unwrap_err();
-        let expected = GraphError::NotARootNode(1);
+        let expected = GraphError::InvalidRootNode(1);
         assert_eq!(err, expected);
     }
 
@@ -764,11 +892,12 @@ mod tests {
         let nodes = (0..10).collect::<Vec<_>>();
 
         let mut uut = TestGraph::default();
-        uut.insert_root(nodes[0]);
+        uut.insert_with_no_parents(nodes[0]);
         for pairs in nodes.windows(2) {
             let (parent, id) = (pairs[0], pairs[1]);
             uut.insert_with_parent(id, parent);
         }
+        uut.promote_all();
 
         let mut ordered_roots = Vec::<u32>::new();
         for node in &nodes {
@@ -796,13 +925,14 @@ mod tests {
         let child_c = 7;
 
         let mut uut = TestGraph::default();
-        uut.insert_root(ancestor_a).unwrap();
-        uut.insert_root(ancestor_b).unwrap();
+        uut.insert_with_no_parents(ancestor_a).unwrap();
+        uut.insert_with_no_parents(ancestor_b).unwrap();
         uut.insert_with_parent(parent_a, ancestor_a).unwrap();
         uut.insert_with_parent(parent_b, ancestor_b).unwrap();
         uut.insert_with_parents(child_a, [ancestor_a, parent_a].into()).unwrap();
         uut.insert_with_parents(child_b, [parent_a, parent_b].into()).unwrap();
         uut.insert_with_parent(child_c, parent_b).unwrap();
+        uut.promote_all();
 
         assert_eq!(uut.roots(), &[ancestor_a, ancestor_b].into());
 

--- a/crates/block-producer/src/mempool/dependency_graph.rs
+++ b/crates/block-producer/src/mempool/dependency_graph.rs
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn unpromoted_nodes_are_not_considered_for_root() {
+    fn pending_nodes_are_not_considered_for_root() {
         //! Ensure that an unpromoted node is _not_ added to the root list even if all parents are
         //! already processed.
         let parent_a = 1;

--- a/crates/block-producer/src/mempool/dependency_graph.rs
+++ b/crates/block-producer/src/mempool/dependency_graph.rs
@@ -15,6 +15,27 @@ use miden_tx::utils::collections::KvMap;
 ///
 /// # Node lifecycle
 /// ```
+///                                    │                           
+///                                    │                           
+///                      insert_pending│                           
+///                              ┌─────▼─────┐                     
+///                              │  pending  │────┐                
+///                              └─────┬─────┘    │                
+///                                    │          │                
+///                     promote_pending│          │                
+///                              ┌─────▼─────┐    │                
+///                   ┌──────────► in queue  │────│                
+///                   │          └─────┬─────┘    │                
+///   revert_processed│                │          │                
+///                   │    process_root│          │                
+///                   │          ┌─────▼─────┐    │                
+///                   └──────────┼ processed │────│                
+///                              └─────┬─────┘    │                
+///                                    │          │                
+///                     prune_processed│          │purge_subgraphs
+///                              ┌─────▼─────┐    │                
+///                              │  <null>   ◄────┘                
+///                              └───────────┘                     
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyGraph<K, V> {

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -150,7 +150,8 @@ impl Mempool {
     ///
     /// Transactions are placed back in the queue.
     pub fn batch_failed(&mut self, batch: BatchJobId) {
-        let removed_batches = self.batches.purge_subgraphs([batch].into());
+        let removed_batches =
+            self.batches.purge_subgraphs([batch].into()).expect("Batch was not present");
 
         // Its possible to receive failures for batches which were already removed
         // as part of a prior failure. Early exit to prevent logging these no-ops.
@@ -197,7 +198,8 @@ impl Mempool {
 
         // Remove committed batches and transactions from graphs.
         let batches = self.block_in_progress.take().expect("No block in progress to commit");
-        let transactions = self.batches.remove_committed(batches);
+        let transactions =
+            self.batches.remove_committed(batches).expect("Batches failed to commit");
         let transactions = self
             .transactions
             .commit_transactions(&transactions)
@@ -221,7 +223,7 @@ impl Mempool {
         let batches = self.block_in_progress.take().expect("No block in progress to be failed");
 
         // Remove all transactions from the graphs.
-        let purged = self.batches.purge_subgraphs(batches);
+        let purged = self.batches.purge_subgraphs(batches).expect("Bad graph");
         let batches = purged.keys().collect::<Vec<_>>();
         let transactions = purged.into_values().flatten().collect();
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -169,7 +169,7 @@ impl Mempool {
 
     /// Marks a batch as proven if it exists.
     pub fn batch_proved(&mut self, batch_id: BatchJobId, batch: TransactionBatch) {
-        self.batches.mark_proven(batch_id, batch);
+        self.batches.submit_proof(batch_id, batch);
     }
 
     /// Select batches for the next block.
@@ -198,8 +198,7 @@ impl Mempool {
 
         // Remove committed batches and transactions from graphs.
         let batches = self.block_in_progress.take().expect("No block in progress to commit");
-        let transactions =
-            self.batches.remove_committed(batches).expect("Batches failed to commit");
+        let transactions = self.batches.prune_committed(batches).expect("Batches failed to commit");
         let transactions = self
             .transactions
             .commit_transactions(&transactions)

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -156,7 +156,7 @@ impl Mempool {
     /// Transactions are placed back in the queue.
     pub fn batch_failed(&mut self, batch: BatchJobId) {
         let removed_batches =
-            self.batches.purge_subgraphs([batch].into()).expect("Batch was not present");
+            self.batches.remove_batches([batch].into()).expect("Batch was not present");
 
         // Its possible to receive failures for batches which were already removed
         // as part of a prior failure. Early exit to prevent logging these no-ops.
@@ -227,13 +227,13 @@ impl Mempool {
         let batches = self.block_in_progress.take().expect("No block in progress to be failed");
 
         // Remove all transactions from the graphs.
-        let purged = self.batches.purge_subgraphs(batches).expect("Bad graph");
+        let purged = self.batches.remove_batches(batches).expect("Bad graph");
         let batches = purged.keys().collect::<Vec<_>>();
         let transactions = purged.into_values().flatten().collect();
 
         let transactions = self
             .transactions
-            .purge_subgraphs(transactions)
+            .remove_transactions(transactions)
             .expect("Transaction graph is malformed");
 
         // Rollback state.

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -38,8 +38,13 @@ impl Display for BatchJobId {
 }
 
 impl BatchJobId {
-    pub fn increment(mut self) {
+    pub fn increment(&mut self) {
         self.0 += 1;
+    }
+
+    #[cfg(test)]
+    pub fn new(value: u64) -> Self {
+        Self(value)
     }
 }
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -231,6 +231,11 @@ impl Mempool {
             .expect("Transaction graph is malformed");
 
         // Rollback state.
+        let transactions = transactions
+            .into_iter()
+            // FIXME
+            .map(|tx_id| todo!("Inflight state should remember diffs"))
+            .collect::<Vec<_>>();
         self.state.revert_transactions(&transactions);
     }
 }

--- a/crates/block-producer/src/mempool/transaction_graph.rs
+++ b/crates/block-producer/src/mempool/transaction_graph.rs
@@ -40,7 +40,8 @@ impl TransactionGraph {
         transaction: AuthenticatedTransaction,
         parents: BTreeSet<TransactionId>,
     ) -> Result<(), GraphError<TransactionId>> {
-        self.inner.insert(transaction.id(), transaction, parents)
+        self.inner.insert_pending(transaction.id(), parents)?;
+        self.inner.promote_pending(transaction.id(), transaction)
     }
 
     /// Selects a set of up-to count transactions for the next batch, as well as their parents.
@@ -115,10 +116,10 @@ impl TransactionGraph {
     pub fn purge_subgraphs(
         &mut self,
         transactions: Vec<TransactionId>,
-    ) -> Result<Vec<AuthenticatedTransaction>, GraphError<TransactionId>> {
+    ) -> Result<BTreeSet<TransactionId>, GraphError<TransactionId>> {
         // TODO: revisit this api.
         let transactions = transactions.into_iter().collect();
-        self.inner.purge_subgraphs(transactions).map(|kv| kv.into_values().collect())
+        self.inner.purge_subgraphs(transactions)
     }
 }
 

--- a/crates/block-producer/src/mempool/transaction_graph.rs
+++ b/crates/block-producer/src/mempool/transaction_graph.rs
@@ -68,8 +68,10 @@ impl TransactionGraph {
                 break;
             };
 
-            // SAFETY: we retieved a root node, and therefore this node must exist.
+            // SAFETY: This is definitely a root since we just selected it from the set of roots.
             self.inner.process_root(root).unwrap();
+            // SAFETY: Since it was a root batch, it must definitely have a processed batch
+            // associated with it.
             let tx = self.inner.get(&root).unwrap();
             let tx_parents = self.inner.parents(&root).unwrap();
 


### PR DESCRIPTION
This PR ports `BatchGraph` to use `DependencyGraph` as its foundation.

I implemented this by extending `DependencyGraph` to have a new `pending` stage, where the node exists but does not yet have an associated value. For batches this value is its proof i.e. `TransactionBatch`.

Effectively nodes now have a pending state, and must be promoted by passing in a value for it. I'm not 100% happy with the naming of things. Pending, promotions, processed, committed.

This model does not quite match the `TransactionGraph` lifecycle, however this was easy to adjust by having `TransacionGraph::insert` invoke both actions.

The main benefit of this is reducing the test surface.