### PR TITLE
feat(block-producer): inflight state custody of transaction data

### DIFF
--- a/crates/block-producer/src/mempool/inflight_state/mod.rs
+++ b/crates/block-producer/src/mempool/inflight_state/mod.rs
@@ -64,10 +64,14 @@ pub struct InflightState {
     chain_tip: BlockNumber,
 }
 
+/// A summary of a transaction's impact on the state.
 #[derive(Clone, Debug, PartialEq)]
 struct Delta {
+    /// The account this transaction updated.
     account: AccountId,
+    /// The nullifiers produced by this transaction.
     nullifiers: BTreeSet<Nullifier>,
+    /// The output notes created by this transaction.
     output_notes: BTreeSet<NoteId>,
 }
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -204,13 +204,12 @@ impl Mempool {
         // Remove committed batches and transactions from graphs.
         let batches = self.block_in_progress.take().expect("No block in progress to commit");
         let transactions = self.batches.prune_committed(batches).expect("Batches failed to commit");
-        let transactions = self
-            .transactions
+        self.transactions
             .commit_transactions(&transactions)
             .expect("Transaction graph malformed");
 
         // Inform inflight state about committed data.
-        self.state.commit_block(&transactions);
+        self.state.commit_block(transactions);
 
         self.chain_tip.increment();
     }
@@ -237,11 +236,6 @@ impl Mempool {
             .expect("Transaction graph is malformed");
 
         // Rollback state.
-        let transactions = transactions
-            .into_iter()
-            // FIXME
-            .map(|tx_id| todo!("Inflight state should remember diffs"))
-            .collect::<Vec<_>>();
-        self.state.revert_transactions(&transactions);
+        self.state.revert_transactions(transactions);
     }
 }

--- a/crates/block-producer/src/mempool/transaction_graph.rs
+++ b/crates/block-producer/src/mempool/transaction_graph.rs
@@ -121,10 +121,11 @@ impl TransactionGraph {
     pub fn commit_transactions(
         &mut self,
         tx_ids: &[TransactionId],
-    ) -> Result<Vec<AuthenticatedTransaction>, GraphError<TransactionId>> {
+    ) -> Result<(), GraphError<TransactionId>> {
         // TODO: revisit this api.
         let tx_ids = tx_ids.iter().cloned().collect();
-        self.inner.prune_processed(tx_ids)
+        self.inner.prune_processed(tx_ids)?;
+        Ok(())
     }
 
     /// Removes the transactions and all their descendants from the graph.


### PR DESCRIPTION
This PR upgrades `InflightState` so that it tracks each transaction's state delta internally. We differentiate between committed and uncommitted transactions. The former cannot be reverted.

This means reverting or committing transactions now only requires passing in the transaction IDs, instead of requiring the full transaction data.

This enables making the inflight state more robust as it now differentiates between committed and uncommitted transaction IDs. Additional work is required to change the current panics into errors instead, though this is left to a future PR as it isn't high priority. Tracked in #537.

Essentially this works towards hardening the different components of the mempool individually so that we can pick up corruption/bugs as soon as possible.