### PR TITLE
chore: re-enable blocks_in_conditions lint

### DIFF
--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -57,9 +57,6 @@ pub struct DefaultBatchBuilder<S, BB> {
     ready_batches: SharedRwVec<TransactionBatch>,
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 impl<S, BB> DefaultBatchBuilder<S, BB>
 where
     S: Store,
@@ -146,9 +143,6 @@ where
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[async_trait]
 impl<S, BB> BatchBuilder for DefaultBatchBuilder<S, BB>
 where

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -58,9 +58,6 @@ where
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[async_trait]
 impl<S, A> BlockBuilder for DefaultBlockBuilder<S, A>
 where

--- a/crates/block-producer/src/server/api.rs
+++ b/crates/block-producer/src/server/api.rs
@@ -28,9 +28,6 @@ impl<BB, TV> BlockProducerApi<BB, TV> {
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[tonic::async_trait]
 impl<BB, TV> api_server::Api for BlockProducerApi<BB, TV>
 where

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -56,9 +56,6 @@ where
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[async_trait]
 impl<S> TransactionValidator for DefaultStateView<S>
 where
@@ -136,9 +133,6 @@ where
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[async_trait]
 impl<S> ApplyBlock for DefaultStateView<S>
 where

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -165,9 +165,6 @@ impl DefaultStore {
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[async_trait]
 impl ApplyBlock for DefaultStore {
     #[instrument(target = "miden-block-producer", skip_all, err)]
@@ -185,9 +182,6 @@ impl ApplyBlock for DefaultStore {
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[async_trait]
 impl Store for DefaultStore {
     #[instrument(target = "miden-block-producer", skip_all, err)]

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -56,9 +56,6 @@ impl RpcApi {
     }
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[tonic::async_trait]
 impl api_server::Api for RpcApi {
     #[instrument(

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -50,9 +50,6 @@ pub struct StoreApi {
     pub(super) state: Arc<State>,
 }
 
-// FIXME: remove the allow when the upstream clippy issue is fixed:
-// https://github.com/rust-lang/rust-clippy/issues/12281
-#[allow(clippy::blocks_in_conditions)]
 #[tonic::async_trait]
 impl api_server::Api for StoreApi {
     // CLIENT ENDPOINTS


### PR DESCRIPTION
Clippy issue https://github.com/rust-lang/rust-clippy/issues/12281 was fixed in v1.81. We now have MSRV of 1.82 allowing us to remove our workaround.

More specifically, `#[async_trait]` was triggering this lint, and as of 1.81 no longer does.

I did grep the repo for `blocks_in_conditions` and can confirm we have no other instances of it.