### PR TITLE
feat(block-producer): improve mempool config

### DIFF
--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -77,7 +77,7 @@ impl TransactionBatch {
     /// # Errors
     ///
     /// Returns an error if:
-    ///   - There are duplicated output notes or unauthenticated notes found across all transactions
+    /// - There are duplicated output notes or unauthenticated notes found across all transactions
     ///   in the batch.
     /// - Hashes for corresponding input notes and output notes don't match.
     #[instrument(target = "miden-block-producer", name = "new_batch", skip_all, err)]

--- a/crates/block-producer/src/block_builder/prover/block_witness.rs
+++ b/crates/block-producer/src/block_builder/prover/block_witness.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     notes::Nullifier,
     transaction::TransactionId,
     vm::{AdviceInputs, StackInputs},
-    BlockHeader, Digest, Felt, BLOCK_NOTE_TREE_DEPTH, MAX_BATCHES_PER_BLOCK, ZERO,
+    BlockHeader, Digest, Felt, BLOCK_NOTE_TREE_DEPTH, ZERO,
 };
 
 use crate::{
@@ -35,9 +35,6 @@ impl BlockWitness {
         mut block_inputs: BlockInputs,
         batches: &[TransactionBatch],
     ) -> Result<(Self, Vec<BlockAccountUpdate>), BuildBlockError> {
-        if batches.len() > MAX_BATCHES_PER_BLOCK {
-            return Err(BuildBlockError::TooManyBatchesInBlock(batches.len()));
-        }
         Self::validate_nullifiers(&block_inputs, batches)?;
 
         let batch_created_notes_roots = batches

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -99,6 +99,14 @@ impl AuthenticatedTransaction {
         self.inner.output_notes().iter().map(|note| note.id())
     }
 
+    pub fn output_note_count(&self) -> usize {
+        self.inner.output_notes().num_notes()
+    }
+
+    pub fn input_note_count(&self) -> usize {
+        self.inner.input_notes().num_notes()
+    }
+
     /// Notes which were unauthenticate in the transaction __and__ which were
     /// not authenticated by the store inputs.
     pub fn unauthenticated_notes(&self) -> impl Iterator<Item = NoteId> + '_ {

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -4,8 +4,8 @@ use miden_objects::{
     accounts::AccountId,
     crypto::merkle::{MerkleError, MmrError},
     notes::{NoteId, Nullifier},
-    transaction::{ProvenTransaction, TransactionId},
-    AccountDeltaError, Digest, TransactionInputError, MAX_BATCHES_PER_BLOCK,
+    transaction::TransactionId,
+    AccountDeltaError, Digest, TransactionInputError,
 };
 use miden_processor::ExecutionError;
 use thiserror::Error;
@@ -97,24 +97,22 @@ impl From<AddTransactionError> for tonic::Status {
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum BuildBatchError {
     #[error("Duplicated unauthenticated transaction input note ID in the batch: {0}")]
-    DuplicateUnauthenticatedNote(NoteId, Vec<ProvenTransaction>),
+    DuplicateUnauthenticatedNote(NoteId),
 
     #[error("Duplicated transaction output note ID in the batch: {0}")]
-    DuplicateOutputNote(NoteId, Vec<ProvenTransaction>),
+    DuplicateOutputNote(NoteId),
 
     #[error("Note hashes mismatch for note {id}: (input: {input_hash}, output: {output_hash})")]
     NoteHashesMismatch {
         id: NoteId,
         input_hash: Digest,
         output_hash: Digest,
-        txs: Vec<ProvenTransaction>,
     },
 
     #[error("Failed to merge transaction delta into account {account_id}: {error}")]
     AccountUpdateError {
         account_id: AccountId,
         error: AccountDeltaError,
-        txs: Vec<ProvenTransaction>,
     },
 
     #[error("Nothing actually went wrong, failure was injected on purpose")]
@@ -178,8 +176,6 @@ pub enum BuildBlockError {
     InconsistentNullifiers(Vec<Nullifier>),
     #[error("unauthenticated transaction notes not found in the store or in outputs of other transactions in the block: {0:?}")]
     UnauthenticatedNotesNotFound(Vec<NoteId>),
-    #[error("too many batches in block. Got: {0}, max: {MAX_BATCHES_PER_BLOCK}")]
-    TooManyBatchesInBlock(usize),
     #[error("failed to merge transaction delta into account {account_id}: {error}")]
     AccountUpdateError {
         account_id: AccountId,

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -94,11 +94,7 @@ impl From<AddTransactionError> for tonic::Status {
 // Batch building errors
 // =================================================================================================
 
-/// Error that may happen while building a transaction batch.
-///
-/// These errors are returned from the batch builder to the transaction queue, instead of
-/// dropping the transactions, they are included into the error values, so that the transaction
-/// queue can re-queue them.
+/// Error encountered while building a batch.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum BuildBatchError {
     #[error(

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -5,8 +5,7 @@ use miden_objects::{
     crypto::merkle::{MerkleError, MmrError},
     notes::{NoteId, Nullifier},
     transaction::{ProvenTransaction, TransactionId},
-    AccountDeltaError, Digest, TransactionInputError, MAX_ACCOUNTS_PER_BATCH,
-    MAX_BATCHES_PER_BLOCK, MAX_INPUT_NOTES_PER_BATCH, MAX_OUTPUT_NOTES_PER_BATCH,
+    AccountDeltaError, Digest, TransactionInputError, MAX_BATCHES_PER_BLOCK,
 };
 use miden_processor::ExecutionError;
 use thiserror::Error;
@@ -97,25 +96,6 @@ impl From<AddTransactionError> for tonic::Status {
 /// Error encountered while building a batch.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum BuildBatchError {
-    #[error(
-        "Too many input notes in the batch. Got: {0}, limit: {}",
-        MAX_INPUT_NOTES_PER_BATCH
-    )]
-    TooManyInputNotes(usize, Vec<ProvenTransaction>),
-
-    #[error(
-        "Too many notes created in the batch. Got: {0}, limit: {}",
-        MAX_OUTPUT_NOTES_PER_BATCH
-    )]
-    TooManyNotesCreated(usize, Vec<ProvenTransaction>),
-
-    #[error(
-        "Too many account updates in the batch. Got: {}, limit: {}",
-        .0.len(),
-        MAX_ACCOUNTS_PER_BATCH
-    )]
-    TooManyAccountsInBatch(Vec<ProvenTransaction>),
-
     #[error("Duplicated unauthenticated transaction input note ID in the batch: {0}")]
     DuplicateUnauthenticatedNote(NoteId, Vec<ProvenTransaction>),
 

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -21,7 +21,7 @@ pub mod server;
 pub const COMPONENT: &str = "miden-block-producer";
 
 /// The number of transactions per batch
-const SERVER_BATCH_SIZE: usize = 2;
+const SERVER_MAX_TXS_PER_BATCH: usize = 2;
 
 /// The frequency at which blocks are produced
 const SERVER_BLOCK_FREQUENCY: Duration = Duration::from_secs(10);

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -37,3 +37,13 @@ const SERVER_MAX_BATCHES_PER_BLOCK: usize = 4;
 /// This determines the grace period incoming transactions have between fetching their input from
 /// the store and verification in the mempool.
 const SERVER_MEMPOOL_STATE_RETENTION: usize = 5;
+
+const _: () = assert!(
+    SERVER_MAX_BATCHES_PER_BLOCK <= miden_objects::MAX_BATCHES_PER_BLOCK,
+    "Server constraint cannot exceed the protocol's constraint"
+);
+
+const _: () = assert!(
+    SERVER_MAX_TXS_PER_BATCH <= miden_objects::MAX_ACCOUNTS_PER_BATCH,
+    "Server constraint cannot exceed the protocol's constraint"
+);

--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -203,7 +203,8 @@ impl BatchGraph {
         self.inner.promote_pending(id, batch)
     }
 
-    /// Returns at most `count` batches which are ready for inclusion in a block.
+    /// Selects the next set of batches ready for inclusion in a block while adhering to the given
+    /// budget.
     pub fn select_block(
         &mut self,
         mut budget: BlockBudget,
@@ -216,7 +217,7 @@ impl BatchGraph {
             let batch = self.inner.get(&batch_id).unwrap().clone();
 
             // Adhere to block's budget.
-            if budget.check_then_deplete(&batch) == BudgetStatus::Depleted {
+            if budget.check_then_deplete(&batch) == BudgetStatus::Exceeded {
                 break;
             }
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -136,9 +136,8 @@ impl BatchBudget {
         let _: miden_objects::accounts::AccountId = tx.account_update().account_id();
         const ACCOUNT_UPDATES_PER_TX: usize = 1;
 
-        // TODO: This is inefficient and ProvenTransaction should provide len() access.
-        let output_notes = tx.output_notes().count();
-        let input_notes = tx.nullifiers().count();
+        let output_notes = tx.output_note_count();
+        let input_notes = tx.input_note_count();
 
         if self.transactions == 0
             || self.accounts < ACCOUNT_UPDATES_PER_TX

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -6,6 +6,9 @@ use std::{
 
 use batch_graph::BatchGraph;
 use inflight_state::InflightState;
+use miden_objects::{
+    MAX_ACCOUNTS_PER_BATCH, MAX_INPUT_NOTES_PER_BATCH, MAX_OUTPUT_NOTES_PER_BATCH,
+};
 use tokio::sync::Mutex;
 use transaction_graph::TransactionGraph;
 
@@ -74,6 +77,101 @@ impl BlockNumber {
     }
 }
 
+// MEMPOOL BUDGET
+// ================================================================================================
+
+/// Limits placed on a batch's contents.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchBudget {
+    /// Maximum number of transactions allowed in a batch.
+    pub transactions: usize,
+    /// Maximum number of input notes allowed.
+    pub input_notes: usize,
+    /// Maximum number of output notes allowed.
+    pub output_notes: usize,
+    /// Maximum number of updated accounts.
+    pub accounts: usize,
+}
+
+/// Limits placed on a blocks's contents.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockBudget {
+    /// Maximum number of batches allowed in a block.
+    pub batches: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BudgetStatus {
+    Depleted,
+    Undepleted,
+}
+
+impl Default for BatchBudget {
+    fn default() -> Self {
+        Self {
+            transactions: SERVER_MAX_TXS_PER_BATCH,
+            input_notes: MAX_INPUT_NOTES_PER_BATCH,
+            output_notes: MAX_OUTPUT_NOTES_PER_BATCH,
+            accounts: MAX_ACCOUNTS_PER_BATCH,
+        }
+    }
+}
+
+impl Default for BlockBudget {
+    fn default() -> Self {
+        Self { batches: SERVER_MAX_BATCHES_PER_BLOCK }
+    }
+}
+
+impl BatchBudget {
+    /// Attempts to consume the transaction's resources from the budget.
+    ///
+    /// Returns [BudgetStatus::Depleted] if the transaction would exceed the remaining budget,
+    /// otherwise returns [BudgetStatus::Undepleted]
+    #[must_use]
+    fn check_then_deplete(&mut self, tx: &AuthenticatedTransaction) -> BudgetStatus {
+        // This type assertion reminds us to update the account check if we ever support multiple
+        // account updates per tx.
+        let _: miden_objects::accounts::AccountId = tx.account_update().account_id();
+        const ACCOUNT_COUNT: usize = 1;
+
+        // TODO: This is inefficient and ProvenTransaction should provide len() access.
+        let output_notes = tx.output_notes().count();
+        let input_notes = tx.nullifiers().count();
+
+        if self.transactions == 0
+            || self.accounts < ACCOUNT_COUNT
+            || self.input_notes < input_notes
+            || self.output_notes < output_notes
+        {
+            return BudgetStatus::Depleted;
+        }
+
+        self.transactions -= 1;
+        self.accounts -= ACCOUNT_COUNT;
+        self.input_notes -= input_notes;
+        self.output_notes -= output_notes;
+
+        BudgetStatus::Undepleted
+    }
+}
+
+impl BlockBudget {
+    /// Attempts to consume the batch's resources from the budget.
+    ///
+    /// Returns [BudgetStatus::Depleted] if the batch would exceed the remaining budget,
+    /// otherwise returns [BudgetStatus::Undepleted]
+    #[must_use]
+    fn check_then_deplete(&mut self, _batch: &TransactionBatch) -> BudgetStatus {
+        if self.batches == 0 {
+            BudgetStatus::Depleted
+        } else {
+            self.batches -= 1;
+            BudgetStatus::Undepleted
+        }
+    }
+}
+
 // MEMPOOL
 // ================================================================================================
 
@@ -81,10 +179,10 @@ pub type SharedMempool = Arc<Mutex<Mempool>>;
 
 #[derive(Clone)]
 pub struct MempoolBuilder {
-    /// The maximum number of transactions that will be selected for a batch.
-    pub batch_transaction_limit: usize,
+    /// Limits placed on each batch.
+    pub batch_limits: BatchBudget,
     /// The maximum number of batches that will be selected for a block.
-    pub block_batch_limit: usize,
+    pub block_limits: BlockBudget,
     /// Number of committed blocks the mempool will retain in its state tracking.
     pub committed_state_retention: usize,
 }
@@ -92,9 +190,9 @@ pub struct MempoolBuilder {
 impl Default for MempoolBuilder {
     fn default() -> Self {
         Self {
-            batch_transaction_limit: SERVER_MAX_TXS_PER_BATCH,
-            block_batch_limit: SERVER_MAX_BATCHES_PER_BLOCK,
             committed_state_retention: SERVER_MEMPOOL_STATE_RETENTION,
+            block_limits: Default::default(),
+            batch_limits: Default::default(),
         }
     }
 }
@@ -106,14 +204,14 @@ impl MempoolBuilder {
 
     fn build(self, chain_tip: BlockNumber) -> Mempool {
         let Self {
-            batch_transaction_limit,
-            block_batch_limit,
+            block_limits,
             committed_state_retention,
+            batch_limits,
         } = self;
         Mempool {
             chain_tip,
-            batch_transaction_limit,
-            block_batch_limit,
+            block_limits,
+            batch_limits,
             state: InflightState::new(chain_tip, committed_state_retention),
             block_in_progress: Default::default(),
             transactions: Default::default(),
@@ -143,8 +241,9 @@ pub struct Mempool {
 
     block_in_progress: Option<BTreeSet<BatchJobId>>,
 
-    batch_transaction_limit: usize,
-    block_batch_limit: usize,
+    batch_limits: BatchBudget,
+
+    block_limits: BlockBudget,
 }
 
 impl Mempool {
@@ -194,7 +293,7 @@ impl Mempool {
     ///
     /// Returns `None` if no transactions are available.
     pub fn select_batch(&mut self) -> Option<(BatchJobId, Vec<AuthenticatedTransaction>)> {
-        let (batch, parents) = self.transactions.select_batch(self.batch_transaction_limit);
+        let (batch, parents) = self.transactions.select_batch(self.batch_limits.clone());
         if batch.is_empty() {
             return None;
         }
@@ -244,7 +343,7 @@ impl Mempool {
     pub fn select_block(&mut self) -> (BlockNumber, BTreeMap<BatchJobId, TransactionBatch>) {
         assert!(self.block_in_progress.is_none(), "Cannot have two blocks inflight.");
 
-        let batches = self.batches.select_block(self.block_batch_limit);
+        let batches = self.batches.select_block(self.block_limits.clone());
         self.block_in_progress = Some(batches.keys().cloned().collect());
 
         (self.chain_tip.next(), batches)

--- a/crates/block-producer/src/mempool/transaction_graph.rs
+++ b/crates/block-producer/src/mempool/transaction_graph.rs
@@ -63,7 +63,9 @@ impl TransactionGraph {
         self.inner.promote_pending(transaction.id(), transaction)
     }
 
-    /// Selects a set of up-to count transactions for the next batch, as well as their parents.
+    /// Selects a set transactions for the next batch such that they adhere to the given budget.
+    ///
+    /// Also returns the transactions' parents.
     ///
     /// Internally these transactions are considered processed and cannot be emitted in future
     /// batches.
@@ -88,7 +90,7 @@ impl TransactionGraph {
             let tx = self.inner.get(&root).unwrap().clone();
 
             // Adhere to batch budget.
-            if budget.check_then_deplete(&tx) == BudgetStatus::Depleted {
+            if budget.check_then_subtract(&tx) == BudgetStatus::Exceeded {
                 break;
             }
 

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -22,7 +22,8 @@ use crate::{
     errors::{AddTransactionError, VerifyTxError},
     mempool::{BlockNumber, Mempool, SharedMempool},
     store::{DefaultStore, Store},
-    COMPONENT, SERVER_BATCH_SIZE, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MEMPOOL_STATE_RETENTION,
+    COMPONENT, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
+    SERVER_MEMPOOL_STATE_RETENTION,
 };
 
 /// Represents an initialized block-producer component where the RPC connection is open,
@@ -76,7 +77,7 @@ impl BlockProducer {
         Ok(Self {
             batch_builder: Default::default(),
             block_builder: BlockBuilder::new(store.clone()),
-            batch_limit: SERVER_BATCH_SIZE,
+            batch_limit: SERVER_MAX_TXS_PER_BATCH,
             block_limit: SERVER_MAX_BATCHES_PER_BLOCK,
             state_retention: SERVER_MEMPOOL_STATE_RETENTION,
             store,

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     config::BlockProducerConfig,
     domain::transaction::AuthenticatedTransaction,
     errors::{AddTransactionError, VerifyTxError},
-    mempool::{BlockNumber, Mempool, SharedMempool},
+    mempool::{BatchBudget, BlockBudget, BlockNumber, Mempool, SharedMempool},
     store::{DefaultStore, Store},
     COMPONENT, SERVER_MEMPOOL_STATE_RETENTION,
 };
@@ -34,8 +34,8 @@ use crate::{
 pub struct BlockProducer {
     batch_builder: BatchBuilder,
     block_builder: BlockBuilder,
-    batch_limits: BatchBudget,
-    block_limits: BlockBudget,
+    batch_budget: BatchBudget,
+    block_budget: BlockBudget,
     state_retention: usize,
     rpc_listener: TcpListener,
     store: DefaultStore,
@@ -76,8 +76,8 @@ impl BlockProducer {
         Ok(Self {
             batch_builder: Default::default(),
             block_builder: BlockBuilder::new(store.clone()),
-            batch_limits: Default::default(),
-            block_limits: Default::default(),
+            batch_budget: Default::default(),
+            block_budget: Default::default(),
             state_retention: SERVER_MEMPOOL_STATE_RETENTION,
             store,
             rpc_listener,
@@ -89,15 +89,15 @@ impl BlockProducer {
         let Self {
             batch_builder,
             block_builder,
-            batch_limits,
-            block_limits,
+            batch_budget,
+            block_budget,
             state_retention,
             rpc_listener,
             store,
             chain_tip,
         } = self;
 
-        let mempool = Mempool::new(chain_tip, batch_limit, block_limit, state_retention);
+        let mempool = Mempool::new(chain_tip, batch_budget, block_budget, state_retention);
 
         // Spawn rpc server and batch and block provers.
         //

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -22,8 +22,7 @@ use crate::{
     errors::{AddTransactionError, VerifyTxError},
     mempool::{BlockNumber, Mempool, SharedMempool},
     store::{DefaultStore, Store},
-    COMPONENT, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
-    SERVER_MEMPOOL_STATE_RETENTION,
+    COMPONENT, SERVER_MEMPOOL_STATE_RETENTION,
 };
 
 /// Represents an initialized block-producer component where the RPC connection is open,
@@ -35,8 +34,8 @@ use crate::{
 pub struct BlockProducer {
     batch_builder: BatchBuilder,
     block_builder: BlockBuilder,
-    batch_limit: usize,
-    block_limit: usize,
+    batch_limits: BatchBudget,
+    block_limits: BlockBudget,
     state_retention: usize,
     rpc_listener: TcpListener,
     store: DefaultStore,
@@ -77,8 +76,8 @@ impl BlockProducer {
         Ok(Self {
             batch_builder: Default::default(),
             block_builder: BlockBuilder::new(store.clone()),
-            batch_limit: SERVER_MAX_TXS_PER_BATCH,
-            block_limit: SERVER_MAX_BATCHES_PER_BLOCK,
+            batch_limits: Default::default(),
+            block_limits: Default::default(),
             state_retention: SERVER_MEMPOOL_STATE_RETENTION,
             store,
             rpc_listener,
@@ -90,8 +89,8 @@ impl BlockProducer {
         let Self {
             batch_builder,
             block_builder,
-            batch_limit,
-            block_limit,
+            batch_limits,
+            block_limits,
             state_retention,
             rpc_listener,
             store,


### PR DESCRIPTION
This PR improves mempool configuration and simplifies the block-producer errors exposed during batch and block building.

Mempool configuration is now separated out into a builder, and constraint support is added as a sort of batch/block budget that gets exhausted during the batch/block selection. In other words, batches/blocks produced by the mempool are guaranteed to adhere to the limits placed on them, removing the need for asserting these errors in the building process.

I've removed the transaction data passing in the error variant, which was used by the previous FIFO implementation to return the failed transactions into the pool. This is no longer required as the mempool retains a copy of all inflight transactions.

We may still want to perform these checks in the builders regardless; though I'd prefer only doing this in a single place.

This completes some tasks in #519 