### PR TITLE
refactor(block-producer): simplify shared mempool

### DIFF
--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -76,28 +76,7 @@ impl BlockNumber {
 // MEMPOOL
 // ================================================================================================
 
-#[derive(Clone)]
-pub struct SharedMempool(Arc<Mutex<Mempool>>);
-
-impl SharedMempool {
-    pub fn new(
-        chain_tip: BlockNumber,
-        batch_limit: usize,
-        block_limit: usize,
-        state_retention: usize,
-    ) -> Self {
-        Self(Arc::new(Mutex::new(Mempool::new(
-            chain_tip,
-            batch_limit,
-            block_limit,
-            state_retention,
-        ))))
-    }
-
-    pub async fn lock(&self) -> tokio::sync::MutexGuard<Mempool> {
-        self.0.lock().await
-    }
-}
+pub type SharedMempool = Arc<Mutex<Mempool>>;
 
 pub struct Mempool {
     /// The latest inflight state of each account.
@@ -125,13 +104,13 @@ pub struct Mempool {
 
 impl Mempool {
     /// Creates a new [Mempool] with the provided configuration.
-    fn new(
+    pub fn new(
         chain_tip: BlockNumber,
         batch_limit: usize,
         block_limit: usize,
         state_retention: usize,
-    ) -> Self {
-        Self {
+    ) -> SharedMempool {
+        Arc::new(Mutex::new(Self {
             chain_tip,
             batch_transaction_limit: batch_limit,
             block_batch_limit: block_limit,
@@ -140,7 +119,7 @@ impl Mempool {
             transactions: Default::default(),
             batches: Default::default(),
             next_batch_id: Default::default(),
-        }
+        }))
     }
 
     /// Adds a transaction to the mempool.

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     config::BlockProducerConfig,
     domain::transaction::AuthenticatedTransaction,
     errors::{AddTransactionError, VerifyTxError},
-    mempool::{BlockNumber, SharedMempool},
+    mempool::{BlockNumber, Mempool, SharedMempool},
     store::{DefaultStore, Store},
     COMPONENT, SERVER_BATCH_SIZE, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MEMPOOL_STATE_RETENTION,
 };
@@ -97,7 +97,7 @@ impl BlockProducer {
             chain_tip,
         } = self;
 
-        let mempool = SharedMempool::new(chain_tip, batch_limit, block_limit, state_retention);
+        let mempool = Mempool::new(chain_tip, batch_limit, block_limit, state_retention);
 
         // Spawn rpc server and batch and block provers.
         //


### PR DESCRIPTION
I think, creation of `SharedMempool` as separated structure doesn't give us any benefits, but makes code more complex. Proposed refactoring in this PR.

By the way, @Mirko-von-Leipzig,  do we need additional mutex here? https://github.com/0xPolygonMiden/miden-node/blob/9445ca2276b3ed5d02bf14928adb221fd274562b/crates/block-producer/src/server/mod.rs#L165-L171
According to comment, this can help with rate limiting and queuing of new transaction, but it seems to me that one mutex in `SharedMempool` is enough to do this job.