### PR TITLE
feat: added https support in endpoint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Added `GetAccountProofs` endpoint (#506).
+- Support Https in endpoint configuration (#556).
 
 ### Changes
 

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -93,10 +93,10 @@ mod tests {
                     verify_tx_proofs = true
 
                     [rpc]
-                    endpoint = { host = "127.0.0.1",  port = 8080 }
+                    endpoint = { host = "127.0.0.1",  port = 8080, protocol = "Http" }
 
                     [store]
-                    endpoint = { host = "127.0.0.1",  port = 8080 }
+                    endpoint = { host = "127.0.0.1",  port = 8080, protocol = "Https" }
                     database_filepath = "local.sqlite3"
                     genesis_filepath = "genesis.dat"
                     blockstore_dir = "blocks"

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -112,7 +112,7 @@ mod tests {
                         endpoint: Endpoint {
                             host: "127.0.0.1".to_string(),
                             port: 8080,
-                            protocol: Protocol::Http
+                            protocol: Protocol::default()
                         },
                         verify_tx_proofs: true
                     },
@@ -127,7 +127,7 @@ mod tests {
                         endpoint: Endpoint {
                             host: "127.0.0.1".to_string(),
                             port: 8080,
-                            protocol: Protocol::Http
+                            protocol: Protocol::Https
                         },
                         database_filepath: "local.sqlite3".into(),
                         genesis_filepath: "genesis.dat".into(),

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -74,7 +74,7 @@ impl NodeConfig {
 mod tests {
     use figment::Jail;
     use miden_node_store::config::StoreConfig;
-    use miden_node_utils::config::{load_config, Endpoint};
+    use miden_node_utils::config::{load_config, Endpoint, Protocol};
 
     use super::NodeConfig;
     use crate::{
@@ -112,6 +112,7 @@ mod tests {
                         endpoint: Endpoint {
                             host: "127.0.0.1".to_string(),
                             port: 8080,
+                            protocol: Protocol::Http
                         },
                         verify_tx_proofs: true
                     },
@@ -119,12 +120,14 @@ mod tests {
                         endpoint: Endpoint {
                             host: "127.0.0.1".to_string(),
                             port: 8080,
+                            protocol: Protocol::Http
                         },
                     },
                     store: StoreConfig {
                         endpoint: Endpoint {
                             host: "127.0.0.1".to_string(),
                             port: 8080,
+                            protocol: Protocol::Http
                         },
                         database_filepath: "local.sqlite3".into(),
                         genesis_filepath: "genesis.dat".into(),

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use miden_node_utils::config::{
-    Endpoint, DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_NODE_RPC_PORT, DEFAULT_STORE_PORT,
+    Endpoint, Protocol, DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_NODE_RPC_PORT, DEFAULT_STORE_PORT,
 };
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +39,7 @@ impl Default for RpcConfig {
             endpoint: Endpoint {
                 host: "0.0.0.0".to_string(),
                 port: DEFAULT_NODE_RPC_PORT,
+                protocol: Protocol::Http,
             },
             store_url: Endpoint::localhost(DEFAULT_STORE_PORT).to_string(),
             block_producer_url: Endpoint::localhost(DEFAULT_BLOCK_PRODUCER_PORT).to_string(),

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -39,7 +39,7 @@ impl Default for RpcConfig {
             endpoint: Endpoint {
                 host: "0.0.0.0".to_string(),
                 port: DEFAULT_NODE_RPC_PORT,
-                protocol: Protocol::Http,
+                protocol: Protocol::default(),
             },
             store_url: Endpoint::localhost(DEFAULT_STORE_PORT).to_string(),
             block_producer_url: Endpoint::localhost(DEFAULT_BLOCK_PRODUCER_PORT).to_string(),

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -17,6 +17,11 @@ pub const DEFAULT_BLOCK_PRODUCER_PORT: u16 = 48046;
 pub const DEFAULT_STORE_PORT: u16 = 28943;
 pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
 
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+pub enum Protocol {
+    Http,
+    Https,
+}
 /// The `(host, port)` pair for the server's listening socket.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Endpoint {
@@ -24,11 +29,17 @@ pub struct Endpoint {
     pub host: String,
     /// Port number used by the store.
     pub port: u16,
+    /// Protocol type: http or https.
+    pub protocol: Protocol,
 }
 
 impl Endpoint {
     pub fn localhost(port: u16) -> Self {
-        Endpoint { host: "localhost".to_string(), port }
+        Endpoint {
+            host: "localhost".to_string(),
+            port,
+            protocol: Protocol::Http,
+        }
     }
 }
 
@@ -41,7 +52,10 @@ impl ToSocketAddrs for Endpoint {
 
 impl Display for Endpoint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("http://{}:{}", self.host, self.port))
+        match self.protocol {
+            Protocol::Http => f.write_fmt(format_args!("http://{}:{}", self.host, self.port)),
+            Protocol::Https => f.write_fmt(format_args!("https://{}:{}", self.host, self.port)),
+        }
     }
 }
 

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -17,9 +17,9 @@ pub const DEFAULT_BLOCK_PRODUCER_PORT: u16 = 48046;
 pub const DEFAULT_STORE_PORT: u16 = 28943;
 pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
 pub enum Protocol {
-    Http,
+    #[default] Http,
     Https,
 }
 /// The `(host, port)` pair for the server's listening socket.
@@ -38,7 +38,7 @@ impl Endpoint {
         Endpoint {
             host: "localhost".to_string(),
             port,
-            protocol: Protocol::Http,
+            protocol: Protocol::default(),
         }
     }
 }
@@ -52,9 +52,16 @@ impl ToSocketAddrs for Endpoint {
 
 impl Display for Endpoint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.protocol {
-            Protocol::Http => f.write_fmt(format_args!("http://{}:{}", self.host, self.port)),
-            Protocol::Https => f.write_fmt(format_args!("https://{}:{}", self.host, self.port)),
+        let Endpoint { protocol, host, port } = self;
+        f.write_fmt(format_args!("{protocol}://{host}:{port}"))
+    }
+}
+
+impl Display for Protocol{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self{
+            Protocol::Http => f.write_fmt(format_args!("http://")),
+            Protocol::Https => f.write_fmt(format_args!("https://")),
         }
     }
 }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -19,7 +19,8 @@ pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
 pub enum Protocol {
-    #[default] Http,
+    #[default]
+    Http,
     Https,
 }
 /// The `(host, port)` pair for the server's listening socket.
@@ -30,6 +31,7 @@ pub struct Endpoint {
     /// Port number used by the store.
     pub port: u16,
     /// Protocol type: http or https.
+    #[serde(default)]
     pub protocol: Protocol,
 }
 
@@ -57,11 +59,11 @@ impl Display for Endpoint {
     }
 }
 
-impl Display for Protocol{
+impl Display for Protocol {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self{
-            Protocol::Http => f.write_fmt(format_args!("http://")),
-            Protocol::Https => f.write_fmt(format_args!("https://")),
+        match self {
+            Protocol::Http => f.write_str("http"),
+            Protocol::Https => f.write_str("https"),
         }
     }
 }


### PR DESCRIPTION
Ref #403 

Added https support in the endpoints struct.
By default, all default calls are to `http` type only as expected for localhost.