### PR TITLE
ci: fix deploy workflow

### DIFF
--- a/.github/actions/ssm_execute/action.yml
+++ b/.github/actions/ssm_execute/action.yml
@@ -35,7 +35,7 @@ runs:
             --output text \
             --query "Command.CommandId")
         echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
-      continue-on-error: true
+      continue-on-error: false
 
     - name: Poll command status and retrieve live logs
       id: poll_output

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,14 @@ jobs:
         if: ${{ !startsWith(inputs.gitref, 'v') }}
         uses: ./.github/actions/build_package
         with: 
-          gitref: inputs.gitref
+          gitref: ${{ inputs.gitref }}
+
+      - name: Rename built packages
+        if: ${{ !startsWith(inputs.gitref, 'v') }}
+        run: |
+          mv miden-node.deb   ${{ env.node-package }} 
+          mv miden-faucet.deb ${{ env.faucet-package }} 
+          
 
       # Configure AWS communication via SSM.
       - name: Configure AWS credentials
@@ -88,7 +95,7 @@ jobs:
         with:
           instance_id: ${{ secrets[env.instance-id] }}
           command: |
-            sudo apt udpate; \
+            sudo apt-get udpate; \
             sudo apt install awscli -y
 
       # Move packages to instance using S3. Note that this will clobber the files.
@@ -133,9 +140,9 @@ jobs:
             sudo /usr/bin/miden-node make-genesis -i /etc/opt/miden-node/genesis.toml -o /opt/miden-node/genesis.dat --force; \
             sudo /usr/bin/miden-faucet init -c /etc/opt/miden-faucet/miden-faucet.toml -f /opt/miden-faucet/accounts/faucet.mac; \
             sudo mkdir /opt/miden-faucet/accounts; \
-            sudo cp /opt/miden-node/accounts/faucet.mac /opt/miden-faucet/accounts/faucet.mac
-            sudo chown -R miden-node /opt/miden-node
-            sudo chown -R miden-faucet /opt/miden-faucet
+            sudo cp /opt/miden-node/accounts/faucet.mac /opt/miden-faucet/accounts/faucet.mac; \
+            sudo chown -R miden-node /opt/miden-node; \
+            sudo chown -R miden-faucet /opt/miden-faucet;
 
       - name: Start miden services
         uses: ./.github/actions/ssm_execute
@@ -144,4 +151,4 @@ jobs:
           command: |
               sudo systemctl daemon-reload; \
               sudo systemctl start miden-node; \
-              sudo systemctl start miden-faucet
+              sudo systemctl start miden-faucet;


### PR DESCRIPTION
Fixes some issues picked up when deploying a non-release version.

Non-release deployments requires building the packages as part of the workflow. Release deployments simply pull the pre-built binaries from github directly. Non-release deployments haven't been exercised fully before.

More concretely this PR fixes:
- missing escape around the git reference input
- renames the built packages to those expected by the workflow
- missing line-ends of some ssm-command invocations