### PR TITLE
chore: remove `test_` prefix stutter

### DIFF
--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -189,11 +189,10 @@ mod tests {
     use miden_node_store::genesis::GenesisState;
     use miden_objects::{accounts::AccountData, utils::serde::Deserializable};
 
-    use super::make_genesis;
     use crate::DEFAULT_GENESIS_FILE_PATH;
 
     #[test]
-    fn test_make_genesis() {
+    fn make_genesis() {
         let genesis_inputs_file_path = PathBuf::from("genesis.toml");
 
         // node genesis configuration
@@ -217,7 +216,7 @@ mod tests {
             let genesis_dat_file_path = PathBuf::from(DEFAULT_GENESIS_FILE_PATH);
 
             //  run make_genesis to generate genesis.dat and accounts folder and files
-            make_genesis(&genesis_inputs_file_path, &genesis_dat_file_path, &true).unwrap();
+            super::make_genesis(&genesis_inputs_file_path, &genesis_dat_file_path, &true).unwrap();
 
             let a0_file_path = PathBuf::from("accounts/faucet.mac");
 

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -280,7 +280,7 @@ mod tests {
     };
 
     #[test]
-    fn test_output_note_tracker_duplicate_output_notes() {
+    fn output_note_tracker_duplicate_output_notes() {
         let mut txs = mock_proven_txs();
 
         let result = OutputNoteTracker::new(&txs);
@@ -306,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn test_output_note_tracker_remove_in_place_consumed_note() {
+    fn output_note_tracker_remove_in_place_consumed_note() {
         let txs = mock_proven_txs();
         let mut tracker = OutputNoteTracker::new(&txs).unwrap();
 
@@ -329,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duplicate_unauthenticated_notes() {
+    fn duplicate_unauthenticated_notes() {
         let mut txs = mock_proven_txs();
         let duplicate_note = mock_note(5);
         txs.push(mock_proven_tx(4, vec![duplicate_note.clone()], vec![mock_output_note(9)]));
@@ -342,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn test_consume_notes_in_place() {
+    fn consume_notes_in_place() {
         let mut txs = mock_proven_txs();
         let note_to_consume = mock_note(3);
         txs.push(mock_proven_tx(
@@ -385,7 +385,7 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_unauthenticated_note_to_authenticated() {
+    fn convert_unauthenticated_note_to_authenticated() {
         let txs = mock_proven_txs();
         let found_unauthenticated_notes = BTreeMap::from_iter([(
             mock_note(5).id(),

--- a/crates/block-producer/src/block_builder/prover/tests.rs
+++ b/crates/block-producer/src/block_builder/prover/tests.rs
@@ -38,7 +38,7 @@ use crate::{
 ///
 /// The store will contain accounts 1 & 2, while the transaction batches will contain 2 & 3.
 #[test]
-fn test_block_witness_validation_inconsistent_account_ids() {
+fn block_witness_validation_inconsistent_account_ids() {
     let account_id_1 = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER));
     let account_id_2 = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER + 1));
     let account_id_3 = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER + 2));
@@ -97,7 +97,7 @@ fn test_block_witness_validation_inconsistent_account_ids() {
 ///
 /// Only account 1 will have a different state hash
 #[test]
-fn test_block_witness_validation_inconsistent_account_hashes() {
+fn block_witness_validation_inconsistent_account_hashes() {
     let account_id_1 =
         AccountId::new_unchecked(Felt::new(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN));
     let account_id_2 = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER));
@@ -178,7 +178,7 @@ fn test_block_witness_validation_inconsistent_account_hashes() {
 /// themselves: `[tx_x0, tx_y1], [tx_y0, tx_x1]`. This test ensures that the witness is
 /// produced correctly as if for a single batch: `[tx_x0, tx_x1, tx_y0, tx_y1]`.
 #[test]
-fn test_block_witness_multiple_batches_per_account() {
+fn block_witness_multiple_batches_per_account() {
     let x_account_id =
         AccountId::new_unchecked(Felt::new(ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN));
     let y_account_id = AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER));
@@ -274,7 +274,7 @@ fn test_block_witness_multiple_batches_per_account() {
 /// We assume an initial store with 5 accounts, and all will be updated.
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_account_root_success() {
+async fn compute_account_root_success() {
     // Set up account states
     // ---------------------------------------------------------------------------------------------
     let account_ids = [
@@ -374,7 +374,7 @@ async fn test_compute_account_root_success() {
 /// Test that the current account root is returned if the batches are empty
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_account_root_empty_batches() {
+async fn compute_account_root_empty_batches() {
     // Set up account states
     // ---------------------------------------------------------------------------------------------
     let account_ids = [
@@ -431,7 +431,7 @@ async fn test_compute_account_root_empty_batches() {
 /// contains no batches
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_note_root_empty_batches_success() {
+async fn compute_note_root_empty_batches_success() {
     // Set up store
     // ---------------------------------------------------------------------------------------------
 
@@ -463,7 +463,7 @@ async fn test_compute_note_root_empty_batches_success() {
 /// which contains at least 1 batch.
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_note_root_empty_notes_success() {
+async fn compute_note_root_empty_notes_success() {
     // Set up store
     // ---------------------------------------------------------------------------------------------
 
@@ -498,7 +498,7 @@ async fn test_compute_note_root_empty_notes_success() {
 /// many batches.
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_note_root_success() {
+async fn compute_note_root_success() {
     let account_ids = [
         AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER)),
         AccountId::new_unchecked(Felt::new(ACCOUNT_ID_OFF_CHAIN_SENDER + 1)),
@@ -605,7 +605,7 @@ async fn test_compute_note_root_success() {
 ///
 /// The transaction batches will contain nullifiers 1 & 2, while the store will contain 2 & 3.
 #[test]
-fn test_block_witness_validation_inconsistent_nullifiers() {
+fn block_witness_validation_inconsistent_nullifiers() {
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
             let tx = MockProvenTxBuilder::with_account_index(0).nullifiers_range(0..1).build();
@@ -684,7 +684,7 @@ fn test_block_witness_validation_inconsistent_nullifiers() {
 /// Tests that the block kernel returns the expected nullifier tree when no nullifiers are present
 /// in the transaction
 #[tokio::test]
-async fn test_compute_nullifier_root_empty_success() {
+async fn compute_nullifier_root_empty_success() {
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
             let tx = MockProvenTxBuilder::with_account_index(0).build();
@@ -738,7 +738,7 @@ async fn test_compute_nullifier_root_empty_success() {
 /// Tests that the block kernel returns the expected nullifier tree when multiple nullifiers are
 /// present in the transaction
 #[tokio::test]
-async fn test_compute_nullifier_root_success() {
+async fn compute_nullifier_root_success() {
     let batches: Vec<TransactionBatch> = {
         let batch_1 = {
             let tx = MockProvenTxBuilder::with_account_index(0).nullifiers_range(0..1).build();
@@ -810,7 +810,7 @@ async fn test_compute_nullifier_root_success() {
 /// Test that the chain mmr root is as expected if the batches are empty
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_chain_mmr_root_empty_mmr() {
+async fn compute_chain_mmr_root_empty_mmr() {
     let store = MockStoreSuccessBuilder::from_batches(iter::empty()).build();
 
     let expected_block_header = build_expected_block_header(&store, &[]).await;
@@ -822,7 +822,7 @@ async fn test_compute_chain_mmr_root_empty_mmr() {
 /// add header to non-empty MMR (1 peak), and check that we get the expected commitment
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_chain_mmr_root_mmr_1_peak() {
+async fn compute_chain_mmr_root_mmr_1_peak() {
     let initial_chain_mmr = {
         let mut mmr = Mmr::new();
         mmr.add(Digest::default());
@@ -843,7 +843,7 @@ async fn test_compute_chain_mmr_root_mmr_1_peak() {
 /// add header to an MMR with 17 peaks, and check that we get the expected commitment
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_compute_chain_mmr_root_mmr_17_peaks() {
+async fn compute_chain_mmr_root_mmr_17_peaks() {
     let initial_chain_mmr = {
         let mut mmr = Mmr::new();
         for _ in 0..(2_u32.pow(17) - 1) {

--- a/crates/block-producer/src/state_view/tests/apply_block.rs
+++ b/crates/block-producer/src/state_view/tests/apply_block.rs
@@ -16,7 +16,7 @@ use crate::test_utils::{block::MockBlockBuilder, MockStoreSuccessBuilder};
 /// Tests requirement AB1
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_apply_block_ab1() {
+async fn apply_block_ab1() {
     let account: MockPrivateAccount<3> = MockPrivateAccount::from(0);
 
     let store = Arc::new(
@@ -57,7 +57,7 @@ async fn test_apply_block_ab1() {
 /// Tests requirement AB2
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_apply_block_ab2() {
+async fn apply_block_ab2() {
     let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(
@@ -113,7 +113,7 @@ async fn test_apply_block_ab2() {
 /// Tests requirement AB3
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_apply_block_ab3() {
+async fn apply_block_ab3() {
     let (txs, accounts): (Vec<_>, Vec<_>) = get_txs_and_accounts(0, 3).unzip();
 
     let store = Arc::new(

--- a/crates/block-producer/src/state_view/tests/verify_tx.rs
+++ b/crates/block-producer/src/state_view/tests/verify_tx.rs
@@ -23,7 +23,7 @@ use crate::test_utils::{block::MockBlockBuilder, note::mock_note, MockStoreSucce
 /// notes all verify successfully
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_happy_path() {
+async fn verify_tx_happy_path() {
     let (txs, accounts): (Vec<ProvenTransaction>, Vec<MockPrivateAccount>) =
         get_txs_and_accounts(0, 3).unzip();
 
@@ -49,7 +49,7 @@ async fn test_verify_tx_happy_path() {
 /// In this test, all calls to `verify_tx()` are concurrent
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_happy_path_concurrent() {
+async fn verify_tx_happy_path_concurrent() {
     let (txs, accounts): (Vec<ProvenTransaction>, Vec<MockPrivateAccount>) =
         get_txs_and_accounts(0, 3).unzip();
 
@@ -79,7 +79,7 @@ async fn test_verify_tx_happy_path_concurrent() {
 /// Verifies requirement VT1
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_vt1() {
+async fn verify_tx_vt1() {
     let account = MockPrivateAccount::<3>::from(1);
 
     let store = Arc::new(
@@ -113,7 +113,7 @@ async fn test_verify_tx_vt1() {
 /// Verifies requirement VT2
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_vt2() {
+async fn verify_tx_vt2() {
     let account_not_in_store: MockPrivateAccount<3> = MockPrivateAccount::from(0);
 
     // Notice: account is not added to the store
@@ -137,7 +137,7 @@ async fn test_verify_tx_vt2() {
 /// Verifies requirement VT3
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_vt3() {
+async fn verify_tx_vt3() {
     let account: MockPrivateAccount<3> = MockPrivateAccount::from(1);
 
     let nullifier_in_store = nullifier_by_index(0);
@@ -169,7 +169,7 @@ async fn test_verify_tx_vt3() {
 /// Verifies requirement VT4
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_vt4() {
+async fn verify_tx_vt4() {
     let account: MockPrivateAccount<3> = MockPrivateAccount::from(1);
 
     let store = Arc::new(
@@ -196,7 +196,7 @@ async fn test_verify_tx_vt4() {
 /// Verifies requirement VT5
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_vt5() {
+async fn verify_tx_vt5() {
     let account_1: MockPrivateAccount<3> = MockPrivateAccount::from(1);
     let account_2: MockPrivateAccount<3> = MockPrivateAccount::from(2);
     let nullifier_in_both_txs = nullifier_by_index(0);
@@ -241,7 +241,7 @@ async fn test_verify_tx_vt5() {
 /// notes
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_dangling_note_found_in_inflight_notes() {
+async fn verify_tx_dangling_note_found_in_inflight_notes() {
     let account_1: MockPrivateAccount<3> = MockPrivateAccount::from(1);
     let account_2: MockPrivateAccount<3> = MockPrivateAccount::from(2);
     let store = Arc::new(
@@ -282,7 +282,7 @@ async fn test_verify_tx_dangling_note_found_in_inflight_notes() {
 /// in-flight notes nor in the store
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_verify_tx_stored_unauthenticated_notes() {
+async fn verify_tx_stored_unauthenticated_notes() {
     let account_1: MockPrivateAccount<3> = MockPrivateAccount::from(1);
     let store = Arc::new(
         MockStoreSuccessBuilder::from_accounts(

--- a/crates/block-producer/src/txqueue/tests/mod.rs
+++ b/crates/block-producer/src/txqueue/tests/mod.rs
@@ -69,7 +69,7 @@ impl BatchBuilder for BatchBuilderFailure {
 /// be built in some batch
 #[tokio::test(start_paused = true)]
 #[miden_node_test_macro::enable_logging]
-async fn test_build_batch_success() {
+async fn build_batch_success() {
     let build_batch_frequency = Duration::from_millis(5);
     let batch_size = 3;
     let (sender, mut receiver) = mpsc::unbounded_channel::<TransactionBatch>();
@@ -160,7 +160,7 @@ async fn test_build_batch_success() {
 /// Tests that when transactions fail to verify, they are not added to the queue
 #[tokio::test(start_paused = true)]
 #[miden_node_test_macro::enable_logging]
-async fn test_tx_verify_failure() {
+async fn tx_verify_failure() {
     let build_batch_frequency = Duration::from_millis(5);
     let batch_size = 3;
 
@@ -194,7 +194,7 @@ async fn test_tx_verify_failure() {
 /// Tests that when batch building fails, transactions are added back to the ready queue
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
-async fn test_build_batch_failure() {
+async fn build_batch_failure() {
     let build_batch_frequency = Duration::from_millis(30);
     let batch_size = 3;
 

--- a/crates/proto/src/domain/digest.rs
+++ b/crates/proto/src/domain/digest.rs
@@ -210,7 +210,7 @@ mod test {
     use crate::generated::digest::Digest;
 
     #[test]
-    fn test_hex_digest() {
+    fn hex_digest() {
         let digest = Digest {
             d0: 3488802789098113751,
             d1: 5271242459988994564,
@@ -229,7 +229,7 @@ mod test {
 
     proptest! {
         #[test]
-        fn test_encode_decode(
+        fn encode_decode(
             d0: u64,
             d1: u64,
             d2: u64,

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -49,7 +49,7 @@ fn create_block(conn: &mut Connection, block_num: u32) {
 }
 
 #[test]
-fn test_sql_insert_nullifiers_for_block() {
+fn sql_insert_nullifiers_for_block() {
     let mut conn = create_db();
 
     let nullifiers = [num_to_nullifier(1 << 48)];
@@ -95,7 +95,7 @@ fn test_sql_insert_nullifiers_for_block() {
 }
 
 #[test]
-fn test_sql_insert_transactions() {
+fn sql_insert_transactions() {
     let mut conn = create_db();
 
     let count = insert_transactions(&mut conn);
@@ -104,7 +104,7 @@ fn test_sql_insert_transactions() {
 }
 
 #[test]
-fn test_sql_select_transactions() {
+fn sql_select_transactions() {
     fn query_transactions(conn: &mut Connection) -> Vec<TransactionSummary> {
         sql::select_transactions_by_accounts_and_block_range(conn, 0, 2, &[1]).unwrap()
     }
@@ -125,7 +125,7 @@ fn test_sql_select_transactions() {
 }
 
 #[test]
-fn test_sql_select_nullifiers() {
+fn sql_select_nullifiers() {
     let mut conn = create_db();
 
     let block_num = 1;
@@ -151,7 +151,7 @@ fn test_sql_select_nullifiers() {
 }
 
 #[test]
-fn test_sql_select_notes() {
+fn sql_select_notes() {
     let mut conn = create_db();
 
     let block_num = 1;
@@ -191,7 +191,7 @@ fn test_sql_select_notes() {
 }
 
 #[test]
-fn test_sql_select_notes_different_execution_hints() {
+fn sql_select_notes_different_execution_hints() {
     let mut conn = create_db();
 
     let block_num = 1;
@@ -278,7 +278,7 @@ fn test_sql_select_notes_different_execution_hints() {
 }
 
 #[test]
-fn test_sql_select_accounts() {
+fn sql_select_accounts() {
     let mut conn = create_db();
 
     let block_num = 1;
@@ -321,7 +321,7 @@ fn test_sql_select_accounts() {
 }
 
 #[test]
-fn test_sql_public_account_details() {
+fn sql_public_account_details() {
     let mut conn = create_db();
 
     create_block(&mut conn, 1);
@@ -472,7 +472,7 @@ fn test_sql_public_account_details() {
 }
 
 #[test]
-fn test_sql_select_nullifiers_by_block_range() {
+fn sql_select_nullifiers_by_block_range() {
     let mut conn = create_db();
 
     // test empty table
@@ -599,7 +599,7 @@ fn test_sql_select_nullifiers_by_block_range() {
 }
 
 #[test]
-fn test_select_nullifiers_by_prefix() {
+fn select_nullifiers_by_prefix() {
     let mut conn = create_db();
     const PREFIX_LEN: u32 = 16;
     // test empty table
@@ -704,7 +704,7 @@ fn test_select_nullifiers_by_prefix() {
 }
 
 #[test]
-fn test_db_block_header() {
+fn db_block_header() {
     let mut conn = create_db();
 
     // test querying empty table
@@ -776,7 +776,7 @@ fn test_db_block_header() {
 }
 
 #[test]
-fn test_db_account() {
+fn db_account() {
     let mut conn = create_db();
 
     let block_num = 1;
@@ -830,7 +830,7 @@ fn test_db_account() {
 }
 
 #[test]
-fn test_notes() {
+fn notes() {
     let mut conn = create_db();
 
     let block_num_1 = 1;

--- a/crates/store/src/nullifier_tree.rs
+++ b/crates/store/src/nullifier_tree.rs
@@ -90,7 +90,7 @@ mod tests {
     use super::NullifierTree;
 
     #[test]
-    fn test_leaf_value_encoding() {
+    fn leaf_value_encoding() {
         let block_num = 123;
         let nullifier_value = NullifierTree::block_num_to_leaf_value(block_num);
 
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn test_leaf_value_decoding() {
+    fn leaf_value_decoding() {
         let block_num = 123;
         let nullifier_value = [Felt::from(block_num), ZERO, ZERO, ZERO];
         let decoded_block_num = NullifierTree::leaf_value_to_block_num(nullifier_value);


### PR DESCRIPTION
Removes the `test_` prefix applied to many of our test cases.

Tests are already annotated with `#[test]` and are usually inside a `mod tests` so also prefixing each test function is largely redundant.

Briefly discussed [here](https://github.com/0xPolygonMiden/miden-node/pull/563#discussion_r1872856703).