### PR TITLE
chore(block-producer): increase block frequency

### DIFF
--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -24,7 +24,7 @@ pub const COMPONENT: &str = "miden-block-producer";
 const SERVER_MAX_TXS_PER_BATCH: usize = 2;
 
 /// The frequency at which blocks are produced
-const SERVER_BLOCK_FREQUENCY: Duration = Duration::from_secs(10);
+const SERVER_BLOCK_FREQUENCY: Duration = Duration::from_secs(5);
 
 /// The frequency at which batches are built
 const SERVER_BUILD_BATCH_FREQUENCY: Duration = Duration::from_secs(2);


### PR DESCRIPTION
Reduce block interval timer: `10s -> 5s`.

No changelog as the `10s` variant was never officially released.

Closes #564.