### PR TITLE
refactor(block-producer): remove Store traits

### DIFF
--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -12,11 +12,8 @@ use tokio::time::Duration;
 use tracing::{debug, info, instrument};
 
 use crate::{
-    batch_builder::batch::TransactionBatch,
-    errors::BuildBlockError,
-    mempool::SharedMempool,
-    store::{DefaultStore, Store},
-    COMPONENT, SERVER_BLOCK_FREQUENCY,
+    batch_builder::batch::TransactionBatch, errors::BuildBlockError, mempool::SharedMempool,
+    store::DefaultStore, COMPONENT, SERVER_BLOCK_FREQUENCY,
 };
 
 pub(crate) mod prover;

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     batch_builder::batch::TransactionBatch,
     errors::BuildBlockError,
     mempool::SharedMempool,
-    store::{ApplyBlock, DefaultStore, Store},
+    store::{DefaultStore, Store},
     COMPONENT, SERVER_BLOCK_FREQUENCY,
 };
 

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info, instrument};
 
 use crate::{
     batch_builder::batch::TransactionBatch, errors::BuildBlockError, mempool::SharedMempool,
-    store::DefaultStore, COMPONENT, SERVER_BLOCK_FREQUENCY,
+    store::StoreClient, COMPONENT, SERVER_BLOCK_FREQUENCY,
 };
 
 pub(crate) mod prover;
@@ -33,12 +33,12 @@ pub struct BlockBuilder {
     /// Note: this _must_ be sign positive and less than 1.0.
     pub failure_rate: f32,
 
-    pub store: DefaultStore,
+    pub store: StoreClient,
     pub block_kernel: BlockProver,
 }
 
 impl BlockBuilder {
-    pub fn new(store: DefaultStore) -> Self {
+    pub fn new(store: StoreClient) -> Self {
         Self {
             block_interval: SERVER_BLOCK_FREQUENCY,
             // Note: The range cannot be empty.

--- a/crates/block-producer/src/block_builder/prover/tests.rs
+++ b/crates/block-producer/src/block_builder/prover/tests.rs
@@ -23,7 +23,6 @@ use super::*;
 use crate::{
     batch_builder::TransactionBatch,
     block::{AccountWitness, BlockInputs},
-    store::Store,
     test_utils::{
         block::{build_actual_block_header, build_expected_block_header, MockBlockBuilder},
         MockProvenTxBuilder, MockStoreSuccessBuilder,

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     domain::transaction::AuthenticatedTransaction,
     errors::{AddTransactionError, BlockProducerError, VerifyTxError},
     mempool::{BatchBudget, BlockBudget, BlockNumber, Mempool, SharedMempool},
-    store::{DefaultStore, Store},
+    store::DefaultStore,
     COMPONENT, SERVER_MEMPOOL_STATE_RETENTION,
 };
 

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -113,15 +113,18 @@ impl TryFrom<GetTransactionInputsResponse> for TransactionInputs {
     }
 }
 
-// DEFAULT STORE IMPLEMENTATION
+// STORE CLIENT
 // ================================================================================================
 
+/// Interface to the store's gRPC API.
+///
+/// Essentially just a thin wrapper around the generated gRPC client which improves type safety.
 #[derive(Clone)]
-pub struct DefaultStore {
+pub struct StoreClient {
     store: store_client::ApiClient<Channel>,
 }
 
-impl DefaultStore {
+impl StoreClient {
     /// TODO: this should probably take store connection string and create a connection internally
     pub fn new(store: store_client::ApiClient<Channel>) -> Self {
         Self { store }

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -207,7 +207,7 @@ impl StoreClient {
             .map_err(|err| BlockInputsError::GrpcClientError(err.message().to_string()))?
             .into_inner();
 
-        Ok(store_response.try_into()?)
+        store_response.try_into()
     }
 
     #[instrument(target = "miden-block-producer", skip_all, err)]

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -13,7 +13,6 @@ use crate::{
     batch_builder::TransactionBatch,
     block::BlockInputs,
     block_builder::prover::{block_witness::BlockWitness, BlockProver},
-    store::Store,
 };
 
 /// Constructs the block we expect to be built given the store state, and a set of transaction

--- a/crates/block-producer/src/test_utils/mod.rs
+++ b/crates/block-producer/src/test_utils/mod.rs
@@ -13,7 +13,7 @@ pub use proven_tx::{mock_proven_tx, MockProvenTxBuilder};
 
 mod store;
 
-pub use store::{MockStoreFailure, MockStoreSuccess, MockStoreSuccessBuilder};
+pub use store::{MockStoreSuccess, MockStoreSuccessBuilder};
 
 mod account;
 

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -19,9 +19,7 @@ use super::*;
 use crate::{
     batch_builder::TransactionBatch,
     block::{AccountWitness, BlockInputs},
-    store::{
-        ApplyBlock, ApplyBlockError, BlockInputsError, Store, TransactionInputs, TxInputsError,
-    },
+    store::{ApplyBlockError, BlockInputsError, Store, TransactionInputs, TxInputsError},
     test_utils::block::{
         block_output_notes, flatten_output_notes, note_created_smt_from_note_batches,
     },
@@ -188,7 +186,7 @@ impl MockStoreSuccess {
 }
 
 #[async_trait]
-impl ApplyBlock for MockStoreSuccess {
+impl Store for MockStoreSuccess {
     async fn apply_block(&self, block: &Block) -> Result<(), ApplyBlockError> {
         // Intentionally, we take and hold both locks, to prevent calls to `get_tx_inputs()` from
         // going through while we're updating the store's data structure
@@ -240,10 +238,6 @@ impl ApplyBlock for MockStoreSuccess {
 
         Ok(())
     }
-}
-
-#[async_trait]
-impl Store for MockStoreSuccess {
     async fn get_tx_inputs(
         &self,
         proven_tx: &ProvenTransaction,
@@ -357,14 +351,11 @@ impl Store for MockStoreSuccess {
 pub struct MockStoreFailure;
 
 #[async_trait]
-impl ApplyBlock for MockStoreFailure {
+impl Store for MockStoreFailure {
     async fn apply_block(&self, _block: &Block) -> Result<(), ApplyBlockError> {
         Err(ApplyBlockError::GrpcClientError(String::new()))
     }
-}
 
-#[async_trait]
-impl Store for MockStoreFailure {
     async fn get_tx_inputs(
         &self,
         _proven_tx: &ProvenTransaction,


### PR DESCRIPTION
This PR removes the block producer's `Store` and `ApplyBlock` traits.

Instead the methods are moved directly into the `DefaultStore` struct, which has also been renamed to a more appropriate `StoreClient`.

The traits were required to facilitate mocking as part of tests. Most of these usages were removed as part of the mempool work, which allowed these traits to largely just disappear.

There are still some remnants lurking (`MockStoreSuccess` et al), but these require larger refactors to the underlying tests. 

In general, we should avoid mocks where possible as its very easy for things to desync with reality. And indeed some of the above tests aren't actually testing the unit-under-test but rather the test setup code. Ideally we would have an actual in-memory store running for each test however this is quite a lot of work. A potentially simpler option is to implement the gRPC server for tests (skipping the database). 

Closes #196 and closes #565.