### PR TITLE
refactor(block-producer): order batches within a block

### DIFF
--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -72,7 +72,7 @@ impl BlockBuilder {
             interval.tick().await;
 
             let (block_number, batches) = mempool.lock().await.select_block();
-            let batches = batches.into_values().collect::<Vec<_>>();
+            let batches = batches.into_iter().map(|(_, batch)| batch).collect::<Vec<_>>();
 
             let mut result = self.build_block(&batches).await;
             let proving_duration = rand::thread_rng().gen_range(self.simulated_proof_time.clone());

--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -217,11 +217,8 @@ impl BatchGraph {
 
     /// Selects the next set of batches ready for inclusion in a block while adhering to the given
     /// budget.
-    pub fn select_block(
-        &mut self,
-        mut budget: BlockBudget,
-    ) -> BTreeMap<BatchJobId, TransactionBatch> {
-        let mut batches = BTreeMap::new();
+    pub fn select_block(&mut self, mut budget: BlockBudget) -> Vec<(BatchJobId, TransactionBatch)> {
+        let mut batches = Vec::with_capacity(budget.batches);
 
         while let Some(batch_id) = self.inner.roots().first().copied() {
             // SAFETY: Since it was a root batch, it must definitely have a processed batch
@@ -240,7 +237,7 @@ impl BatchGraph {
             // SAFETY: This is definitely a root since we just selected it from the set of roots.
             self.inner.process_root(batch_id).expect("root should be processed");
 
-            batches.insert(batch_id, batch);
+            batches.push((batch_id, batch));
         }
 
         batches

--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -217,6 +217,9 @@ impl BatchGraph {
 
     /// Selects the next set of batches ready for inclusion in a block while adhering to the given
     /// budget.
+    ///
+    /// Note that batch order should be maintained to allow for inter-batch dependencies to be
+    /// correctly resolved.
     pub fn select_block(&mut self, mut budget: BlockBudget) -> Vec<(BatchJobId, TransactionBatch)> {
         let mut batches = Vec::with_capacity(budget.batches);
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -310,7 +310,9 @@ impl Mempool {
 
     /// Select batches for the next block.
     ///
-    /// May return an empty set if no batches are ready.
+    /// Note that the set of batches
+    /// - may be empty if none are available, and
+    /// - may contain dependencies and therefore the order must be maintained
     ///
     /// # Panics
     ///

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Display,
-    sync::Arc,
-};
+use std::{collections::BTreeSet, fmt::Display, sync::Arc};
 
 use batch_graph::BatchGraph;
 use inflight_state::InflightState;
@@ -319,11 +315,11 @@ impl Mempool {
     /// # Panics
     ///
     /// Panics if there is already a block in flight.
-    pub fn select_block(&mut self) -> (BlockNumber, BTreeMap<BatchJobId, TransactionBatch>) {
+    pub fn select_block(&mut self) -> (BlockNumber, Vec<(BatchJobId, TransactionBatch)>) {
         assert!(self.block_in_progress.is_none(), "Cannot have two blocks inflight.");
 
         let batches = self.batches.select_block(self.block_budget);
-        self.block_in_progress = Some(batches.keys().cloned().collect());
+        self.block_in_progress = Some(batches.iter().map(|(id, _)| *id).collect());
 
         (self.chain_tip.next(), batches)
     }


### PR DESCRIPTION
As mentioned in this [comment](https://github.com/0xPolygonMiden/miden-node/issues/397#issuecomment-2529077185), this PR makes it clear that batches within a block have a given order. This intention signaling is improved by using a vector instead of a map (with accidental ordering). As alluded to in [this comment](https://github.com/0xPolygonMiden/miden-node/issues/397) from #397.

> The [current](https://github.com/0xPolygonMiden/miden-node/blob/0f6b69af58189755d0ec9b13f994d3ef75317485/crates/block-producer/src/mempool/batch_graph.rs#L220-L247) batch selection strategy just selects an arbitrary available root batch. A root batch by definition is one who's parents have already been selected previously; or in other words dependency order is enforced within the selection process.
>
> The set of batches is then [consumed in order](https://github.com/0xPolygonMiden/miden-node/blob/0f6b69af58189755d0ec9b13f994d3ef75317485/crates/block-producer/src/block_builder/mod.rs#L74-L75) by the block builder. Though it does use a BTreeMap which makes this a bit opaque (the keys form a sort of FIFO so ordering is kept), and I guess more or less implies that the ordering is accidental and not necessarily intentional.
>
> This issue is technically complete but I'll create a PR changing the BTreeMap to a Vec so that this ordering is made more clear.

Closes #397.