### PR TITLE
refactor(block-producer): cleanup StoreClient

### DIFF
--- a/crates/block-producer/src/block.rs
+++ b/crates/block-producer/src/block.rs
@@ -13,8 +13,6 @@ use miden_objects::{
     BlockHeader, Digest,
 };
 
-use crate::store::BlockInputsError;
-
 // BLOCK INPUTS
 // ================================================================================================
 
@@ -44,12 +42,12 @@ pub struct AccountWitness {
 }
 
 impl TryFrom<GetBlockInputsResponse> for BlockInputs {
-    type Error = BlockInputsError;
+    type Error = ConversionError;
 
     fn try_from(response: GetBlockInputsResponse) -> Result<Self, Self::Error> {
         let block_header: BlockHeader = response
             .block_header
-            .ok_or(GetBlockInputsResponse::missing_field(stringify!(block_header)))?
+            .ok_or(miden_node_proto::generated::block::BlockHeader::missing_field("block_header"))?
             .try_into()?;
 
         let chain_peaks = {

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -135,7 +135,8 @@ impl BlockBuilder {
                 produced_nullifiers.iter(),
                 dangling_notes.iter(),
             )
-            .await?;
+            .await
+            .map_err(BuildBlockError::GetBlockInputsFailed)?;
 
         let missing_notes: Vec<_> = dangling_notes
             .difference(&block_inputs.found_unauthenticated_notes.note_ids())
@@ -160,7 +161,10 @@ impl BlockBuilder {
         info!(target: COMPONENT, block_num, %block_hash, "block built");
         debug!(target: COMPONENT, ?block);
 
-        self.store.apply_block(&block).await?;
+        self.store
+            .apply_block(&block)
+            .await
+            .map_err(BuildBlockError::ApplyBlockFailed)?;
 
         info!(target: COMPONENT, block_num, %block_hash, "block committed");
 

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -28,8 +28,7 @@ use miden_processor::crypto::RpoDigest;
 use tonic::transport::Channel;
 use tracing::{debug, info, instrument};
 
-pub use crate::errors::{ApplyBlockError, BlockInputsError, TxInputsError};
-use crate::{block::BlockInputs, COMPONENT};
+use crate::{block::BlockInputs, errors::StoreError, COMPONENT};
 
 // TRANSACTION INPUTS
 // ================================================================================================
@@ -132,24 +131,26 @@ impl StoreClient {
 
     /// Returns the latest block's header from the store.
     #[instrument(target = "miden-block-producer", skip_all, err)]
-    pub async fn latest_header(&self) -> Result<BlockHeader, String> {
-        // TODO: Consolidate the error types returned by the store (and its trait).
+    pub async fn latest_header(&self) -> Result<BlockHeader, StoreError> {
         let response = self
             .inner
             .clone()
             .get_block_header_by_number(tonic::Request::new(Default::default()))
-            .await
-            .map_err(|err| err.to_string())?
-            .into_inner();
+            .await?
+            .into_inner()
+            .block_header
+            .ok_or(miden_node_proto::generated::block::BlockHeader::missing_field(
+                "block_header",
+            ))?;
 
-        BlockHeader::try_from(response.block_header.unwrap()).map_err(|err| err.to_string())
+        BlockHeader::try_from(response).map_err(Into::into)
     }
 
     #[instrument(target = "miden-block-producer", skip_all, err)]
     pub async fn get_tx_inputs(
         &self,
         proven_tx: &ProvenTransaction,
-    ) -> Result<TransactionInputs, TxInputsError> {
+    ) -> Result<TransactionInputs, StoreError> {
         let message = GetTransactionInputsRequest {
             account_id: Some(proven_tx.account_id().into()),
             nullifiers: proven_tx.get_nullifiers().map(Into::into).collect(),
@@ -163,20 +164,14 @@ impl StoreClient {
         debug!(target: COMPONENT, ?message);
 
         let request = tonic::Request::new(message);
-        let response = self
-            .inner
-            .clone()
-            .get_transaction_inputs(request)
-            .await
-            .map_err(|status| TxInputsError::GrpcClientError(status.message().to_string()))?
-            .into_inner();
+        let response = self.inner.clone().get_transaction_inputs(request).await?.into_inner();
 
         debug!(target: COMPONENT, ?response);
 
         let tx_inputs: TransactionInputs = response.try_into()?;
 
         if tx_inputs.account_id != proven_tx.account_id() {
-            return Err(TxInputsError::MalformedResponse(format!(
+            return Err(StoreError::MalformedResponse(format!(
                 "incorrect account id returned from store. Got: {}, expected: {}",
                 tx_inputs.account_id,
                 proven_tx.account_id()
@@ -194,35 +189,22 @@ impl StoreClient {
         updated_accounts: impl Iterator<Item = AccountId> + Send,
         produced_nullifiers: impl Iterator<Item = &Nullifier> + Send,
         notes: impl Iterator<Item = &NoteId> + Send,
-    ) -> Result<BlockInputs, BlockInputsError> {
+    ) -> Result<BlockInputs, StoreError> {
         let request = tonic::Request::new(GetBlockInputsRequest {
             account_ids: updated_accounts.map(Into::into).collect(),
             nullifiers: produced_nullifiers.map(digest::Digest::from).collect(),
             unauthenticated_notes: notes.map(digest::Digest::from).collect(),
         });
 
-        let store_response = self
-            .inner
-            .clone()
-            .get_block_inputs(request)
-            .await
-            .map_err(|err| BlockInputsError::GrpcClientError(err.message().to_string()))?
-            .into_inner();
+        let store_response = self.inner.clone().get_block_inputs(request).await?.into_inner();
 
-        store_response.try_into()
+        store_response.try_into().map_err(Into::into)
     }
 
     #[instrument(target = "miden-block-producer", skip_all, err)]
-    pub async fn apply_block(&self, block: &Block) -> Result<(), ApplyBlockError> {
+    pub async fn apply_block(&self, block: &Block) -> Result<(), StoreError> {
         let request = tonic::Request::new(ApplyBlockRequest { block: block.to_bytes() });
 
-        let _ = self
-            .inner
-            .clone()
-            .apply_block(request)
-            .await
-            .map_err(|status| ApplyBlockError::GrpcClientError(status.message().to_string()))?;
-
-        Ok(())
+        self.inner.clone().apply_block(request).await.map(|_| ()).map_err(Into::into)
     }
 }

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -131,6 +131,7 @@ impl StoreClient {
     }
 
     /// Returns the latest block's header from the store.
+    #[instrument(target = "miden-block-producer", skip_all, err)]
     pub async fn latest_header(&self) -> Result<BlockHeader, String> {
         // TODO: Consolidate the error types returned by the store (and its trait).
         let response = self
@@ -187,6 +188,7 @@ impl StoreClient {
         Ok(tx_inputs)
     }
 
+    #[instrument(target = "miden-block-producer", skip_all, err)]
     pub async fn get_block_inputs(
         &self,
         updated_accounts: impl Iterator<Item = AccountId> + Send,

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -121,13 +121,13 @@ impl TryFrom<GetTransactionInputsResponse> for TransactionInputs {
 /// Essentially just a thin wrapper around the generated gRPC client which improves type safety.
 #[derive(Clone)]
 pub struct StoreClient {
-    store: store_client::ApiClient<Channel>,
+    inner: store_client::ApiClient<Channel>,
 }
 
 impl StoreClient {
     /// TODO: this should probably take store connection string and create a connection internally
     pub fn new(store: store_client::ApiClient<Channel>) -> Self {
-        Self { store }
+        Self { inner: store }
     }
 
     /// Returns the latest block's header from the store.
@@ -135,7 +135,7 @@ impl StoreClient {
     pub async fn latest_header(&self) -> Result<BlockHeader, String> {
         // TODO: Consolidate the error types returned by the store (and its trait).
         let response = self
-            .store
+            .inner
             .clone()
             .get_block_header_by_number(tonic::Request::new(Default::default()))
             .await
@@ -164,7 +164,7 @@ impl StoreClient {
 
         let request = tonic::Request::new(message);
         let response = self
-            .store
+            .inner
             .clone()
             .get_transaction_inputs(request)
             .await
@@ -202,7 +202,7 @@ impl StoreClient {
         });
 
         let store_response = self
-            .store
+            .inner
             .clone()
             .get_block_inputs(request)
             .await
@@ -217,7 +217,7 @@ impl StoreClient {
         let request = tonic::Request::new(ApplyBlockRequest { block: block.to_bytes() });
 
         let _ = self
-            .store
+            .inner
             .clone()
             .apply_block(request)
             .await

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -18,7 +18,8 @@ use super::*;
 use crate::{
     batch_builder::TransactionBatch,
     block::{AccountWitness, BlockInputs},
-    store::{ApplyBlockError, BlockInputsError, TransactionInputs, TxInputsError},
+    errors::StoreError,
+    store::TransactionInputs,
     test_utils::block::{
         block_output_notes, flatten_output_notes, note_created_smt_from_note_batches,
     },
@@ -183,7 +184,7 @@ impl MockStoreSuccess {
         locked_accounts.root()
     }
 
-    pub async fn apply_block(&self, block: &Block) -> Result<(), ApplyBlockError> {
+    pub async fn apply_block(&self, block: &Block) -> Result<(), StoreError> {
         // Intentionally, we take and hold both locks, to prevent calls to `get_tx_inputs()` from
         // going through while we're updating the store's data structure
         let mut locked_accounts = self.accounts.write().await;
@@ -238,7 +239,7 @@ impl MockStoreSuccess {
     pub async fn get_tx_inputs(
         &self,
         proven_tx: &ProvenTransaction,
-    ) -> Result<TransactionInputs, TxInputsError> {
+    ) -> Result<TransactionInputs, StoreError> {
         let locked_accounts = self.accounts.read().await;
         let locked_produced_nullifiers = self.produced_nullifiers.read().await;
 
@@ -286,7 +287,7 @@ impl MockStoreSuccess {
         updated_accounts: impl Iterator<Item = AccountId> + Send,
         produced_nullifiers: impl Iterator<Item = &Nullifier> + Send,
         notes: impl Iterator<Item = &NoteId> + Send,
-    ) -> Result<BlockInputs, BlockInputsError> {
+    ) -> Result<BlockInputs, StoreError> {
         let locked_accounts = self.accounts.read().await;
         let locked_produced_nullifiers = self.produced_nullifiers.read().await;
 

--- a/crates/proto/src/errors.rs
+++ b/crates/proto/src/errors.rs
@@ -26,6 +26,8 @@ pub enum ConversionError {
         entity: &'static str,
         field_name: &'static str,
     },
+    #[error("MMR error: {0}")]
+    MmrError(#[from] miden_objects::crypto::merkle::MmrError),
 }
 
 pub trait MissingFieldHelper {


### PR DESCRIPTION
This PR instruments the `StoreClient` API (follow-up task from #571), and also consolidates the errors into a single `StoreError` variant.

We should also create an issue for adapting the error guidelines discussed in https://github.com/0xPolygonMiden/miden-base/discussions/966.