### PR TITLE
chore: remove miette dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,10 +1607,10 @@ dependencies = [
 name = "miden-node-proto"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "hex",
  "miden-node-utils",
  "miden-objects",
- "miette",
  "proptest",
  "prost",
  "prost-build",
@@ -1792,16 +1792,8 @@ version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap",
  "thiserror 1.0.68",
  "unicode-width 0.1.14",
 ]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -23,7 +23,7 @@ tonic = { workspace = true }
 proptest = { version = "1.5" }
 
 [build-dependencies]
-miette = { version = "7.2", features = ["fancy"] }
+anyhow = { version = "1.0" }
 prost = { workspace = true }
 prost-build = { version = "0.13" }
 protox = { version = "0.7" }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -3,14 +3,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use miette::IntoDiagnostic;
+use anyhow::Context;
 use protox::prost::Message;
 
 /// Generates Rust protobuf bindings from .proto files in the root directory.
 ///
 /// This is done only if BUILD_PROTO environment variable is set to `1` to avoid running the script
 /// on crates.io where repo-level .proto files are not available.
-fn main() -> miette::Result<()> {
+fn main() -> anyhow::Result<()> {
     println!("cargo::rerun-if-changed=../../proto");
     println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 
@@ -24,21 +24,21 @@ fn main() -> miette::Result<()> {
     let dst_dir = crate_root.join("src").join("generated");
 
     // Remove all existing files.
-    fs::remove_dir_all(&dst_dir).into_diagnostic()?;
-    fs::create_dir(&dst_dir).into_diagnostic()?;
+    fs::remove_dir_all(&dst_dir).context("removing existing files")?;
+    fs::create_dir(&dst_dir).context("creating destination folder")?;
 
     // Compute the directory of the `proto` definitions
-    let cwd: PathBuf = env::current_dir().into_diagnostic()?;
+    let cwd: PathBuf = env::current_dir().context("current directory")?;
 
     let cwd = cwd
         .parent()
         .and_then(|p| p.parent())
-        .ok_or_else(|| miette::miette!("Failed to navigate two directories up"))?;
+        .context("navigating to grandparent directory")?;
 
     let proto_dir: PathBuf = cwd.join("proto");
 
     // Compute the compiler's target file path.
-    let out = env::var("OUT_DIR").into_diagnostic()?;
+    let out = env::var("OUT_DIR").context("env::OUT_DIR not set")?;
     let file_descriptor_path = PathBuf::from(out).join("file_descriptor_set.bin");
 
     // Compile the proto file for all servers APIs
@@ -49,7 +49,8 @@ fn main() -> miette::Result<()> {
     ];
     let includes = &[proto_dir];
     let file_descriptors = protox::compile(protos, includes)?;
-    fs::write(&file_descriptor_path, file_descriptors.encode_to_vec()).into_diagnostic()?;
+    fs::write(&file_descriptor_path, file_descriptors.encode_to_vec())
+        .context("writing file descriptors")?;
 
     let mut prost_config = prost_build::Config::new();
     prost_config.skip_debug(["AccountId", "Digest"]);
@@ -60,9 +61,9 @@ fn main() -> miette::Result<()> {
         .skip_protoc_run()
         .out_dir(&dst_dir)
         .compile_protos_with_config(prost_config, protos, includes)
-        .into_diagnostic()?;
+        .context("compiling protobufs")?;
 
-    generate_mod_rs(&dst_dir).into_diagnostic()?;
+    generate_mod_rs(&dst_dir).context("generating mod.rs")?;
 
     Ok(())
 }


### PR DESCRIPTION
Remove the final remnants of `miette` by replacing its usage in `proto::build.rs` with `anyhow`.

Motivation is to minimize our direct dependencies and there is not really an argument for `miette` as we don't have any source code errors to display.