### PR TITLE
refactor(block-producer): replace BatchJobId with BatchId

### DIFF
--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use miden_node_proto::domain::notes::NoteAuthenticationInfo;
+use miden_node_utils::formatting::format_blake3_digest;
 use miden_objects::{
     accounts::{delta::AccountUpdateDetails, AccountId},
     batches::BatchNoteTree,
@@ -16,22 +17,32 @@ use tracing::instrument;
 
 use crate::errors::BuildBatchError;
 
-pub type BatchId = Blake3Digest<32>;
-
-// TRANSACTION BATCH
+// BATCH ID
 // ================================================================================================
 
-/// A batch of transactions that share a common proof.
-///
-/// Note: Until recursive proofs are available in the Miden VM, we don't include the common proof.
+/// Uniquely identifies a [TransactionBatch].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TransactionBatch {
-    id: BatchId,
-    updated_accounts: BTreeMap<AccountId, AccountUpdate>,
-    input_notes: Vec<InputNoteCommitment>,
-    output_notes_smt: BatchNoteTree,
-    output_notes: Vec<OutputNote>,
+pub struct BatchId(Blake3Digest<32>);
+
+impl BatchId {
+    /// Calculates a batch ID from the given set of transactions.
+    pub fn compute(txs: impl Iterator<Item = TransactionId>) -> Self {
+        let mut buf = Vec::with_capacity(32 * txs.size_hint().0);
+        for tx in txs {
+            buf.extend_from_slice(&tx.as_bytes());
+        }
+        Self(Blake3_256::hash(&buf))
+    }
 }
+
+impl std::fmt::Display for BatchId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format_blake3_digest(self.0))
+    }
+}
+
+// ACCOUNT UPDATE
+// ================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountUpdate {
@@ -66,6 +77,21 @@ impl AccountUpdate {
     }
 }
 
+// TRANSACTION BATCH
+// ================================================================================================
+
+/// A batch of transactions that share a common proof.
+///
+/// Note: Until recursive proofs are available in the Miden VM, we don't include the common proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionBatch {
+    id: BatchId,
+    updated_accounts: BTreeMap<AccountId, AccountUpdate>,
+    input_notes: Vec<InputNoteCommitment>,
+    output_notes_smt: BatchNoteTree,
+    output_notes: Vec<OutputNote>,
+}
+
 impl TransactionBatch {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
@@ -93,7 +119,7 @@ impl TransactionBatch {
         I: Iterator<Item = &'a ProvenTransaction> + Clone,
     {
         let tx_iter = txs.into_iter();
-        let id = Self::compute_id(tx_iter.clone());
+        let id = BatchId::compute(tx_iter.clone().map(ProvenTransaction::id));
 
         // Populate batch output notes and updated accounts.
         let mut output_notes = OutputNoteTracker::new(tx_iter.clone())?;
@@ -174,8 +200,8 @@ impl TransactionBatch {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the batch ID.
-    pub fn id(&self) -> BatchId {
-        self.id
+    pub fn id(&self) -> &BatchId {
+        &self.id
     }
 
     /// Returns an iterator over (account_id, init_state_hash) tuples for accounts that were
@@ -213,17 +239,6 @@ impl TransactionBatch {
     /// Returns output notes list.
     pub fn output_notes(&self) -> &Vec<OutputNote> {
         &self.output_notes
-    }
-
-    // HELPER FUNCTIONS
-    // --------------------------------------------------------------------------------------------
-
-    fn compute_id<'a>(txs: impl Iterator<Item = &'a ProvenTransaction>) -> BatchId {
-        let mut buf = Vec::with_capacity(32 * txs.size_hint().0);
-        for tx in txs {
-            buf.extend_from_slice(&tx.id().as_bytes());
-        }
-        Blake3_256::hash(&buf)
     }
 }
 

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -37,11 +37,6 @@ impl BatchId {
         }
         Self(Blake3_256::hash(&buf))
     }
-
-    #[cfg(test)]
-    pub fn new(x: u64) -> Self {
-        Self(Blake3_256::hash(&x.to_le_bytes()))
-    }
 }
 
 impl std::fmt::Display for BatchId {

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -1,13 +1,13 @@
 use std::{num::NonZeroUsize, ops::Range, time::Duration};
 
+use batch::BatchId;
 use rand::Rng;
 use tokio::{task::JoinSet, time};
 use tracing::{debug, info, instrument, Span};
 
 use crate::{
-    domain::transaction::AuthenticatedTransaction,
-    mempool::{BatchJobId, SharedMempool},
-    COMPONENT, SERVER_BUILD_BATCH_FREQUENCY,
+    domain::transaction::AuthenticatedTransaction, mempool::SharedMempool, COMPONENT,
+    SERVER_BUILD_BATCH_FREQUENCY,
 };
 
 pub mod batch;
@@ -91,8 +91,8 @@ impl BatchBuilder {
                             tracing::warn!(%batch_id, %err, "Batch job failed.");
                             mempool.batch_failed(batch_id);
                         },
-                        Ok((batch_id, batch)) => {
-                            mempool.batch_proved(batch_id, batch);
+                        Ok(batch) => {
+                            mempool.batch_proved(batch);
                         }
                     }
                 }
@@ -104,7 +104,7 @@ impl BatchBuilder {
 // BATCH WORKER
 // ================================================================================================
 
-type BatchResult = Result<(BatchJobId, TransactionBatch), (BatchJobId, BuildBatchError)>;
+type BatchResult = Result<TransactionBatch, (BatchId, BuildBatchError)>;
 
 /// Represents a pool of batch provers.
 ///
@@ -121,7 +121,7 @@ struct WorkerPool {
     /// This allows us to map panic'd tasks to the job ID. Uses [Vec] because the task ID does not
     /// implement [Ord]. Given that the expected capacity is relatively low, this has no real
     /// impact beyond ergonomics.
-    task_map: Vec<(tokio::task::Id, BatchJobId)>,
+    task_map: Vec<(tokio::task::Id, BatchId)>,
 }
 
 impl WorkerPool {
@@ -171,10 +171,10 @@ impl WorkerPool {
         // Cleanup task mapping by removing the result's task. This is inefficient but does not
         // matter as the capacity is expected to be low.
         let job_id = match &result {
-            Ok((id, _)) => id,
-            Err((id, _)) => id,
+            Ok(batch) => batch.id(),
+            Err((id, _)) => *id,
         };
-        self.task_map.retain(|(_, elem_job_id)| elem_job_id != job_id);
+        self.task_map.retain(|(_, elem_job_id)| *elem_job_id != job_id);
 
         result
     }
@@ -192,7 +192,7 @@ impl WorkerPool {
     /// [has_capacity](Self::has_capacity).
     fn spawn(
         &mut self,
-        id: BatchJobId,
+        id: BatchId,
         transactions: Vec<AuthenticatedTransaction>,
     ) -> Result<(), ()> {
         if !self.has_capacity() {
@@ -224,7 +224,7 @@ impl WorkerPool {
 
                     tracing::debug!("Batch proof completed.");
 
-                    Ok((id, batch))
+                    Ok(batch)
                 }
             })
             .id();

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 
 pub mod batch;
 pub use batch::TransactionBatch;
-use miden_node_utils::formatting::{format_array, format_blake3_digest};
+use miden_node_utils::formatting::format_array;
 
 use crate::errors::BuildBatchError;
 
@@ -247,7 +247,7 @@ impl WorkerPool {
         // TODO: Found unauthenticated notes are no longer required.. potentially?
         let batch = TransactionBatch::new(txs, Default::default())?;
 
-        Span::current().record("batch_id", format_blake3_digest(batch.id()));
+        Span::current().record("batch_id", batch.id().to_string());
         info!(target: COMPONENT, "Transaction batch built");
 
         Ok(batch)

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -69,7 +69,6 @@ impl BlockBuilder {
             interval.tick().await;
 
             let (block_number, batches) = mempool.lock().await.select_block();
-            let batches = batches.into_iter().map(|(_, batch)| batch).collect::<Vec<_>>();
 
             let mut result = self.build_block(&batches).await;
             let proving_duration = rand::thread_rng().gen_range(self.simulated_proof_time.clone());

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, ops::Range};
 
-use miden_node_utils::formatting::{format_array, format_blake3_digest};
+use miden_node_utils::formatting::format_array;
 use miden_objects::{
     accounts::AccountId,
     block::Block,
@@ -96,7 +96,7 @@ impl BlockBuilder {
         info!(
             target: COMPONENT,
             num_batches = batches.len(),
-            batches = %format_array(batches.iter().map(|batch| format_blake3_digest(batch.id()))),
+            batches = %format_array(batches.iter().map(|batch| batch.id())),
         );
 
         let updated_account_set: BTreeSet<AccountId> = batches

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -9,34 +9,16 @@ use tokio::sync::Mutex;
 use transaction_graph::TransactionGraph;
 
 use crate::{
-    batch_builder::batch::TransactionBatch, domain::transaction::AuthenticatedTransaction,
-    errors::AddTransactionError, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
+    batch_builder::batch::{BatchId, TransactionBatch},
+    domain::transaction::AuthenticatedTransaction,
+    errors::AddTransactionError,
+    SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
 };
 
 mod batch_graph;
 mod graph;
 mod inflight_state;
 mod transaction_graph;
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct BatchJobId(u64);
-
-impl Display for BatchJobId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl BatchJobId {
-    pub fn increment(&mut self) {
-        self.0 += 1;
-    }
-
-    #[cfg(test)]
-    pub fn new(value: u64) -> Self {
-        Self(value)
-    }
-}
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BlockNumber(u32);
@@ -186,14 +168,11 @@ pub struct Mempool {
     /// Inflight batches.
     batches: BatchGraph,
 
-    /// The next batches ID.
-    next_batch_id: BatchJobId,
-
     /// The current block height of the chain.
     chain_tip: BlockNumber,
 
     /// The current inflight block, if any.
-    block_in_progress: Option<BTreeSet<BatchJobId>>,
+    block_in_progress: Option<BTreeSet<BatchId>>,
 
     block_budget: BlockBudget,
     batch_budget: BatchBudget,
@@ -224,7 +203,6 @@ impl Mempool {
             block_in_progress: Default::default(),
             transactions: Default::default(),
             batches: Default::default(),
-            next_batch_id: Default::default(),
         }
     }
 
@@ -256,15 +234,13 @@ impl Mempool {
     /// Transactions are returned in a valid execution ordering.
     ///
     /// Returns `None` if no transactions are available.
-    pub fn select_batch(&mut self) -> Option<(BatchJobId, Vec<AuthenticatedTransaction>)> {
+    pub fn select_batch(&mut self) -> Option<(BatchId, Vec<AuthenticatedTransaction>)> {
         let (batch, parents) = self.transactions.select_batch(self.batch_budget);
         if batch.is_empty() {
             return None;
         }
-        let tx_ids = batch.iter().map(AuthenticatedTransaction::id).collect();
-
-        let batch_id = self.next_batch_id;
-        self.next_batch_id.increment();
+        let tx_ids = batch.iter().map(AuthenticatedTransaction::id).collect::<Vec<_>>();
+        let batch_id = BatchId::compute(tx_ids.iter());
 
         self.batches
             .insert(batch_id, tx_ids, parents)
@@ -276,7 +252,7 @@ impl Mempool {
     /// Drops the failed batch and all of its descendants.
     ///
     /// Transactions are placed back in the queue.
-    pub fn batch_failed(&mut self, batch: BatchJobId) {
+    pub fn batch_failed(&mut self, batch: BatchId) {
         // Batch may already have been removed as part of a parent batches failure.
         if !self.batches.contains(&batch) {
             return;
@@ -299,13 +275,13 @@ impl Mempool {
     }
 
     /// Marks a batch as proven if it exists.
-    pub fn batch_proved(&mut self, batch_id: BatchJobId, batch: TransactionBatch) {
+    pub fn batch_proved(&mut self, batch: TransactionBatch) {
         // Batch may have been removed as part of a parent batches failure.
-        if !self.batches.contains(&batch_id) {
+        if !self.batches.contains(&batch.id()) {
             return;
         }
 
-        self.batches.submit_proof(batch_id, batch).expect("Batch proof should submit");
+        self.batches.submit_proof(batch).expect("Batch proof should submit");
     }
 
     /// Select batches for the next block.
@@ -317,11 +293,11 @@ impl Mempool {
     /// # Panics
     ///
     /// Panics if there is already a block in flight.
-    pub fn select_block(&mut self) -> (BlockNumber, Vec<(BatchJobId, TransactionBatch)>) {
+    pub fn select_block(&mut self) -> (BlockNumber, Vec<TransactionBatch>) {
         assert!(self.block_in_progress.is_none(), "Cannot have two blocks inflight.");
 
         let batches = self.batches.select_block(self.block_budget);
-        self.block_in_progress = Some(batches.iter().map(|(id, _)| *id).collect());
+        self.block_in_progress = Some(batches.iter().map(TransactionBatch::id).collect());
 
         (self.chain_tip.next(), batches)
     }
@@ -405,7 +381,7 @@ mod tests {
         assert_eq!(batch_txs, vec![txs[1].clone()]);
 
         uut.add_transaction(txs[2].clone()).unwrap();
-        let (child_batch_b, batch_txs) = uut.select_batch().unwrap();
+        let (_, batch_txs) = uut.select_batch().unwrap();
         assert_eq!(batch_txs, vec![txs[2].clone()]);
 
         // Child batch jobs are now dangling.
@@ -418,7 +394,7 @@ mod tests {
 
         let proof =
             TransactionBatch::new([txs[2].raw_proven_transaction()], Default::default()).unwrap();
-        uut.batch_proved(child_batch_b, proof);
+        uut.batch_proved(proof);
         assert_eq!(uut, reference);
     }
 
@@ -444,8 +420,6 @@ mod tests {
         reference.select_batch().unwrap();
         reference.add_transaction(txs[1].clone()).unwrap();
         reference.add_transaction(txs[2].clone()).unwrap();
-        reference.next_batch_id.increment();
-        reference.next_batch_id.increment();
 
         assert_eq!(uut, reference);
     }

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -240,11 +240,8 @@ impl Mempool {
             return None;
         }
         let tx_ids = batch.iter().map(AuthenticatedTransaction::id).collect::<Vec<_>>();
-        let batch_id = BatchId::compute(tx_ids.iter());
 
-        self.batches
-            .insert(batch_id, tx_ids, parents)
-            .expect("Selected batch should insert");
+        let batch_id = self.batches.insert(tx_ids, parents).expect("Selected batch should insert");
 
         Some((batch_id, batch))
     }


### PR DESCRIPTION
This PR replaces the `BatchId` type alias with a new type, and then uses this instead of `BatchJobId` to track batches within the mempool. This will prepare us for when such a ty

I have reservations about doing this as it forces the computation of `BatchId` to occur within the mempool's lock. Since this is hash over all transaction IDs this will be computationally expensive especially in comparison to all other operations in the mempool. 

Completes a task in #519 (Use a more correct BatchId)