### PR TITLE
feat(block-producer): instrument mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,9 +3200,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3212,9 +3212,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3223,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -14,7 +14,7 @@ use miden_objects::{
 };
 use tracing::instrument;
 
-use crate::errors::BuildBatchError;
+use crate::{errors::BuildBatchError, COMPONENT};
 
 pub type BatchId = Blake3Digest<32>;
 
@@ -84,7 +84,7 @@ impl TransactionBatch {
     /// - There are duplicated output notes or unauthenticated notes found across all transactions
     ///   in the batch.
     /// - Hashes for corresponding input notes and output notes don't match.
-    #[instrument(target = "miden-block-producer", name = "new_batch", skip_all, err)]
+    #[instrument(target = COMPONENT, name = "new_batch", skip_all, err)]
     pub fn new<'a, I>(
         txs: impl IntoIterator<Item = &'a ProvenTransaction, IntoIter = I>,
         found_unauthenticated_notes: NoteAuthenticationInfo,

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -234,7 +234,7 @@ impl WorkerPool {
         Ok(())
     }
 
-    #[instrument(target = "miden-block-producer", skip_all, err, fields(batch_id))]
+    #[instrument(target = COMPONENT, skip_all, err, fields(batch_id))]
     fn build_batch(
         txs: Vec<AuthenticatedTransaction>,
     ) -> Result<TransactionBatch, BuildBatchError> {

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -91,7 +91,7 @@ impl BlockBuilder {
         }
     }
 
-    #[instrument(target = "miden-block-producer", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     async fn build_block(&self, batches: &[TransactionBatch]) -> Result<(), BuildBlockError> {
         info!(
             target: COMPONENT,

--- a/crates/block-producer/src/server/api.rs
+++ b/crates/block-producer/src/server/api.rs
@@ -35,7 +35,7 @@ where
     BB: BatchBuilder,
 {
     #[instrument(
-        target = "miden-block-producer",
+        target = COMPONENT,
         name = "block_producer:submit_proven_transaction",
         skip_all,
         err

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -201,7 +201,7 @@ impl BlockProducerRpcServer {
     }
 
     #[instrument(
-        target = "miden-block-producer",
+        target = COMPONENT,
         name = "block_producer:submit_proven_transaction",
         skip_all,
         err

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -138,7 +138,7 @@ impl<S> ApplyBlock for DefaultStateView<S>
 where
     S: Store,
 {
-    #[instrument(target = "miden-block-producer", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     async fn apply_block(&self, block: &Block) -> Result<(), ApplyBlockError> {
         self.store.apply_block(block).await?;
 
@@ -179,7 +179,7 @@ where
 /// - all notes in `tx_notes_not_in_store` are currently in flight
 ///
 /// The account state is not verified as it is performed by [InflightAccountStates].
-#[instrument(target = "miden-block-producer", skip_all, err)]
+#[instrument(target = COMPONENT, skip_all, err)]
 fn ensure_in_flight_constraints(
     candidate_tx: &ProvenTransaction,
     accounts_in_flight: &InflightAccountStates,
@@ -225,7 +225,7 @@ fn ensure_in_flight_constraints(
 /// - input notes must not be already consumed
 ///
 /// Returns a list of unauthenticated input notes that were not found in the store.
-#[instrument(target = "miden-block-producer", skip_all, err)]
+#[instrument(target = COMPONENT, skip_all, err)]
 fn ensure_tx_inputs_constraints(
     candidate_tx: &ProvenTransaction,
     tx_inputs: TransactionInputs,

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -144,7 +144,7 @@ impl StoreClient {
         BlockHeader::try_from(response.block_header.unwrap()).map_err(|err| err.to_string())
     }
 
-    #[instrument(target = "miden-block-producer", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     pub async fn get_tx_inputs(
         &self,
         proven_tx: &ProvenTransaction,
@@ -210,7 +210,7 @@ impl StoreClient {
         store_response.try_into()
     }
 
-    #[instrument(target = "miden-block-producer", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     pub async fn apply_block(&self, block: &Block) -> Result<(), ApplyBlockError> {
         let request = tonic::Request::new(ApplyBlockRequest { block: block.to_bytes() });
 

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -59,7 +59,7 @@ impl RpcApi {
 #[tonic::async_trait]
 impl api_server::Api for RpcApi {
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:check_nullifiers",
         skip_all,
         ret(level = "debug"),
@@ -82,7 +82,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:check_nullifiers_by_prefix",
         skip_all,
         ret(level = "debug"),
@@ -98,7 +98,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:get_block_header_by_number",
         skip_all,
         ret(level = "debug"),
@@ -114,7 +114,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:sync_state",
         skip_all,
         ret(level = "debug"),
@@ -130,7 +130,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:sync_notes",
         skip_all,
         ret(level = "debug"),
@@ -146,7 +146,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:get_notes_by_id",
         skip_all,
         ret(level = "debug"),
@@ -167,7 +167,7 @@ impl api_server::Api for RpcApi {
         self.store.clone().get_notes_by_id(request).await
     }
 
-    #[instrument(target = "miden-rpc", name = "rpc:submit_proven_transaction", skip_all, err)]
+    #[instrument(target = COMPONENT, name = "rpc:submit_proven_transaction", skip_all, err)]
     async fn submit_proven_transaction(
         &self,
         request: Request<SubmitProvenTransactionRequest>,
@@ -190,7 +190,7 @@ impl api_server::Api for RpcApi {
 
     /// Returns details for public (public) account by id.
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:get_account_details",
         skip_all,
         ret(level = "debug"),
@@ -214,7 +214,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:get_block_by_number",
         skip_all,
         ret(level = "debug"),
@@ -232,7 +232,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:get_account_state_delta",
         skip_all,
         ret(level = "debug"),
@@ -250,7 +250,7 @@ impl api_server::Api for RpcApi {
     }
 
     #[instrument(
-        target = "miden-rpc",
+        target = COMPONENT,
         name = "rpc:get_account_proofs",
         skip_all,
         ret(level = "debug"),

--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -24,7 +24,7 @@ fn up(s: &'static str) -> M<'static> {
 const DB_MIGRATION_HASH_FIELD: &str = "db-migration-hash";
 const DB_SCHEMA_VERSION_FIELD: &str = "db-schema-version";
 
-#[instrument(target = "miden-store", skip_all, err)]
+#[instrument(target = COMPONENT, skip_all, err)]
 pub fn apply_migrations(conn: &mut Connection) -> super::Result<()> {
     let version_before = MIGRATIONS.current_version(conn)?;
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -132,7 +132,7 @@ impl Db {
     /// Open a connection to the DB, apply any pending migrations, and ensure that the genesis block
     /// is as expected and present in the database.
     // TODO: This span is logged in a root span, we should connect it to the parent one.
-    #[instrument(target = "miden-store", skip_all)]
+    #[instrument(target = COMPONENT, skip_all)]
     pub async fn setup(
         config: StoreConfig,
         block_store: Arc<BlockStore>,
@@ -199,7 +199,7 @@ impl Db {
     }
 
     /// Loads all the nullifiers from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_nullifiers(&self) -> Result<Vec<(Nullifier, BlockNumber)>> {
         self.pool
             .get()
@@ -212,7 +212,7 @@ impl Db {
     }
 
     /// Loads the nullifiers that match the prefixes from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_nullifiers_by_prefix(
         &self,
         prefix_len: u32,
@@ -233,7 +233,7 @@ impl Db {
     }
 
     /// Loads all the notes from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_notes(&self) -> Result<Vec<NoteRecord>> {
         self.pool.get().await?.interact(sql::select_all_notes).await.map_err(|err| {
             DatabaseError::InteractError(format!("Select notes task failed: {err}"))
@@ -241,7 +241,7 @@ impl Db {
     }
 
     /// Loads all the accounts from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_accounts(&self) -> Result<Vec<AccountInfo>> {
         self.pool.get().await?.interact(sql::select_all_accounts).await.map_err(|err| {
             DatabaseError::InteractError(format!("Select accounts task failed: {err}"))
@@ -251,7 +251,7 @@ impl Db {
     /// Search for a [BlockHeader] from the database by its `block_num`.
     ///
     /// When `block_number` is [None], the latest block header is returned.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_block_header_by_block_num(
         &self,
         block_number: Option<BlockNumber>,
@@ -267,7 +267,7 @@ impl Db {
     }
 
     /// Loads multiple block headers from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_block_headers(&self, blocks: Vec<BlockNumber>) -> Result<Vec<BlockHeader>> {
         self.pool
             .get()
@@ -282,7 +282,7 @@ impl Db {
     }
 
     /// Loads all the block headers from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_block_headers(&self) -> Result<Vec<BlockHeader>> {
         self.pool
             .get()
@@ -295,7 +295,7 @@ impl Db {
     }
 
     /// Loads all the account hashes from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_account_hashes(&self) -> Result<Vec<(AccountId, RpoDigest)>> {
         self.pool
             .get()
@@ -308,7 +308,7 @@ impl Db {
     }
 
     /// Loads public account details from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_account(&self, id: AccountId) -> Result<AccountInfo> {
         self.pool
             .get()
@@ -321,7 +321,7 @@ impl Db {
     }
 
     /// Loads public accounts details from the DB.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_accounts_by_ids(
         &self,
         account_ids: Vec<AccountId>,
@@ -336,7 +336,7 @@ impl Db {
             })?
     }
 
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn get_state_sync(
         &self,
         block_num: BlockNumber,
@@ -357,7 +357,7 @@ impl Db {
             })?
     }
 
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn get_note_sync(
         &self,
         block_num: BlockNumber,
@@ -375,7 +375,7 @@ impl Db {
     }
 
     /// Loads all the Note's matching a certain NoteId from the database.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_notes_by_id(&self, note_ids: Vec<NoteId>) -> Result<Vec<NoteRecord>> {
         self.pool
             .get()
@@ -388,7 +388,7 @@ impl Db {
     }
 
     /// Loads inclusion proofs for notes matching the given IDs.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_note_inclusion_proofs(
         &self,
         note_ids: BTreeSet<NoteId>,
@@ -406,7 +406,7 @@ impl Db {
     }
 
     /// Loads all note IDs matching a certain NoteId from the database.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_note_ids(&self, note_ids: Vec<NoteId>) -> Result<BTreeSet<NoteId>> {
         self.select_notes_by_id(note_ids)
             .await
@@ -418,7 +418,7 @@ impl Db {
     /// `allow_acquire` and `acquire_done` are used to synchronize writes to the DB with writes to
     /// the in-memory trees. Further details available on [super::state::State::apply_block].
     // TODO: This span is logged in a root span, we should connect it to the parent one.
-    #[instrument(target = "miden-store", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     pub async fn apply_block(
         &self,
         allow_acquire: oneshot::Sender<()>,
@@ -485,7 +485,7 @@ impl Db {
     /// If the database is empty, generates and stores the genesis block. Otherwise, it ensures that
     /// the genesis block in the database is consistent with the genesis block data in the
     /// genesis JSON file.
-    #[instrument(target = "miden-store", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     async fn ensure_genesis_block(
         &self,
         genesis_filepath: &str,

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -59,7 +59,7 @@ impl api_server::Api for StoreApi {
     ///
     /// If the block number is not provided, block header for the latest block is returned.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_block_header_by_number",
         skip_all,
         ret(level = "debug"),
@@ -91,7 +91,7 @@ impl api_server::Api for StoreApi {
     /// This endpoint also returns Merkle authentication path for each requested nullifier which can
     /// be verified against the latest root of the nullifier database.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:check_nullifiers",
         skip_all,
         ret(level = "debug"),
@@ -115,7 +115,7 @@ impl api_server::Api for StoreApi {
     ///
     /// Currently the only supported prefix length is 16 bits.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:check_nullifiers_by_prefix",
         skip_all,
         ret(level = "debug"),
@@ -148,7 +148,7 @@ impl api_server::Api for StoreApi {
     /// Returns info which can be used by the client to sync up to the latest state of the chain
     /// for the objects the client is interested in.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:sync_state",
         skip_all,
         ret(level = "debug"),
@@ -212,7 +212,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns info which can be used by the client to sync note state.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:sync_notes",
         skip_all,
         ret(level = "debug"),
@@ -244,7 +244,7 @@ impl api_server::Api for StoreApi {
     ///
     /// If the list is empty or no Note matched the requested NoteId and empty list is returned.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_notes_by_id",
         skip_all,
         ret(level = "debug"),
@@ -276,7 +276,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns a list of Note inclusion proofs for the specified NoteId's.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_note_inclusion_proofs",
         skip_all,
         ret(level = "debug"),
@@ -312,7 +312,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns details for public (public) account by id.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_account_details",
         skip_all,
         ret(level = "debug"),
@@ -340,7 +340,7 @@ impl api_server::Api for StoreApi {
 
     /// Updates the local DB by inserting a new block header and the related data.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:apply_block",
         skip_all,
         ret(level = "debug"),
@@ -376,7 +376,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns data needed by the block producer to construct and prove the next block.
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_block_inputs",
         skip_all,
         ret(level = "debug"),
@@ -402,7 +402,7 @@ impl api_server::Api for StoreApi {
     }
 
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_transaction_inputs",
         skip_all,
         ret(level = "debug"),
@@ -450,7 +450,7 @@ impl api_server::Api for StoreApi {
     }
 
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_block_by_number",
         skip_all,
         ret(level = "debug"),
@@ -470,7 +470,7 @@ impl api_server::Api for StoreApi {
     }
 
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_account_proofs",
         skip_all,
         ret(level = "debug"),
@@ -508,7 +508,7 @@ impl api_server::Api for StoreApi {
     }
 
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:get_account_state_delta",
         skip_all,
         ret(level = "debug"),
@@ -540,7 +540,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns a list of all nullifiers
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:list_nullifiers",
         skip_all,
         ret(level = "debug"),
@@ -563,7 +563,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns a list of all notes
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:list_notes",
         skip_all,
         ret(level = "debug"),
@@ -579,7 +579,7 @@ impl api_server::Api for StoreApi {
 
     /// Returns a list of all accounts
     #[instrument(
-        target = "miden-store",
+        target = COMPONENT,
         name = "store:list_accounts",
         skip_all,
         ret(level = "debug"),
@@ -607,7 +607,7 @@ fn invalid_argument<E: core::fmt::Display>(err: E) -> Status {
     Status::invalid_argument(err.to_string())
 }
 
-#[instrument(target = "miden-store", skip_all, err)]
+#[instrument(target = COMPONENT, skip_all, err)]
 fn validate_nullifiers(nullifiers: &[generated::digest::Digest]) -> Result<Vec<Nullifier>, Status> {
     nullifiers
         .iter()
@@ -617,7 +617,7 @@ fn validate_nullifiers(nullifiers: &[generated::digest::Digest]) -> Result<Vec<N
         .map_err(|_| invalid_argument("Digest field is not in the modulus range"))
 }
 
-#[instrument(target = "miden-store", skip_all, err)]
+#[instrument(target = COMPONENT, skip_all, err)]
 fn validate_notes(notes: &[generated::digest::Digest]) -> Result<Vec<NoteId>, Status> {
     notes
         .iter()

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -126,7 +126,7 @@ pub struct State {
 
 impl State {
     /// Loads the state from the `db`.
-    #[instrument(target = "miden-store", skip_all)]
+    #[instrument(target = COMPONENT, skip_all)]
     pub async fn load(
         mut db: Db,
         block_store: Arc<BlockStore>,
@@ -167,7 +167,7 @@ impl State {
     /// - the in-memory structures are updated, including the latest block pointer and the lock is
     ///   released.
     // TODO: This span is logged in a root span, we should connect it to the parent span.
-    #[instrument(target = "miden-store", skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err)]
     pub async fn apply_block(&self, block: Block) -> Result<(), ApplyBlockError> {
         let _lock = self.writer.try_lock().map_err(|_| ApplyBlockError::ConcurrentWrite)?;
 
@@ -377,7 +377,7 @@ impl State {
     ///
     /// If [None] is given as the value of `block_num`, the data for the latest [BlockHeader] is
     /// returned.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn get_block_header(
         &self,
         block_num: Option<BlockNumber>,
@@ -410,7 +410,7 @@ impl State {
     /// tree.
     ///
     /// Note: these proofs are invalidated once the nullifier tree is modified, i.e. on a new block.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"))]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"))]
     pub async fn check_nullifiers(&self, nullifiers: &[Nullifier]) -> Vec<SmtProof> {
         let inner = self.inner.read().await;
         nullifiers.iter().map(|n| inner.nullifier_tree.open(n)).collect()
@@ -502,7 +502,7 @@ impl State {
     ///   with any matches tags.
     /// - `nullifier_prefixes`: Only the 16 high bits of the nullifiers the client is interested in,
     ///   results will include nullifiers matching prefixes produced in the given block range.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn sync_state(
         &self,
         block_num: BlockNumber,
@@ -552,7 +552,7 @@ impl State {
     /// - `block_num`: The last block *known* by the client, updates start from the next block.
     /// - `note_tags`: The tags the client is interested in, resulting notes are restricted to the
     ///   first block containing a matching note.
-    #[instrument(target = "miden-store", skip_all, ret(level = "debug"), err)]
+    #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn sync_notes(
         &self,
         block_num: BlockNumber,
@@ -635,7 +635,7 @@ impl State {
     }
 
     /// Returns data needed by the block producer to verify transactions validity.
-    #[instrument(target = "miden-store", skip_all, ret)]
+    #[instrument(target = COMPONENT, skip_all, ret)]
     pub async fn get_transaction_inputs(
         &self,
         account_id: AccountId,
@@ -792,7 +792,7 @@ impl State {
 // UTILITIES
 // ================================================================================================
 
-#[instrument(target = "miden-store", skip_all)]
+#[instrument(target = COMPONENT, skip_all)]
 async fn load_nullifier_tree(db: &mut Db) -> Result<NullifierTree, StateInitializationError> {
     let nullifiers = db.select_all_nullifiers().await?;
     let len = nullifiers.len();
@@ -811,7 +811,7 @@ async fn load_nullifier_tree(db: &mut Db) -> Result<NullifierTree, StateInitiali
     Ok(nullifier_tree)
 }
 
-#[instrument(target = "miden-store", skip_all)]
+#[instrument(target = COMPONENT, skip_all)]
 async fn load_mmr(db: &mut Db) -> Result<Mmr, StateInitializationError> {
     let block_hashes: Vec<RpoDigest> =
         db.select_all_block_headers().await?.iter().map(BlockHeader::hash).collect();
@@ -819,7 +819,7 @@ async fn load_mmr(db: &mut Db) -> Result<Mmr, StateInitializationError> {
     Ok(block_hashes.into())
 }
 
-#[instrument(target = "miden-store", skip_all)]
+#[instrument(target = COMPONENT, skip_all)]
 async fn load_accounts(
     db: &mut Db,
 ) -> Result<SimpleSmt<ACCOUNT_TREE_DEPTH>, StateInitializationError> {


### PR DESCRIPTION
This PR adds tracing instrumentation to the mempool.

In addition, this PR also bumps `tracing` to v0.14 which now allows using constants for instrument targets. Before this we've had the unfortunate situation of using `target = COMPONENT` when emitting events, but having to manually set `target = miden-node-<xxx>` when using the `#[instrument]` macro. This PR fixes this; though I think our behaviour here could be improved.

Blocked by #577 as it refactors batch ID, and by #574 which added instrumentation which will require a minor tweak or two in this PR.

Closes a task in #519 