### PR TITLE
chore: move new changelog entries to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Support Https in endpoint configuration (#556).
+- Upgrade `block-producer` from FIFO queue to mempool dependency graph (#562).
+
 ## v0.6.0 (2024-11-05)
 
 ### Enhancements
 
 - Added `GetAccountProofs` endpoint (#506).
-- Support Https in endpoint configuration (#556).
-- Upgrade `block-producer` from FIFO queue to mempool dependency graph (#562).
 
 ### Changes
 


### PR DESCRIPTION
I've been appending them to the wrong section like a dummy :)

Wondering if I should add a CI check just to ensure there is always an unreleased section at the top as an enhancement to the changelog checker so I don't confuse myself.