### PR TITLE
perf: When using rand::random(), it's recommended to explicitly ensure that its seed source is sufficiently secure. In production environments, it may be necessary to switch to rand::rngs::OsRng to provide stronger randomness.

### DIFF
--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<()> {
             let current_dir =
                 std::env::current_dir().context("Failed to open current directory")?;
 
-            let mut rng = ChaCha20Rng::from_seed(rand::random());
+            let mut rng = ChaCha20Rng::from_seed(rand::rngs::OsRng);
 
             let secret = SecretKey::with_rng(&mut get_rpo_random_coin(&mut rng));
 


### PR DESCRIPTION
When using rand::random(), it's recommended to explicitly ensure that its seed source is sufficiently secure. In production environments, it may be necessary to switch to rand::rngs::OsRng to provide stronger randomness.