### PR TITLE
Update command in README to `--inputs-path` when creating genesis file

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Next, bootstrap the chain by generating the genesis data:
 
 ```sh
 miden-node make-genesis \
-  --input-path  <CONFIG>/genesis.toml \
+  --inputs-path  <CONFIG>/genesis.toml \
   --output-path <STORAGE>/genesis.dat
 ```
 


### PR DESCRIPTION
Was setting up the miden-node and came across this small issue in the README. This PR is to update command in README from `--input-path` to `--inputs-path`.

The command in the CLI: https://github.com/0xPolygonMiden/miden-node/blob/944d589bef23449dcb56f16702211c1699be4d5b/bin/node/src/main.rs#L50