### PR TITLE
feat(block-producer): catch up missed blocks instead of skipping

### DIFF
--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -63,7 +63,7 @@ impl BlockBuilder {
         );
 
         let mut interval = tokio::time::interval(self.block_interval);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
 
         loop {
             interval.tick().await;

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -63,6 +63,9 @@ impl BlockBuilder {
         );
 
         let mut interval = tokio::time::interval(self.block_interval);
+        // We set the inverval's missed tick behaviour to burst. This means we'll catch up missed
+        // blocks as fast as possible. In other words, we try our best to keep the desired block
+        // interval on average. The other options would result in at least one skipped block.
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
 
         loop {


### PR DESCRIPTION
This PR changes the behaviour when a block tick is missed from `Delay` to `Burst`.

#523 discusses this is slightly more detail:

> Burst will let us catch up lost blocks, but will have the least predictable block times while this is happening. Essentially blocks are produced as fast as possible.
>
> Skip will miss a block but keep the block publishing moment predictable. I'm not sure this matters.
>
> Delay means we only have a single slow block, and that block times are kept consistent.

`Burst` seems fine, and means we make the best attempt at the desired block interval on average.

Closed #523 