### PR TITLE
feat(block-producer): re-add batch inputs

### DIFF
--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -142,6 +142,9 @@ pub enum BuildBatchError {
 
     #[error("Batch proving task panic'd")]
     JoinError(#[from] tokio::task::JoinError),
+
+    #[error("Fetching inputs from store failed")]
+    StoreError(#[from] StoreError),
 }
 
 // Block prover errors

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -109,8 +109,9 @@ impl BlockProducer {
         let batch_builder_id = tasks
             .spawn({
                 let mempool = mempool.clone();
+                let store = store.clone();
                 async {
-                    batch_builder.run(mempool).await;
+                    batch_builder.run(mempool, store).await;
                     Ok(())
                 }
             })


### PR DESCRIPTION
This was removed as part of the mempool feature, but should not have been.

I've renamed the function `get_batch_inputs` and I'm wondering if we shouldn't rename the proto definition and domain object similarly?

I'm assuming there might be more input fields coming in the future so having it be more specific is ok?

Closes #566 