### PR TITLE
refactor(rpc): invert tx inputs missing notes to found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Support Https in endpoint configuration (#556).
 - Upgrade `block-producer` from FIFO queue to mempool dependency graph (#562).
 
+### Changes
+
+- [BREAKING] Inverted `TransactionInputs.missing_unauthenticated_notes` to `found_missing_notes` (#509). 
+
 ## v0.6.0 (2024-11-05)
 
 ### Enhancements

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -56,16 +56,9 @@ impl AuthenticatedTransaction {
             return Err(VerifyTxError::InputNotesAlreadyConsumed(nullifiers_already_spent));
         }
 
-        // Invert the missing notes; i.e. we now know the rest were actually found.
-        let authenticated_notes = tx
-            .get_unauthenticated_notes()
-            .map(|header| header.id())
-            .filter(|note_id| !inputs.missing_unauthenticated_notes.contains(note_id))
-            .collect();
-
         Ok(AuthenticatedTransaction {
             inner: Arc::new(tx),
-            notes_authenticated_by_store: authenticated_notes,
+            notes_authenticated_by_store: inputs.found_unauthenticated_notes,
             authentication_height: BlockNumber::new(inputs.current_block_height),
             store_account_state: inputs.account_hash,
         })
@@ -137,10 +130,7 @@ impl AuthenticatedTransaction {
             account_id: inner.account_id(),
             account_hash: store_account_state,
             nullifiers: inner.get_nullifiers().map(|nullifier| (nullifier, None)).collect(),
-            missing_unauthenticated_notes: inner
-                .get_unauthenticated_notes()
-                .map(|header| header.id())
-                .collect(),
+            found_unauthenticated_notes: Default::default(),
             current_block_height: Default::default(),
         };
         // SAFETY: nullifiers were set to None aka are definitely unspent.

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroU32,
-    ops::Not,
 };
 
 use miden_node_proto::domain::{blocks::BlockInclusionProof, notes::NoteAuthenticationInfo};
@@ -265,11 +264,11 @@ impl MockStoreSuccess {
             .collect();
 
         let locked_notes = self.notes.read().await;
-        let missing_unauthenticated_notes = proven_tx
+        let found_unauthenticated_notes = proven_tx
             .get_unauthenticated_notes()
             .filter_map(|header| {
                 let id = header.id();
-                locked_notes.contains_key(&id).not().then_some(id)
+                locked_notes.contains_key(&id).then_some(id)
             })
             .collect();
 
@@ -277,7 +276,7 @@ impl MockStoreSuccess {
             account_id: proven_tx.account_id(),
             account_hash,
             nullifiers,
-            missing_unauthenticated_notes,
+            found_unauthenticated_notes,
             current_block_height: 0,
         })
     }

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -138,7 +138,7 @@ pub struct GetTransactionInputsResponse {
     #[prost(message, repeated, tag = "2")]
     pub nullifiers: ::prost::alloc::vec::Vec<NullifierTransactionInputRecord>,
     #[prost(message, repeated, tag = "3")]
-    pub missing_unauthenticated_notes: ::prost::alloc::vec::Vec<super::digest::Digest>,
+    pub found_unauthenticated_notes: ::prost::alloc::vec::Vec<super::digest::Digest>,
     #[prost(fixed32, tag = "4")]
     pub block_height: u32,
 }

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -126,7 +126,7 @@ message NullifierTransactionInputRecord {
 message GetTransactionInputsResponse {
     AccountTransactionInputRecord account_state = 1;
     repeated NullifierTransactionInputRecord nullifiers = 2;
-    repeated digest.Digest missing_unauthenticated_notes = 3;
+    repeated digest.Digest found_unauthenticated_notes = 3;
     fixed32 block_height = 4;
 }
 

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -440,8 +440,8 @@ impl api_server::Api for StoreApi {
                     block_num: nullifier.block_num,
                 })
                 .collect(),
-            missing_unauthenticated_notes: tx_inputs
-                .missing_unauthenticated_notes
+            found_unauthenticated_notes: tx_inputs
+                .found_unauthenticated_notes
                 .into_iter()
                 .map(Into::into)
                 .collect(),

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -86,7 +86,7 @@ impl From<BlockInputs> for GetBlockInputsResponse {
 pub struct TransactionInputs {
     pub account_hash: RpoDigest,
     pub nullifiers: Vec<NullifierInfo>,
-    pub missing_unauthenticated_notes: Vec<NoteId>,
+    pub found_unauthenticated_notes: BTreeSet<NoteId>,
 }
 
 /// Container for state that needs to be updated atomically.
@@ -659,16 +659,10 @@ impl State {
         let found_unauthenticated_notes =
             self.db.select_note_ids(unauthenticated_notes.clone()).await?;
 
-        let missing_unauthenticated_notes = unauthenticated_notes
-            .iter()
-            .filter(|note_id| !found_unauthenticated_notes.contains(note_id))
-            .copied()
-            .collect();
-
         Ok(TransactionInputs {
             account_hash,
             nullifiers,
-            missing_unauthenticated_notes,
+            found_unauthenticated_notes,
         })
     }
 

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -126,7 +126,7 @@ message NullifierTransactionInputRecord {
 message GetTransactionInputsResponse {
     AccountTransactionInputRecord account_state = 1;
     repeated NullifierTransactionInputRecord nullifiers = 2;
-    repeated digest.Digest missing_unauthenticated_notes = 3;
+    repeated digest.Digest found_unauthenticated_notes = 3;
     fixed32 block_height = 4;
 }
 


### PR DESCRIPTION
This PR inverts `TransactionInputs.missing_unauthenticated_notes` to `found_authenticated_ntoes`.

Closes a task from #519.
