### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -22,7 +22,7 @@ Here is a brief description of supported methods.
 
 ### CheckNullifiers
 
-Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Trees
+Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree
 
 **Parameters:**
 


### PR DESCRIPTION
Corrected `Trees` to `Tree`