### PR TITLE
refactor: change account ID SQL's backing type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+- Changed the SQL backing type for account IDs to two integers (#603).
 - [BREAKING] Added support for new two `Felt` account ID (#591).
 - [BREAKING] Inverted `TransactionInputs.missing_unauthenticated_notes` to `found_missing_notes` (#509).
 

--- a/crates/store/src/db/sql/queries/select_notes_since_block_by_tag_and_sender.sql
+++ b/crates/store/src/db/sql/queries/select_notes_since_block_by_tag_and_sender.sql
@@ -5,7 +5,8 @@ SELECT
     note_index,
     note_id,
     note_type,
-    sender,
+    sender_id_prefix,
+    sender_id_suffix,
     tag,
     aux,
     execution_hint,
@@ -20,10 +21,10 @@ WHERE
         FROM
             notes
         WHERE
-            (tag IN rarray(?1) OR sender IN rarray(?2)) AND
+            (tag IN rarray(?1) OR sender_id_prefix IN rarray(?2)) AND
             block_num > ?3
         ORDER BY
             block_num ASC
     LIMIT 1) AND
     -- filter the block's notes and return only the ones matching the requested tags or senders
-    (tag IN rarray(?1) OR sender IN rarray(?2))
+    (tag IN rarray(?1) OR sender_id_prefix IN rarray(?2))


### PR DESCRIPTION
closes #602 

In this PR we change the account ID sql columns from blobs to two integers (u64). This allows us to index only with the prefix (as it uniquely identifies accounts) which is faster than indexing with the whole ID.

In this implementation I used two integers in tables where the full account ID was needed and only prefix when it was used as a foreign key.