### PR TITLE
style: standardize protobuf aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+- Standardized protobuf type aliases (#609).
 - [BREAKING] Added support for new two `Felt` account ID (#591).
 - [BREAKING] Inverted `TransactionInputs.missing_unauthenticated_notes` to `found_missing_notes` (#509).
 

--- a/crates/proto/src/domain/digest.rs
+++ b/crates/proto/src/domain/digest.rs
@@ -207,23 +207,23 @@ mod test {
     use hex::{FromHex, ToHex};
     use proptest::prelude::*;
 
-    use crate::generated::digest::Digest;
+    use crate::generated::digest as proto;
 
     #[test]
     fn hex_digest() {
-        let digest = Digest {
+        let digest = proto::Digest {
             d0: 3488802789098113751,
             d1: 5271242459988994564,
             d2: 17816570245237064784,
             d3: 10910963388447438895,
         };
         let encoded: String = ToHex::encode_hex(&digest);
-        let round_trip: Result<Digest, _> = FromHex::from_hex::<&[u8]>(encoded.as_ref());
+        let round_trip: Result<proto::Digest, _> = FromHex::from_hex::<&[u8]>(encoded.as_ref());
         assert_eq!(digest, round_trip.unwrap());
 
-        let digest = Digest { d0: 0, d1: 0, d2: 0, d3: 0 };
+        let digest = proto::Digest { d0: 0, d1: 0, d2: 0, d3: 0 };
         let encoded: String = ToHex::encode_hex(&digest);
-        let round_trip: Result<Digest, _> = FromHex::from_hex::<&[u8]>(encoded.as_ref());
+        let round_trip: Result<proto::Digest, _> = FromHex::from_hex::<&[u8]>(encoded.as_ref());
         assert_eq!(digest, round_trip.unwrap());
     }
 
@@ -235,9 +235,9 @@ mod test {
             d2: u64,
             d3: u64,
         ) {
-            let digest = Digest { d0, d1, d2, d3 };
+            let digest = proto::Digest { d0, d1, d2, d3 };
             let encoded: String = ToHex::encode_hex(&digest);
-            let round_trip: Result<Digest, _> = FromHex::from_hex::<&[u8]>(encoded.as_ref());
+            let round_trip: Result<proto::Digest, _> = FromHex::from_hex::<&[u8]>(encoded.as_ref());
             assert_eq!(digest, round_trip.unwrap());
         }
     }

--- a/crates/proto/src/domain/merkle.rs
+++ b/crates/proto/src/domain/merkle.rs
@@ -6,29 +6,29 @@ use miden_objects::{
 use super::{convert, try_convert};
 use crate::{
     errors::{ConversionError, MissingFieldHelper},
-    generated,
+    generated as proto,
 };
 
 // MERKLE PATH
 // ================================================================================================
 
-impl From<&MerklePath> for generated::merkle::MerklePath {
+impl From<&MerklePath> for proto::merkle::MerklePath {
     fn from(value: &MerklePath) -> Self {
-        let siblings = value.nodes().iter().map(generated::digest::Digest::from).collect();
-        generated::merkle::MerklePath { siblings }
+        let siblings = value.nodes().iter().map(proto::digest::Digest::from).collect();
+        proto::merkle::MerklePath { siblings }
     }
 }
 
-impl From<MerklePath> for generated::merkle::MerklePath {
+impl From<MerklePath> for proto::merkle::MerklePath {
     fn from(value: MerklePath) -> Self {
         (&value).into()
     }
 }
 
-impl TryFrom<&generated::merkle::MerklePath> for MerklePath {
+impl TryFrom<&proto::merkle::MerklePath> for MerklePath {
     type Error = ConversionError;
 
-    fn try_from(merkle_path: &generated::merkle::MerklePath) -> Result<Self, Self::Error> {
+    fn try_from(merkle_path: &proto::merkle::MerklePath) -> Result<Self, Self::Error> {
         merkle_path.siblings.iter().map(Digest::try_from).collect()
     }
 }
@@ -36,17 +36,17 @@ impl TryFrom<&generated::merkle::MerklePath> for MerklePath {
 // MMR DELTA
 // ================================================================================================
 
-impl From<MmrDelta> for generated::mmr::MmrDelta {
+impl From<MmrDelta> for proto::mmr::MmrDelta {
     fn from(value: MmrDelta) -> Self {
-        let data = value.data.into_iter().map(generated::digest::Digest::from).collect();
-        generated::mmr::MmrDelta { forest: value.forest as u64, data }
+        let data = value.data.into_iter().map(proto::digest::Digest::from).collect();
+        proto::mmr::MmrDelta { forest: value.forest as u64, data }
     }
 }
 
-impl TryFrom<generated::mmr::MmrDelta> for MmrDelta {
+impl TryFrom<proto::mmr::MmrDelta> for MmrDelta {
     type Error = ConversionError;
 
-    fn try_from(value: generated::mmr::MmrDelta) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::mmr::MmrDelta) -> Result<Self, Self::Error> {
         let data: Result<Vec<_>, ConversionError> =
             value.data.into_iter().map(Digest::try_from).collect();
 
@@ -63,22 +63,22 @@ impl TryFrom<generated::mmr::MmrDelta> for MmrDelta {
 // SMT LEAF
 // ------------------------------------------------------------------------------------------------
 
-impl TryFrom<generated::smt::SmtLeaf> for SmtLeaf {
+impl TryFrom<proto::smt::SmtLeaf> for SmtLeaf {
     type Error = ConversionError;
 
-    fn try_from(value: generated::smt::SmtLeaf) -> Result<Self, Self::Error> {
-        let leaf = value.leaf.ok_or(generated::smt::SmtLeaf::missing_field(stringify!(leaf)))?;
+    fn try_from(value: proto::smt::SmtLeaf) -> Result<Self, Self::Error> {
+        let leaf = value.leaf.ok_or(proto::smt::SmtLeaf::missing_field(stringify!(leaf)))?;
 
         match leaf {
-            generated::smt::smt_leaf::Leaf::Empty(leaf_index) => {
+            proto::smt::smt_leaf::Leaf::Empty(leaf_index) => {
                 Ok(Self::new_empty(LeafIndex::new_max_depth(leaf_index)))
             },
-            generated::smt::smt_leaf::Leaf::Single(entry) => {
+            proto::smt::smt_leaf::Leaf::Single(entry) => {
                 let (key, value): (Digest, Word) = entry.try_into()?;
 
                 Ok(SmtLeaf::new_single(key, value))
             },
-            generated::smt::smt_leaf::Leaf::Multiple(entries) => {
+            proto::smt::smt_leaf::Leaf::Multiple(entries) => {
                 let domain_entries: Vec<(Digest, Word)> = try_convert(entries.entries)?;
 
                 Ok(SmtLeaf::new_multiple(domain_entries)?)
@@ -87,15 +87,15 @@ impl TryFrom<generated::smt::SmtLeaf> for SmtLeaf {
     }
 }
 
-impl From<SmtLeaf> for generated::smt::SmtLeaf {
+impl From<SmtLeaf> for proto::smt::SmtLeaf {
     fn from(smt_leaf: SmtLeaf) -> Self {
-        use generated::smt::smt_leaf::Leaf;
+        use proto::smt::smt_leaf::Leaf;
 
         let leaf = match smt_leaf {
             SmtLeaf::Empty(leaf_index) => Leaf::Empty(leaf_index.value()),
             SmtLeaf::Single(entry) => Leaf::Single(entry.into()),
             SmtLeaf::Multiple(entries) => {
-                Leaf::Multiple(generated::smt::SmtLeafEntries { entries: convert(entries) })
+                Leaf::Multiple(proto::smt::SmtLeafEntries { entries: convert(entries) })
             },
         };
 
@@ -106,24 +106,24 @@ impl From<SmtLeaf> for generated::smt::SmtLeaf {
 // SMT LEAF ENTRY
 // ------------------------------------------------------------------------------------------------
 
-impl TryFrom<generated::smt::SmtLeafEntry> for (Digest, Word) {
+impl TryFrom<proto::smt::SmtLeafEntry> for (Digest, Word) {
     type Error = ConversionError;
 
-    fn try_from(entry: generated::smt::SmtLeafEntry) -> Result<Self, Self::Error> {
+    fn try_from(entry: proto::smt::SmtLeafEntry) -> Result<Self, Self::Error> {
         let key: Digest = entry
             .key
-            .ok_or(generated::smt::SmtLeafEntry::missing_field(stringify!(key)))?
+            .ok_or(proto::smt::SmtLeafEntry::missing_field(stringify!(key)))?
             .try_into()?;
         let value: Word = entry
             .value
-            .ok_or(generated::smt::SmtLeafEntry::missing_field(stringify!(value)))?
+            .ok_or(proto::smt::SmtLeafEntry::missing_field(stringify!(value)))?
             .try_into()?;
 
         Ok((key, value))
     }
 }
 
-impl From<(Digest, Word)> for generated::smt::SmtLeafEntry {
+impl From<(Digest, Word)> for proto::smt::SmtLeafEntry {
     fn from((key, value): (Digest, Word)) -> Self {
         Self {
             key: Some(key.into()),
@@ -135,25 +135,25 @@ impl From<(Digest, Word)> for generated::smt::SmtLeafEntry {
 // SMT PROOF
 // ------------------------------------------------------------------------------------------------
 
-impl TryFrom<generated::smt::SmtOpening> for SmtProof {
+impl TryFrom<proto::smt::SmtOpening> for SmtProof {
     type Error = ConversionError;
 
-    fn try_from(opening: generated::smt::SmtOpening) -> Result<Self, Self::Error> {
+    fn try_from(opening: proto::smt::SmtOpening) -> Result<Self, Self::Error> {
         let path: MerklePath = opening
             .path
             .as_ref()
-            .ok_or(generated::smt::SmtOpening::missing_field(stringify!(path)))?
+            .ok_or(proto::smt::SmtOpening::missing_field(stringify!(path)))?
             .try_into()?;
         let leaf: SmtLeaf = opening
             .leaf
-            .ok_or(generated::smt::SmtOpening::missing_field(stringify!(leaf)))?
+            .ok_or(proto::smt::SmtOpening::missing_field(stringify!(leaf)))?
             .try_into()?;
 
         Ok(SmtProof::new(path, leaf)?)
     }
 }
 
-impl From<SmtProof> for generated::smt::SmtOpening {
+impl From<SmtProof> for proto::smt::SmtOpening {
     fn from(proof: SmtProof) -> Self {
         let (ref path, leaf) = proof.into_parts();
         Self {

--- a/crates/proto/src/domain/notes.rs
+++ b/crates/proto/src/domain/notes.rs
@@ -9,20 +9,17 @@ use crate::{
     convert,
     domain::blocks::BlockInclusionProof,
     errors::{ConversionError, MissingFieldHelper},
-    generated::note::{
-        NoteAuthenticationInfo as NoteAuthenticationInfoProto,
-        NoteInclusionInBlockProof as NoteInclusionInBlockProofPb, NoteMetadata as NoteMetadataPb,
-    },
+    generated::note as proto,
     try_convert,
 };
 
-impl TryFrom<NoteMetadataPb> for NoteMetadata {
+impl TryFrom<proto::NoteMetadata> for NoteMetadata {
     type Error = ConversionError;
 
-    fn try_from(value: NoteMetadataPb) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::NoteMetadata) -> Result<Self, Self::Error> {
         let sender = value
             .sender
-            .ok_or_else(|| NoteMetadataPb::missing_field(stringify!(sender)))?
+            .ok_or_else(|| proto::NoteMetadata::missing_field(stringify!(sender)))?
             .try_into()?;
         let note_type = NoteType::try_from(value.note_type as u64)?;
         let tag = NoteTag::from(value.tag);
@@ -35,7 +32,7 @@ impl TryFrom<NoteMetadataPb> for NoteMetadata {
     }
 }
 
-impl From<NoteMetadata> for NoteMetadataPb {
+impl From<NoteMetadata> for proto::NoteMetadata {
     fn from(val: NoteMetadata) -> Self {
         let sender = Some(val.sender().into());
         let note_type = val.note_type() as u32;
@@ -43,7 +40,7 @@ impl From<NoteMetadata> for NoteMetadataPb {
         let execution_hint: u64 = val.execution_hint().into();
         let aux = val.aux().into();
 
-        crate::generated::note::NoteMetadata {
+        proto::NoteMetadata {
             sender,
             note_type,
             tag,
@@ -53,7 +50,7 @@ impl From<NoteMetadata> for NoteMetadataPb {
     }
 }
 
-impl From<(&NoteId, &NoteInclusionProof)> for NoteInclusionInBlockProofPb {
+impl From<(&NoteId, &NoteInclusionProof)> for proto::NoteInclusionInBlockProof {
     fn from((note_id, proof): (&NoteId, &NoteInclusionProof)) -> Self {
         Self {
             note_id: Some(note_id.into()),
@@ -64,18 +61,18 @@ impl From<(&NoteId, &NoteInclusionProof)> for NoteInclusionInBlockProofPb {
     }
 }
 
-impl TryFrom<&NoteInclusionInBlockProofPb> for (NoteId, NoteInclusionProof) {
+impl TryFrom<&proto::NoteInclusionInBlockProof> for (NoteId, NoteInclusionProof) {
     type Error = ConversionError;
 
     fn try_from(
-        proof: &NoteInclusionInBlockProofPb,
+        proof: &proto::NoteInclusionInBlockProof,
     ) -> Result<(NoteId, NoteInclusionProof), Self::Error> {
         Ok((
             Digest::try_from(
                 proof
                     .note_id
                     .as_ref()
-                    .ok_or(NoteInclusionInBlockProofPb::missing_field(stringify!(note_id)))?,
+                    .ok_or(proto::NoteInclusionInBlockProof::missing_field(stringify!(note_id)))?,
             )?
             .into(),
             NoteInclusionProof::new(
@@ -84,7 +81,9 @@ impl TryFrom<&NoteInclusionInBlockProofPb> for (NoteId, NoteInclusionProof) {
                 proof
                     .merkle_path
                     .as_ref()
-                    .ok_or(NoteInclusionInBlockProofPb::missing_field(stringify!(merkle_path)))?
+                    .ok_or(proto::NoteInclusionInBlockProof::missing_field(stringify!(
+                        merkle_path
+                    )))?
                     .try_into()?,
             )?,
         ))
@@ -107,7 +106,7 @@ impl NoteAuthenticationInfo {
     }
 }
 
-impl From<NoteAuthenticationInfo> for NoteAuthenticationInfoProto {
+impl From<NoteAuthenticationInfo> for proto::NoteAuthenticationInfo {
     fn from(value: NoteAuthenticationInfo) -> Self {
         Self {
             note_proofs: convert(&value.note_proofs),
@@ -116,10 +115,10 @@ impl From<NoteAuthenticationInfo> for NoteAuthenticationInfoProto {
     }
 }
 
-impl TryFrom<NoteAuthenticationInfoProto> for NoteAuthenticationInfo {
+impl TryFrom<proto::NoteAuthenticationInfo> for NoteAuthenticationInfo {
     type Error = ConversionError;
 
-    fn try_from(value: NoteAuthenticationInfoProto) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::NoteAuthenticationInfo) -> Result<Self, Self::Error> {
         let result = Self {
             block_proofs: try_convert(value.block_proofs)?,
             note_proofs: try_convert(&value.note_proofs)?,

--- a/crates/proto/src/domain/nullifiers.rs
+++ b/crates/proto/src/domain/nullifiers.rs
@@ -5,19 +5,19 @@ use miden_objects::{
 
 use crate::{
     errors::{ConversionError, MissingFieldHelper},
-    generated::{digest::Digest, responses::NullifierBlockInputRecord},
+    generated as proto,
 };
 
 // FROM NULLIFIER
 // ================================================================================================
 
-impl From<&Nullifier> for Digest {
+impl From<&Nullifier> for proto::digest::Digest {
     fn from(value: &Nullifier) -> Self {
         (*value).inner().into()
     }
 }
 
-impl From<Nullifier> for Digest {
+impl From<Nullifier> for proto::digest::Digest {
     fn from(value: Nullifier) -> Self {
         value.inner().into()
     }
@@ -26,10 +26,10 @@ impl From<Nullifier> for Digest {
 // INTO NULLIFIER
 // ================================================================================================
 
-impl TryFrom<Digest> for Nullifier {
+impl TryFrom<proto::digest::Digest> for Nullifier {
     type Error = ConversionError;
 
-    fn try_from(value: Digest) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::digest::Digest) -> Result<Self, Self::Error> {
         let digest: RpoDigest = value.try_into()?;
         Ok(digest.into())
     }
@@ -44,24 +44,30 @@ pub struct NullifierWitness {
     pub proof: SmtProof,
 }
 
-impl TryFrom<NullifierBlockInputRecord> for NullifierWitness {
+impl TryFrom<proto::responses::NullifierBlockInputRecord> for NullifierWitness {
     type Error = ConversionError;
 
-    fn try_from(nullifier_input_record: NullifierBlockInputRecord) -> Result<Self, Self::Error> {
+    fn try_from(
+        nullifier_input_record: proto::responses::NullifierBlockInputRecord,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             nullifier: nullifier_input_record
                 .nullifier
-                .ok_or(NullifierBlockInputRecord::missing_field(stringify!(nullifier)))?
+                .ok_or(proto::responses::NullifierBlockInputRecord::missing_field(stringify!(
+                    nullifier
+                )))?
                 .try_into()?,
             proof: nullifier_input_record
                 .opening
-                .ok_or(NullifierBlockInputRecord::missing_field(stringify!(opening)))?
+                .ok_or(proto::responses::NullifierBlockInputRecord::missing_field(stringify!(
+                    opening
+                )))?
                 .try_into()?,
         })
     }
 }
 
-impl From<NullifierWitness> for NullifierBlockInputRecord {
+impl From<NullifierWitness> for proto::responses::NullifierBlockInputRecord {
     fn from(value: NullifierWitness) -> Self {
         Self {
             nullifier: Some(value.nullifier.into()),

--- a/crates/proto/src/domain/transactions.rs
+++ b/crates/proto/src/domain/transactions.rs
@@ -1,32 +1,29 @@
 use miden_objects::{crypto::hash::rpo::RpoDigest, transaction::TransactionId};
 
-use crate::{
-    errors::ConversionError,
-    generated::{digest::Digest, transaction::TransactionId as TransactionIdPb},
-};
+use crate::{errors::ConversionError, generated as proto};
 
 // FROM TRANSACTION ID
 // ================================================================================================
 
-impl From<&TransactionId> for Digest {
+impl From<&TransactionId> for proto::digest::Digest {
     fn from(value: &TransactionId) -> Self {
         (*value).inner().into()
     }
 }
 
-impl From<TransactionId> for Digest {
+impl From<TransactionId> for proto::digest::Digest {
     fn from(value: TransactionId) -> Self {
         value.inner().into()
     }
 }
 
-impl From<&TransactionId> for TransactionIdPb {
+impl From<&TransactionId> for proto::transaction::TransactionId {
     fn from(value: &TransactionId) -> Self {
-        TransactionIdPb { id: Some(value.into()) }
+        proto::transaction::TransactionId { id: Some(value.into()) }
     }
 }
 
-impl From<TransactionId> for TransactionIdPb {
+impl From<TransactionId> for proto::transaction::TransactionId {
     fn from(value: TransactionId) -> Self {
         (&value).into()
     }
@@ -35,19 +32,19 @@ impl From<TransactionId> for TransactionIdPb {
 // INTO TRANSACTION ID
 // ================================================================================================
 
-impl TryFrom<Digest> for TransactionId {
+impl TryFrom<proto::digest::Digest> for TransactionId {
     type Error = ConversionError;
 
-    fn try_from(value: Digest) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::digest::Digest) -> Result<Self, Self::Error> {
         let digest: RpoDigest = value.try_into()?;
         Ok(digest.into())
     }
 }
 
-impl TryFrom<TransactionIdPb> for TransactionId {
+impl TryFrom<proto::transaction::TransactionId> for TransactionId {
     type Error = ConversionError;
 
-    fn try_from(value: TransactionIdPb) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::transaction::TransactionId) -> Result<Self, Self::Error> {
         value
             .id
             .ok_or(ConversionError::MissingFieldInProtobufRepresentation {

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use deadpool_sqlite::{Config as SqliteConfig, Hook, HookError, Pool, Runtime};
 use miden_node_proto::{
     domain::accounts::{AccountInfo, AccountSummary},
-    generated::note::{Note as NotePb, NoteSyncRecord as NoteSyncRecordPb},
+    generated::note as proto,
 };
 use miden_objects::{
     accounts::{AccountDelta, AccountId},
@@ -68,7 +68,7 @@ pub struct NoteRecord {
     pub merkle_path: MerklePath,
 }
 
-impl From<NoteRecord> for NotePb {
+impl From<NoteRecord> for proto::Note {
     fn from(note: NoteRecord) -> Self {
         Self {
             block_num: note.block_num,
@@ -105,7 +105,7 @@ pub struct NoteSyncRecord {
     pub merkle_path: MerklePath,
 }
 
-impl From<NoteSyncRecord> for NoteSyncRecordPb {
+impl From<NoteSyncRecord> for proto::NoteSyncRecord {
     fn from(note: NoteSyncRecord) -> Self {
         Self {
             note_index: note.note_index.leaf_index_value().into(),


### PR DESCRIPTION
Closes #454.

This PR aims to unify the aliases used for importing the protobuf types. When possible, referenced types like `proto::T.` If more than one type T is imported, the mod was used to locate it. For example: `proto::account::AccountId` and `proto::responses::AccountBlockInputRecord`.