### PR TITLE
refactor: standardize errors

### DIFF
--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -29,12 +29,7 @@ use rand::{random, rngs::StdRng};
 use tonic::transport::Channel;
 use tracing::info;
 
-use crate::{
-    config::FaucetConfig,
-    errors::{ClientError, ImplError},
-    store::FaucetDataStore,
-    COMPONENT,
-};
+use crate::{config::FaucetConfig, errors::ClientError, store::FaucetDataStore, COMPONENT};
 
 pub const DISTRIBUTE_FUNGIBLE_ASSET_SCRIPT: &str =
     include_str!("transaction_scripts/distribute_fungible_asset.masm");
@@ -255,7 +250,6 @@ async fn request_account_state(
         account_info.details.context("Account details field is empty")?;
 
     Account::read_from_bytes(&faucet_account_state_bytes)
-        .map_err(ImplError)
         .context("Failed to deserialize faucet account")
         .map_err(Into::into)
 }

--- a/bin/faucet/src/errors.rs
+++ b/bin/faucet/src/errors.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 use axum::{
     http::{header, StatusCode},
@@ -6,41 +6,31 @@ use axum::{
 };
 use thiserror::Error;
 
-/// Wrapper for implementing `Error` trait for errors, which do not implement it, like
-/// [miden_objects::crypto::utils::DeserializationError] and other error types from `miden-base`.
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct ImplError<E: Display + Debug>(pub E);
-
 #[derive(Debug, Error)]
 pub enum ClientError {
-    #[error("Request error: {0}")]
+    #[error(transparent)]
     RequestError(#[from] tonic::Status),
 
-    #[error("Client error: {0:#}")]
+    #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 
 #[derive(Debug, Error)]
 pub enum HandlerError {
-    #[error("Node client error: {0}")]
+    #[error("client error")]
     ClientError(#[from] ClientError),
 
-    #[error("Server has encountered an internal error: {0:#}")]
+    #[error("internal error")]
     Internal(#[from] anyhow::Error),
 
-    #[error("Client has submitted a bad request: {0}")]
+    #[error("bad request: {0}")]
     BadRequest(String),
-
-    #[error("Page not found: {0}")]
-    NotFound(String),
 }
 
 impl HandlerError {
     fn status_code(&self) -> StatusCode {
         match *self {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
-            Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::ClientError(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -48,8 +38,7 @@ impl HandlerError {
     fn message(&self) -> String {
         match self {
             Self::BadRequest(msg) => msg,
-            Self::ClientError(_) | Self::Internal(_) => "Error processing request",
-            Self::NotFound(msg) => msg,
+            Self::ClientError(_) | Self::Internal(_) => "Internal error",
         }
         .to_string()
     }

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use axum::{
-    extract::{Path, State},
+    extract::State,
     http::{Response, StatusCode},
     response::IntoResponse,
     Json,
@@ -56,7 +56,7 @@ pub async fn get_tokens(
 
     // Check that the amount is in the asset amount options
     if !state.config.asset_amount_options.contains(&req.asset_amount) {
-        return Err(HandlerError::BadRequest("Invalid asset amount".to_string()));
+        return Err(HandlerError::BadRequest("invalid asset amount".to_string()));
     }
 
     let mut client = state.client.lock().await;
@@ -114,16 +114,9 @@ pub async fn get_tokens(
 }
 
 pub async fn get_index(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
-    get_static_file(state, Path("index.html".to_string())).await
-}
+    info!(target: COMPONENT, "Serving `index.html`");
 
-pub async fn get_static_file(
-    State(state): State<FaucetState>,
-    Path(path): Path<String>,
-) -> Result<impl IntoResponse, HandlerError> {
-    info!(target: COMPONENT, path, "Serving static file");
-
-    let static_file = state.static_files.get(path.as_str()).ok_or(HandlerError::NotFound(path))?;
+    let static_file = state.static_files.get("index.html").expect("index.html should be bundled");
 
     Response::builder()
         .status(StatusCode::OK)

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -56,14 +56,17 @@ pub async fn get_tokens(
 
     // Check that the amount is in the asset amount options
     if !state.config.asset_amount_options.contains(&req.asset_amount) {
-        return Err(HandlerError::BadRequest("invalid asset amount".to_string()));
+        return Err(HandlerError::InvalidAssetAmount {
+            requested: req.asset_amount,
+            options: state.config.asset_amount_options.clone(),
+        });
     }
 
     let mut client = state.client.lock().await;
 
     // Receive and hex user account id
     let target_account_id = AccountId::from_hex(req.account_id.as_str())
-        .map_err(|err| HandlerError::BadRequest(err.to_string()))?;
+        .map_err(HandlerError::AccountIdDeserializationError)?;
 
     // Execute transaction
     info!(target: COMPONENT, "Executing mint transaction for account.");

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -33,7 +33,7 @@ use tracing::info;
 
 use crate::{
     config::{FaucetConfig, DEFAULT_FAUCET_ACCOUNT_PATH},
-    handlers::{get_index, get_metadata, get_static_file, get_tokens},
+    handlers::{get_index, get_metadata, get_tokens},
 };
 
 // CONSTANTS
@@ -105,7 +105,6 @@ async fn main() -> anyhow::Result<()> {
                 .route("/", get(get_index))
                 .route("/get_metadata", get(get_metadata))
                 .route("/get_tokens", post(get_tokens))
-                .route("/*path", get(get_static_file))
                 .layer(
                     ServiceBuilder::new()
                         .layer(TraceLayer::new_for_http())

--- a/crates/block-producer/src/batch_builder/batch.rs
+++ b/crates/block-producer/src/batch_builder/batch.rs
@@ -135,9 +135,11 @@ impl TransactionBatch {
                 Entry::Vacant(vacant) => {
                     vacant.insert(AccountUpdate::new(tx));
                 },
-                Entry::Occupied(occupied) => occupied.into_mut().merge_tx(tx).map_err(|error| {
-                    BuildBatchError::AccountUpdateError { account_id: tx.account_id(), error }
-                })?,
+                Entry::Occupied(occupied) => {
+                    occupied.into_mut().merge_tx(tx).map_err(|source| {
+                        BuildBatchError::AccountUpdateError { account_id: tx.account_id(), source }
+                    })?
+                },
             };
 
             // Check unauthenticated input notes for duplicates:

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -224,7 +224,7 @@ impl WorkerPool {
                             transactions.iter().flat_map(|tx| tx.unauthenticated_notes()),
                         )
                         .await
-                        .map_err(|err| (id, err.into()))?;
+                        .map_err(|err| (id, BuildBatchError::FetchBatchInputsFailed(err)))?;
                     let batch = Self::build_batch(transactions, inputs).map_err(|err| (id, err))?;
 
                     tokio::time::sleep(simulated_proof_time).await;

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -166,7 +166,7 @@ impl BlockBuilder {
         self.store
             .apply_block(&block)
             .await
-            .map_err(BuildBlockError::ApplyBlockFailed)?;
+            .map_err(BuildBlockError::StoreApplyBlockFailed)?;
 
         info!(target: COMPONENT, block_num, %block_hash, "block committed");
 

--- a/crates/block-producer/src/block_builder/prover/block_witness.rs
+++ b/crates/block-producer/src/block_builder/prover/block_witness.rs
@@ -89,8 +89,8 @@ impl BlockWitness {
 
                 details = Some(match details {
                     None => update.details,
-                    Some(details) => details.merge(update.details).map_err(|err| {
-                        BuildBlockError::AccountUpdateError { account_id, error: err }
+                    Some(details) => details.merge(update.details).map_err(|source| {
+                        BuildBlockError::AccountUpdateError { account_id, source }
                     })?,
                 });
             }

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -40,21 +40,23 @@ pub enum BlockProducerError {
 #[derive(Debug, Error)]
 pub enum VerifyTxError {
     /// Another transaction already consumed the notes with given nullifiers
-    #[error("Input notes with given nullifiers were already consumed by another transaction")]
+    #[error(
+        "input notes with given nullifiers were already consumed by another transaction: {0:?}"
+    )]
     InputNotesAlreadyConsumed(Vec<Nullifier>),
 
     /// Unauthenticated transaction notes were not found in the store or in outputs of in-flight
     /// transactions
     #[error(
-        "Unauthenticated transaction notes were not found in the store or in outputs of in-flight transactions: {0:?}"
+        "unauthenticated transaction notes were not found in the store or in outputs of in-flight transactions: {0:?}"
     )]
     UnauthenticatedNotesNotFound(Vec<NoteId>),
 
-    #[error("Output note IDs already used: {0:?}")]
+    #[error("output note IDs already used: {0:?}")]
     OutputNotesAlreadyExist(Vec<NoteId>),
 
     /// The account's initial hash did not match the current account's hash
-    #[error("Incorrect account's initial hash ({tx_initial_account_hash}, current: {})", format_opt(.current_account_hash.as_ref()))]
+    #[error("incorrect account's initial hash ({tx_initial_account_hash}, current: {})", format_opt(.current_account_hash.as_ref()))]
     IncorrectAccountInitialHash {
         tx_initial_account_hash: Digest,
         current_account_hash: Option<Digest>,
@@ -64,14 +66,14 @@ pub enum VerifyTxError {
     ///
     /// TODO: Make this an "internal error". Q: Should we have a single `InternalError` enum for
     /// all internal errors that can occur across the system?
-    #[error("Failed to retrieve transaction inputs from the store: {0}")]
+    #[error("failed to retrieve transaction inputs from the store")]
     StoreConnectionFailed(#[from] StoreError),
 
-    #[error("Transaction input error: {0}")]
+    #[error("transaction input error")]
     TransactionInputError(#[from] TransactionInputError),
 
     /// Failed to verify the transaction execution proof
-    #[error("Invalid transaction proof error for transaction: {0}")]
+    #[error("invalid transaction proof error for transaction: {0}")]
     InvalidTransactionProof(TransactionId),
 }
 
@@ -80,19 +82,19 @@ pub enum VerifyTxError {
 
 #[derive(Debug, Error)]
 pub enum AddTransactionError {
-    #[error("Transaction verification failed: {0}")]
+    #[error("transaction verification failed")]
     VerificationFailed(#[from] VerifyTxError),
 
-    #[error("Transaction input data is stale. Required data from {stale_limit} or newer, but inputs are from {input_block}.")]
+    #[error("transaction input data is stale. Required data from {stale_limit} or newer, but inputs are from {input_block}")]
     StaleInputs {
         input_block: BlockNumber,
         stale_limit: BlockNumber,
     },
 
-    #[error("Deserialization failed: {0}")]
+    #[error("deserialization failed: {0}")]
     DeserializationError(String),
 
-    #[error("Transaction expired at {expired_at} but the limit was {limit}")]
+    #[error("transaction expired at {expired_at} but the limit was {limit}")]
     Expired {
         expired_at: BlockNumber,
         limit: BlockNumber,
@@ -125,32 +127,32 @@ impl From<AddTransactionError> for tonic::Status {
 /// Error encountered while building a batch.
 #[derive(Debug, Error)]
 pub enum BuildBatchError {
-    #[error("Duplicated unauthenticated transaction input note ID in the batch: {0}")]
+    #[error("duplicated unauthenticated transaction input note ID in the batch: {0}")]
     DuplicateUnauthenticatedNote(NoteId),
 
-    #[error("Duplicated transaction output note ID in the batch: {0}")]
+    #[error("duplicated transaction output note ID in the batch: {0}")]
     DuplicateOutputNote(NoteId),
 
-    #[error("Note hashes mismatch for note {id}: (input: {input_hash}, output: {output_hash})")]
+    #[error("note hashes mismatch for note {id}: (input: {input_hash}, output: {output_hash})")]
     NoteHashesMismatch {
         id: NoteId,
         input_hash: Digest,
         output_hash: Digest,
     },
 
-    #[error("Failed to merge transaction delta into account {account_id}: {error}")]
+    #[error("failed to merge transaction delta into account {account_id}: {error}")]
     AccountUpdateError {
         account_id: AccountId,
         error: AccountDeltaError,
     },
 
-    #[error("Nothing actually went wrong, failure was injected on purpose")]
+    #[error("nothing actually went wrong, failure was injected on purpose")]
     InjectedFailure,
 
-    #[error("Batch proving task panic'd")]
+    #[error("batch proving task panic'd")]
     JoinError(#[from] tokio::task::JoinError),
 
-    #[error("Fetching inputs from store failed")]
+    #[error("fetching inputs from store failed")]
     StoreError(#[from] StoreError),
 }
 
@@ -159,11 +161,11 @@ pub enum BuildBatchError {
 
 #[derive(Debug, Error)]
 pub enum BlockProverError {
-    #[error("Received invalid merkle path")]
+    #[error("received invalid merkle path")]
     InvalidMerklePaths(MerkleError),
-    #[error("Program execution failed")]
+    #[error("program execution failed")]
     ProgramExecutionFailed(ExecutionError),
-    #[error("Failed to retrieve {0} root from stack outputs")]
+    #[error("failed to retrieve {0} root from stack outputs")]
     InvalidRootOutput(&'static str),
 }
 
@@ -172,11 +174,11 @@ pub enum BlockProverError {
 
 #[derive(Debug, Error)]
 pub enum BuildBlockError {
-    #[error("failed to compute new block: {0}")]
+    #[error("failed to compute new block")]
     BlockProverFailed(#[from] BlockProverError),
-    #[error("failed to apply block: {0}")]
+    #[error("failed to apply block")]
     ApplyBlockFailed(#[source] StoreError),
-    #[error("failed to get block inputs from store: {0}")]
+    #[error("failed to get block inputs from store")]
     GetBlockInputsFailed(#[source] StoreError),
     #[error("store did not produce data for account: {0}")]
     MissingAccountInput(AccountId),

--- a/crates/block-producer/src/mempool/graph/mod.rs
+++ b/crates/block-producer/src/mempool/graph/mod.rs
@@ -82,25 +82,25 @@ where
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum GraphError<K> {
-    #[error("Node {0} already exists")]
+    #[error("node {0} already exists")]
     DuplicateKey(K),
 
-    #[error("Parents not found: {0:?}")]
+    #[error("parents not found: {0:?}")]
     MissingParents(BTreeSet<K>),
 
-    #[error("Nodes not found: {0:?}")]
+    #[error("nodes not found: {0:?}")]
     UnknownNodes(BTreeSet<K>),
 
-    #[error("Nodes were not yet processed: {0:?}")]
+    #[error("nodes were not yet processed: {0:?}")]
     UnprocessedNodes(BTreeSet<K>),
 
-    #[error("Nodes would be left dangling: {0:?}")]
+    #[error("nodes would be left dangling: {0:?}")]
     DanglingNodes(BTreeSet<K>),
 
-    #[error("Node {0} is not a root node")]
+    #[error("node {0} is not a root node")]
     InvalidRootNode(K),
 
-    #[error("Node {0} is not a pending node")]
+    #[error("node {0} is not a pending node")]
     InvalidPendingNode(K),
 }
 

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -223,7 +223,7 @@ impl BlockProducerRpcServer {
         debug!(target: COMPONENT, ?request);
 
         let tx = ProvenTransaction::read_from_bytes(&request.transaction)
-            .map_err(|err| AddTransactionError::DeserializationError(err.to_string()))?;
+            .map_err(AddTransactionError::TransactionDeserializationFailed)?;
 
         let tx_id = tx.id();
 

--- a/crates/proto/src/errors.rs
+++ b/crates/proto/src/errors.rs
@@ -5,28 +5,28 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ConversionError {
-    #[error("Hex error: {0}")]
+    #[error("hex error")]
     HexError(#[from] hex::FromHexError),
-    #[error("Note error: {0}")]
+    #[error("note error")]
     NoteError(#[from] miden_objects::NoteError),
-    #[error("SMT leaf error: {0}")]
+    #[error("SMT leaf error")]
     SmtLeafError(#[from] SmtLeafError),
-    #[error("SMT proof error: {0}")]
+    #[error("SMT proof error")]
     SmtProofError(#[from] SmtProofError),
-    #[error("Integer conversion error: {0}")]
+    #[error("integer conversion error: {0}")]
     TryFromIntError(#[from] TryFromIntError),
-    #[error("Too much data, expected {expected}, got {got}")]
+    #[error("too much data, expected {expected}, got {got}")]
     TooMuchData { expected: usize, got: usize },
-    #[error("Not enough data, expected {expected}, got {got}")]
+    #[error("not enough data, expected {expected}, got {got}")]
     InsufficientData { expected: usize, got: usize },
-    #[error("Value is not in the range 0..MODULUS")]
+    #[error("value is not in the range 0..MODULUS")]
     NotAValidFelt,
-    #[error("Field `{field_name}` required to be filled in protobuf representation of {entity}")]
+    #[error("field `{entity}::{field_name}` is missing")]
     MissingFieldInProtobufRepresentation {
         entity: &'static str,
         field_name: &'static str,
     },
-    #[error("MMR error: {0}")]
+    #[error("MMR error")]
     MmrError(#[from] miden_objects::crypto::merkle::MmrError),
 }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -476,10 +476,10 @@ impl Db {
         block_store: Arc<BlockStore>,
     ) -> Result<(), GenesisError> {
         let genesis_block = {
-            let file_contents = fs::read(genesis_filepath).map_err(|error| {
+            let file_contents = fs::read(genesis_filepath).map_err(|source| {
                 GenesisError::FailedToReadGenesisFile {
                     genesis_filepath: genesis_filepath.to_string(),
-                    error,
+                    source,
                 }
             })?;
 
@@ -535,7 +535,7 @@ impl Db {
                         Ok(())
                     })
                     .await
-                    .map_err(|err| GenesisError::ApplyBlockFailed(err.to_string()))??;
+                    .map_err(GenesisError::ApplyBlockFailed)??;
             },
         }
 

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -138,7 +138,7 @@ pub fn apply_delta(
     let account = account.map(Account::read_from_bytes).transpose()?;
 
     let Some(mut account) = account else {
-        return Err(DatabaseError::AccountNotOnChain(account_id));
+        return Err(DatabaseError::AccountNotPublic(account_id));
     };
 
     account.apply_delta(delta)?;

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -24,9 +24,9 @@ use crate::types::BlockNumber;
 
 #[derive(Debug, Error)]
 pub enum NullifierTreeError {
-    #[error("Merkle error: {0}")]
+    #[error("merkle error")]
     MerkleError(#[from] MerkleError),
-    #[error("Nullifier {nullifier} for block #{block_num} already exists in the nullifier tree")]
+    #[error("nullifier {nullifier} for block #{block_num} already exists in the nullifier tree")]
     NullifierAlreadyExists {
         nullifier: Nullifier,
         block_num: BlockNumber,
@@ -40,63 +40,57 @@ pub enum NullifierTreeError {
 pub enum DatabaseError {
     // ERRORS WITH AUTOMATIC CONVERSIONS FROM NESTED ERROR TYPES
     // ---------------------------------------------------------------------------------------------
-    #[error("Account error: {0}")]
+    #[error("account error")]
     AccountError(#[from] AccountError),
-    #[error("Account delta error: {0}")]
+    #[error("account delta error")]
     AccountDeltaError(#[from] AccountDeltaError),
-    #[error("Block error: {0}")]
+    #[error("block error")]
     BlockError(#[from] BlockError),
-    #[error("Closed channel: {0}")]
+    #[error("closed channel")]
     ClosedChannel(#[from] RecvError),
-    #[error("Deserialization of BLOB data from database failed: {0}")]
-    DeserializationError(DeserializationError),
-    #[error("Hex parsing error: {0}")]
+    #[error("deserialization failed")]
+    DeserializationError(#[from] DeserializationError),
+    #[error("hex parsing error")]
     FromHexError(#[from] hex::FromHexError),
-    #[error("SQLite error: {0}")]
+    #[error("SQLite deserialization error")]
     FromSqlError(#[from] FromSqlError),
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     IoError(#[from] io::Error),
-    #[error("Migration error: {0}")]
+    #[error("migration failed")]
     MigrationError(#[from] rusqlite_migration::Error),
-    #[error("Missing database connection: {0}")]
+    #[error("missing database connection")]
     MissingDbConnection(#[from] PoolError),
-    #[error("Note error: {0}")]
+    #[error("note error")]
     NoteError(#[from] NoteError),
-    #[error("SQLite error: {0}")]
+    #[error("SQLite error")]
     SqliteError(#[from] rusqlite::Error),
 
     // OTHER ERRORS
     // ---------------------------------------------------------------------------------------------
-    #[error("Account hashes mismatch (expected {expected}, but calculated is {calculated})")]
+    #[error("account hash mismatch (expected {expected}, but calculated is {calculated})")]
     AccountHashesMismatch {
         expected: RpoDigest,
         calculated: RpoDigest,
     },
-    #[error("Account {0} not found in the database")]
+    #[error("account {0} not found")]
     AccountNotFoundInDb(AccountId),
-    #[error("Accounts {0:?} not found in the database")]
+    #[error("accounts {0:?} not found")]
     AccountsNotFoundInDb(Vec<AccountId>),
-    #[error("Account {0} is not on the chain")]
+    #[error("account {0} is not on the chain")]
     AccountNotOnChain(AccountId),
-    #[error("Block {0} not found in the database")]
+    #[error("block {0} not found")]
     BlockNotFoundInDb(BlockNumber),
-    #[error("Data corrupted: {0}")]
+    #[error("data corrupted: {0}")]
     DataCorrupted(String),
-    #[error("SQLite pool interaction task failed: {0}")]
+    #[error("SQLite pool interaction failed: {0}")]
     InteractError(String),
-    #[error("Invalid Felt: {0}")]
+    #[error("invalid Felt: {0}")]
     InvalidFelt(String),
     #[error(
-        "Unsupported database version. There is no migration chain from/to this version. \
+        "unsupported database version. There is no migration chain from/to this version. \
         Remove all database files and try again."
     )]
     UnsupportedDatabaseVersion,
-}
-
-impl From<DeserializationError> for DatabaseError {
-    fn from(value: DeserializationError) -> Self {
-        Self::DeserializationError(value)
-    }
 }
 
 impl From<DatabaseError> for Status {
@@ -117,25 +111,25 @@ impl From<DatabaseError> for Status {
 
 #[derive(Error, Debug)]
 pub enum StateInitializationError {
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Failed to create nullifier tree: {0}")]
-    FailedToCreateNullifierTree(NullifierTreeError),
-    #[error("Failed to create accounts tree: {0}")]
-    FailedToCreateAccountsTree(MerkleError),
+    #[error("failed to create nullifier tree")]
+    FailedToCreateNullifierTree(#[from] NullifierTreeError),
+    #[error("failed to create accounts tree")]
+    FailedToCreateAccountsTree(#[from] MerkleError),
 }
 
 #[derive(Debug, Error)]
 pub enum DatabaseSetupError {
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     IoError(#[from] io::Error),
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Genesis block error: {0}")]
+    #[error("genesis block error")]
     GenesisBlockError(#[from] GenesisError),
-    #[error("Pool build error: {0}")]
+    #[error("pool build error")]
     PoolBuildError(#[from] deadpool_sqlite::BuildError),
-    #[error("SQLite migration error: {0}")]
+    #[error("SQLite migration error")]
     SqliteMigrationError(#[from] rusqlite_migration::Error),
 }
 
@@ -143,54 +137,54 @@ pub enum DatabaseSetupError {
 pub enum GenesisError {
     // ERRORS WITH AUTOMATIC CONVERSIONS FROM NESTED ERROR TYPES
     // ---------------------------------------------------------------------------------------------
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Block error: {0}")]
+    #[error("block error")]
     BlockError(#[from] BlockError),
-    #[error("Merkle error: {0}")]
+    #[error("merkle error")]
     MerkleError(#[from] MerkleError),
+    #[error("failed to deserialize genesis file")]
+    GenesisFileDeserializationError(#[from] DeserializationError),
+    #[error("retrieving genesis block header failed")]
+    SelectBlockHeaderByBlockNumError(#[from] Box<DatabaseError>),
 
     // OTHER ERRORS
     // ---------------------------------------------------------------------------------------------
-    #[error("Apply block failed: {0}")]
+    #[error("apply block failed: {0}")]
     ApplyBlockFailed(String),
-    #[error("Failed to read genesis file \"{genesis_filepath}\": {error}")]
+    #[error("failed to read genesis file \"{genesis_filepath}\": {error}")]
     FailedToReadGenesisFile {
         genesis_filepath: String,
         error: io::Error,
     },
-    #[error("Block header in store doesn't match block header in genesis file. Expected {expected_genesis_header:?}, but store contained {block_header_in_store:?}")]
+    #[error("block header in store doesn't match block header in genesis file. Expected {expected_genesis_header:?}, but store contained {block_header_in_store:?}")]
     GenesisBlockHeaderMismatch {
         expected_genesis_header: Box<BlockHeader>,
         block_header_in_store: Box<BlockHeader>,
     },
-    #[error("Failed to deserialize genesis file: {0}")]
-    GenesisFileDeserializationError(DeserializationError),
-    #[error("Retrieving genesis block header failed: {0}")]
-    SelectBlockHeaderByBlockNumError(Box<DatabaseError>),
 }
 
 // ENDPOINT ERRORS
 // =================================================================================================
 #[derive(Error, Debug)]
 pub enum InvalidBlockError {
-    #[error("Duplicated nullifiers {0:?}")]
+    #[error("duplicated nullifiers {0:?}")]
     DuplicatedNullifiers(Vec<Nullifier>),
-    #[error("Invalid output note type: {0:?}")]
+    #[error("invalid output note type: {0:?}")]
     InvalidOutputNoteType(Box<OutputNote>),
-    #[error("Invalid tx hash: expected {expected}, but got {actual}")]
+    #[error("invalid tx hash: expected {expected}, but got {actual}")]
     InvalidTxHash { expected: RpoDigest, actual: RpoDigest },
-    #[error("Received invalid account tree root")]
+    #[error("received invalid account tree root")]
     NewBlockInvalidAccountRoot,
-    #[error("New block number must be 1 greater than the current block number")]
+    #[error("new block number must be 1 greater than the current block number")]
     NewBlockInvalidBlockNum,
-    #[error("New block chain root is not consistent with chain MMR")]
+    #[error("new block chain root is not consistent with chain MMR")]
     NewBlockInvalidChainRoot,
-    #[error("Received invalid note root")]
+    #[error("received invalid note root")]
     NewBlockInvalidNoteRoot,
-    #[error("Received invalid nullifier root")]
+    #[error("received invalid nullifier root")]
     NewBlockInvalidNullifierRoot,
-    #[error("New block `prev_hash` must match the chain's tip")]
+    #[error("new block `prev_hash` must match the chain's tip")]
     NewBlockInvalidPrevHash,
 }
 
@@ -198,24 +192,24 @@ pub enum InvalidBlockError {
 pub enum ApplyBlockError {
     // ERRORS WITH AUTOMATIC CONVERSIONS FROM NESTED ERROR TYPES
     // ---------------------------------------------------------------------------------------------
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     IoError(#[from] io::Error),
-    #[error("Task join error: {0}")]
+    #[error("task join error")]
     TokioJoinError(#[from] tokio::task::JoinError),
-    #[error("Invalid block error: {0}")]
+    #[error("invalid block error")]
     InvalidBlockError(#[from] InvalidBlockError),
 
     // OTHER ERRORS
     // ---------------------------------------------------------------------------------------------
-    #[error("Block applying was cancelled because of closed channel on database side: {0}")]
-    ClosedChannel(RecvError),
-    #[error("Concurrent write detected")]
+    #[error("block applying was cancelled because of closed channel on database side")]
+    ClosedChannel(#[from] RecvError),
+    #[error("concurrent write detected")]
     ConcurrentWrite,
-    #[error("Database doesn't have any block header data")]
+    #[error("database doesn't have any block header data")]
     DbBlockHeaderEmpty,
-    #[error("Database update task failed: {0}")]
+    #[error("database update failed: {0}")]
     DbUpdateTaskFailed(String),
 }
 
@@ -231,26 +225,26 @@ impl From<ApplyBlockError> for Status {
 
 #[derive(Error, Debug)]
 pub enum GetBlockHeaderError {
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Error retrieving the merkle proof for the block: {0}")]
+    #[error("error retrieving the merkle proof for the block")]
     MmrError(#[from] MmrError),
 }
 
 #[derive(Error, Debug)]
 pub enum GetBlockInputsError {
-    #[error("Account error: {0}")]
+    #[error("account error")]
     AccountError(#[from] AccountError),
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Database doesn't have any block header data")]
+    #[error("database doesn't have any block header data")]
     DbBlockHeaderEmpty,
-    #[error("Failed to get MMR peaks for forest ({forest}): {error}")]
+    #[error("failed to get MMR peaks for forest ({forest}): {error}")]
     FailedToGetMmrPeaksForForest { forest: usize, error: MmrError },
-    #[error("Chain MMR forest expected to be 1 less than latest header's block num. Chain MMR forest: {forest}, block num: {block_num}")]
+    #[error("chain MMR forest expected to be 1 less than latest header's block num. Chain MMR forest: {forest}, block num: {block_num}")]
     IncorrectChainMmrForestNumber { forest: usize, block_num: u32 },
-    #[error("Note inclusion proof MMR error: {0}")]
-    NoteInclusionMmr(MmrError),
+    #[error("note inclusion proof MMR error")]
+    NoteInclusionMmr(#[from] MmrError),
 }
 
 impl From<GetNoteInclusionProofError> for GetBlockInputsError {
@@ -264,28 +258,28 @@ impl From<GetNoteInclusionProofError> for GetBlockInputsError {
 
 #[derive(Error, Debug)]
 pub enum StateSyncError {
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Block headers table is empty")]
+    #[error("block headers table is empty")]
     EmptyBlockHeadersTable,
-    #[error("Failed to build MMR delta: {0}")]
-    FailedToBuildMmrDelta(MmrError),
+    #[error("failed to build MMR delta")]
+    FailedToBuildMmrDelta(#[from] MmrError),
 }
 
 #[derive(Error, Debug)]
 pub enum NoteSyncError {
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Block headers table is empty")]
+    #[error("block headers table is empty")]
     EmptyBlockHeadersTable,
-    #[error("Error retrieving the merkle proof for the block: {0}")]
+    #[error("error retrieving the merkle proof for the block")]
     MmrError(#[from] MmrError),
 }
 
 #[derive(Error, Debug)]
 pub enum GetNoteInclusionProofError {
-    #[error("Database error: {0}")]
+    #[error("database error")]
     DatabaseError(#[from] DatabaseError),
-    #[error("Mmr error: {0}")]
+    #[error("Mmr error")]
     MmrError(#[from] MmrError),
 }

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -77,7 +77,7 @@ pub enum DatabaseError {
     #[error("accounts {0:?} not found")]
     AccountsNotFoundInDb(Vec<AccountId>),
     #[error("account {0} is not on the chain")]
-    AccountNotOnChain(AccountId),
+    AccountNotPublic(AccountId),
     #[error("block {0} not found")]
     BlockNotFoundInDb(BlockNumber),
     #[error("data corrupted: {0}")]
@@ -98,7 +98,7 @@ impl From<DatabaseError> for Status {
         match err {
             DatabaseError::AccountNotFoundInDb(_)
             | DatabaseError::AccountsNotFoundInDb(_)
-            | DatabaseError::AccountNotOnChain(_)
+            | DatabaseError::AccountNotPublic(_)
             | DatabaseError::BlockNotFoundInDb(_) => Status::not_found(err.to_string()),
 
             _ => Status::internal(err.to_string()),

--- a/crates/store/src/nullifier_tree.rs
+++ b/crates/store/src/nullifier_tree.rs
@@ -22,7 +22,7 @@ impl NullifierTree {
             (nullifier.inner(), Self::block_num_to_leaf_value(block_num))
         });
 
-        let inner = Smt::with_entries(leaves)?;
+        let inner = Smt::with_entries(leaves).map_err(NullifierTreeError::CreationFailed)?;
 
         Ok(Self(inner))
     }
@@ -63,7 +63,7 @@ impl NullifierTree {
         &mut self,
         mutations: MutationSet<SMT_DEPTH, RpoDigest, Word>,
     ) -> Result<(), NullifierTreeError> {
-        self.0.apply_mutations(mutations).map_err(Into::into)
+        self.0.apply_mutations(mutations).map_err(NullifierTreeError::MutationFailed)
     }
 
     // HELPER FUNCTIONS

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -175,7 +175,7 @@ impl State {
 
         let tx_hash = block.compute_tx_hash();
         if header.tx_hash() != tx_hash {
-            return Err(InvalidBlockError::InvalidTxHash {
+            return Err(InvalidBlockError::InvalidBlockTxHash {
                 expected: tx_hash,
                 actual: header.tx_hash(),
             }

--- a/crates/utils/src/errors.rs
+++ b/crates/utils/src/errors.rs
@@ -3,22 +3,22 @@ use tonic::transport::Error as TransportError;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
-    #[error("An I/O error has occurred: {0}")]
+    #[error("an I/O error has occurred")]
     IoError(#[from] std::io::Error),
 
     #[error("initialisation of the Api has failed: {0}")]
     ApiInitialisationFailed(String),
 
-    #[error("Serving the Api server has failed.")]
-    ApiServeFailed(TransportError),
+    #[error("serving the Api server has failed")]
+    ApiServeFailed(#[from] TransportError),
 
-    #[error("Resolution of the server address has failed: {0}")]
+    #[error("resolution of the server address has failed: {0}")]
     AddressResolutionFailed(String),
 
     /// Converting the provided `Endpoint` into a socket address has failed
-    #[error("Converting the `Endpoint` into a socket address failed: {0}")]
+    #[error("converting the `Endpoint` into a socket address failed: {0}")]
     EndpointToSocketFailed(std::io::Error),
 
-    #[error("Connection to the database has failed: {0}")]
+    #[error("connection to the database has failed: {0}")]
     DatabaseConnectionFailed(String),
 }

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -22,7 +22,7 @@ pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             // axum logs rejections from built-in extracts on the trace level, so we enable this
             // manually.
-            format!("{}=info,axum::rejection=trace", env!("CARGO_CRATE_NAME")).into()
+            "info,axum::rejection=trace".into()
         }))
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .finish()
@@ -37,7 +37,7 @@ pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             // axum logs rejections from built-in extracts on the trace level, so we enable this
             // manually.
-            format!("{}=info,axum::rejection=trace", env!("CARGO_CRATE_NAME")).into()
+            "info,axum::rejection=trace".into()
         }),
     )
 }

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -1,8 +1,5 @@
 use anyhow::Result;
-use tracing::{
-    level_filters::LevelFilter,
-    subscriber::{self, Subscriber},
-};
+use tracing::subscriber::{self, Subscriber};
 use tracing_subscriber::EnvFilter;
 
 pub fn setup_logging() -> Result<()> {
@@ -22,11 +19,11 @@ pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
         .with_file(true)
         .with_line_number(true)
         .with_target(true)
-        .with_env_filter(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy(),
-        )
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            // axum logs rejections from built-in extracts on the trace level, so we enable this
+            // manually.
+            format!("{}=info,axum::rejection=trace", env!("CARGO_CRATE_NAME")).into()
+        }))
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .finish()
 }
@@ -37,8 +34,10 @@ pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
     pub use tracing_subscriber::{layer::SubscriberExt, Registry};
 
     Registry::default().with(ForestLayer::default()).with(
-        EnvFilter::builder()
-            .with_default_directive(LevelFilter::INFO.into())
-            .from_env_lossy(),
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            // axum logs rejections from built-in extracts on the trace level, so we enable this
+            // manually.
+            format!("{}=info,axum::rejection=trace", env!("CARGO_CRATE_NAME")).into()
+        }),
     )
 }


### PR DESCRIPTION
Updates errors to follow the guidelines in https://github.com/0xPolygonMiden/miden-base/discussions/966.

This PR also removes the wildcard route option from the faucet. Currently the faucet allows visiting arbitrary paths (e.g. https://testnet.miden.io/asdas). Clearly this isn't behaving as intended and since we only have the single static file I've removed the wildcard entirely.

I looked into the axum defaults relating to https://github.com/0xPolygonMiden/miden-node/issues/499#issuecomment-2399190012 and decided the defaults of `Error` for failures, `Debug` for success are fine - though maybe we want to log the latter as info? I've also enabled the built-in axum rejects by setting `axum::rejections=trace` by default.

Closes #484, #499 and #581.

I do feel we could simplify our error handling strategy but that can wait for another day. In general we have many error variants, but we never actually do anything with them except bubble them up. Or put differently, aside from differentiating between internal/user-facing errors, we don't usually care about the errors.