### PR TITLE
feat: remove `testing` feature

### DIFF
--- a/.github/workflows/amd_deb_packager.yml
+++ b/.github/workflows/amd_deb_packager.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Building for amd64
         run: |
-          cargo build --release --locked --features testing --bin miden-node
-          cargo build --release --locked --features testing --bin miden-faucet
+          cargo build --release --locked --bin miden-node
+          cargo build --release --locked --bin miden-faucet
 
       - name: create package directories
         run: |

--- a/.github/workflows/arm_deb_packager.yml
+++ b/.github/workflows/arm_deb_packager.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Building for arm64
         run: |
-          cargo build --release --locked --features testing --bin miden-node
-          cargo build --release --locked --features testing --bin miden-faucet
+          cargo build --release --locked --bin miden-node
+          cargo build --release --locked --bin miden-faucet
 
       - name: create package directories
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [BREAKING] Added support for new two `Felt` account ID (#591).
 - [BREAKING] Inverted `TransactionInputs.missing_unauthenticated_notes` to `found_missing_notes` (#509).
 - [BREAKING] Remove store's `ListXXX` endpoints which were intended for test purposes (#608).
+- [BREAKING] Removed the `testing` feature (#619).
 
 ## v0.6.0 (2024-11-05)
 

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,6 @@ install-node: ## Installs node
 install-faucet: ## Installs faucet
 	${BUILD_PROTO} cargo install --path bin/faucet --locked
 
-.PHONY: install-node-testing
-install-node-testing: ## Installs node with testing feature enabled
-	${BUILD_PROTO} cargo install --features testing --path bin/node --locked
-
-.PHONY: install-faucet-testing
-install-faucet-testing: ## Installs faucet with testing feature enabled
-	${BUILD_PROTO} cargo install --features testing --path bin/faucet --locked
-
 # --- docker --------------------------------------------------------------------------------------
 
 .PHONY: docker-build-node

--- a/README.md
+++ b/README.md
@@ -93,12 +93,6 @@ cargo install --locked --git https://github.com/0xPolygonMiden/miden-node miden-
 
 More information on the various options can be found [here](https://doc.rust-lang.org/cargo/commands/cargo-install.html#install-options).
 
-> [!TIP]
-> Miden account generation uses a proof-of-work puzzle to prevent DoS attacks. These puzzles can be quite expensive, especially for test purposes. You can lower the difficulty of the puzzle by appending `--features testing` to the `cargo install ..` invocation. For example:
-> ```sh
-> cargo install miden-node --locked --features testing
-> ```
-
 ### Verify installation
 
 You can verify the installation by checking the node's version:

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -11,11 +11,6 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[features]
-# Makes `make-genesis` subcommand run faster. Is only suitable for testing.
-# INFO: Make sure that all your components have matching features for them to function.
-testing = ["miden-objects/testing", "miden-lib/testing"]
-
 [dependencies]
 anyhow = "1.0"
 axum = { version = "0.7", features = ["tokio"] }

--- a/bin/faucet/README.md
+++ b/bin/faucet/README.md
@@ -2,20 +2,17 @@
 
 This crate contains a binary for running a Miden rollup faucet.
 
-## Running the faucet in testing mode
+## Running the faucet
 
-> [!TIP]
-> Miden account generation uses a proof-of-work puzzle to prevent DoS attacks. These puzzles can be quite expensive, especially for test purposes. You can lower the difficulty of the puzzle by appending `--features testing` to the `cargo install ..` invocation.
-
-1. Run a local node with the "testing" feature, for example using the docker image. From the "miden-node" repo root run the following commands:
+1. Run a local node using the docker image. From the "miden-node" repo root run the following commands:
 ```bash
 make docker-build-node
 make docker-run-node
 ```
 
-2. Install the faucet (with the "testing" feature):
+2. Install the faucet:
 ```bash
-make install-faucet-testing
+make install-faucet
 ```
 
 3. [Optional] Create faucet account (skip this step if you want to use an account from the genesis). This will generate authentication keypair and generate and write public faucet account data with its keypair into the file specified in `output-path`: 

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -12,9 +12,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-# Makes `make-genesis` subcommand run faster. Is only suitable for testing.
-# INFO: Make sure that all your components have matching features for them to function.
-testing = ["miden-lib/testing", "miden-objects/testing"]
 tracing-forest = ["miden-node-block-producer/tracing-forest"]
 
 [dependencies]

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 WORKDIR /app
 COPY . .
 
-RUN cargo install --features testing --path bin/node --locked
+RUN cargo install --path bin/node --locked
 RUN miden-node make-genesis --inputs-path config/genesis.toml
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
This PR removes the `--testing` feature.

This feature lowered the proof-of-work requirement to something more reasonable during this alpha period. It is no longer required due to changes in the protocol which reduced the proof-of-work required in proper production.

Closes #615 