### PR TITLE
ci: check for unused dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,14 @@ jobs:
       - name: check rust versions
         run: ./scripts/check-rust-version.sh
 
+  unused_deps:
+    name: check for unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: machete
+        uses: bnjbvr/cargo-machete@main
+
   proto:
     name: proto check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,6 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
- "figment",
  "http",
  "http-body-util",
  "miden-lib",
@@ -1590,7 +1589,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -15,7 +15,6 @@ repository.workspace = true
 anyhow = "1.0"
 axum = { version = "0.7", features = ["tokio"] }
 clap = { version = "4.5", features = ["derive", "string"] }
-figment = { version = "0.10", features = ["toml", "env"] }
 http = "1.1"
 http-body-util = "0.1"
 miden-lib = { workspace = true }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -29,7 +29,6 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros"] }
 toml = { version = "0.8" }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env", "test"] }


### PR DESCRIPTION
This PR adds CI job to reject unused dependencies using [cargo machete](https://github.com/bnjbvr/cargo-machete).

In addition this PR also removes two unused dependencies.