### PR TITLE
docs: align readme rpc docs

### DIFF
--- a/crates/block-producer/README.md
+++ b/crates/block-producer/README.md
@@ -16,9 +16,39 @@ The full gRPC API can be found [here](../../proto/block_producer.proto).
 
 ### SubmitProvenTransaction
 
-Submits proven transaction to the Miden network.
+Submits a proven transaction to the block-producer, returning the current chain height if successful.
+
+The block-producer does _not_ verify the transaction's proof as it assumes the RPC component has done so. This is done
+to minimize the performance impact of new transactions on the block-producer.
+
+Transactions are verified before being added to the block-producer's mempool. Transaction which fail verification are
+rejected and an error is returned. Possible reasons for verification failure include
+
+- current account state does not match the transaction's initial account state
+- transaction attempts to consume non-existing, or already consumed notes
+- transaction attempts to create a duplicate note
+- invalid transaction proof (checked by the RPC component)
+
+Verified transactions are added to the mempool however they are still _not guaranteed_ to make it into a block.
+Transactions may be evicted from the mempool if their preconditions no longer hold. Currently the only precondition is
+transaction expiration height. Furthermore, as a defense against bugs the mempool may evict transactions it deems buggy
+e.g. cause block proofs to fail due to some bug in the VM, compiler, prover etc.
+
+Since transactions can depend on other transactions in the mempool this means a specific transaction may be evicted if:
+
+- it's own expiration height is exceeded, or
+- it is deemed buggy by the mempool, or
+- any ancestor transaction in the mempool is evicted
+
+This list will be extended in the future e.g. eviction due to gas price fluctuations.
+
+Note that since the RPC response only indicates admission into the mempool, its not directly possible to know if the
+transaction was evicted. The best way to ensure this is to effectively add a timeout to the transaction by setting the
+transaction's expiration height. Once the blockchain advances beyond this point without including the transaction you
+can know for certain it was evicted.
 
 ---
 
 ## License
+
 This project is [MIT licensed](../../LICENSE).

--- a/crates/block-producer/README.md
+++ b/crates/block-producer/README.md
@@ -1,35 +1,20 @@
 # Miden block producer
 
-The **Block producer** receives transactions from the RPC component, processes them, creates block containing those transactions before sending created blocks to the store. 
+Contains code definining the [Miden node's block-producer](/README.md#architecture) component. It is responsible for
+ordering transactions into blocks and submitting these for inclusion in the blockchain.
 
-**Block Producer** is one of components of the [Miden node](..). 
+It serves a small [rRPC](htts://grpc.io) API which the node's RPC component uses to submit new transactions. In turn,
+the `block-producer` uses the store's gRPC API to submit blocks and query chain state.
 
-## Architecture
-
-`TODO`
-
-## Usage
-
-### Installing the Block Producer
-
-The Block Producer can be installed and run as part of [Miden node](../README.md#installing-the-node). 
+For more information on the installation and operation of this component, please see the [node's readme](/README.md).
 
 ## API
 
-The **Block Producer** serves connections using the [gRPC protocol](https://grpc.io) on a port, set in the previously mentioned configuration file. 
-Here is a brief description of supported methods.
+The full gRPC API can be found [here](../../proto/block_producer.proto).
 
 ### SubmitProvenTransaction
 
 Submits proven transaction to the Miden network.
-
-**Parameters**
-
-* `transaction`: `bytes` - transaction encoded using [winter_utils::Serializable](https://github.com/facebook/winterfell/blob/main/utils/core/src/serde/mod.rs#L26) implementation for [miden_objects::transaction::proven_tx::ProvenTransaction](https://github.com/0xPolygonMiden/miden-base/blob/main/objects/src/transaction/proven_tx.rs#L22).
-
-**Returns**
-
-This method doesn't return any data.
 
 ## License
 This project is [MIT licensed](../../LICENSE).

--- a/crates/block-producer/README.md
+++ b/crates/block-producer/README.md
@@ -12,9 +12,13 @@ For more information on the installation and operation of this component, please
 
 The full gRPC API can be found [here](../../proto/block_producer.proto).
 
+---
+
 ### SubmitProvenTransaction
 
 Submits proven transaction to the Miden network.
+
+---
 
 ## License
 This project is [MIT licensed](../../LICENSE).

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -18,7 +18,7 @@ pub struct CheckNullifiersByPrefixRequest {
     #[prost(uint32, repeated, tag = "2")]
     pub nullifiers: ::prost::alloc::vec::Vec<u32>,
 }
-/// Get a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+/// Returns a nullifier proof for each of the requested nullifiers.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersRequest {
     /// List of nullifiers to return proofs for.

--- a/crates/proto/src/generated/rpc.rs
+++ b/crates/proto/src/generated/rpc.rs
@@ -90,7 +90,7 @@ pub mod api_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
-        /// Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+        /// Returns a nullifier proof for each of the requested nullifiers.
         pub async fn check_nullifiers(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -115,6 +115,8 @@ pub mod api_client {
             self.inner.unary(req, path, codec).await
         }
         /// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+        ///
+        /// Note that only 16-bit prefixes are supported at this time.
         pub async fn check_nullifiers_by_prefix(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -219,7 +221,7 @@ pub mod api_client {
                 .insert(GrpcMethod::new("rpc.Api", "GetAccountStateDelta"));
             self.inner.unary(req, path, codec).await
         }
-        /// Retrieves block data by given block number.
+        /// Returns raw block data for the specified block number.
         pub async fn get_block_by_number(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -320,10 +322,15 @@ pub mod api_client {
                 .insert(GrpcMethod::new("rpc.Api", "SubmitProvenTransaction"));
             self.inner.unary(req, path, codec).await
         }
-        /// Note synchronization request.
+        /// Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
         ///
-        /// Specifies note tags that client is interested in. The server will return the first block which
-        /// contains a note matching `note_tags` or the chain tip.
+        /// Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+        /// matching notes for. The request will then return the next block containing any note matching the provided tags.
+        ///
+        /// The response includes each note's metadata and inclusion proof.
+        ///
+        /// A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+        /// tip of the chain.
         pub async fn sync_notes(
             &mut self,
             request: impl tonic::IntoRequest<super::super::requests::SyncNoteRequest>,
@@ -396,7 +403,7 @@ pub mod api_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ApiServer.
     #[async_trait]
     pub trait Api: std::marker::Send + std::marker::Sync + 'static {
-        /// Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+        /// Returns a nullifier proof for each of the requested nullifiers.
         async fn check_nullifiers(
             &self,
             request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
@@ -405,6 +412,8 @@ pub mod api_server {
             tonic::Status,
         >;
         /// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+        ///
+        /// Note that only 16-bit prefixes are supported at this time.
         async fn check_nullifiers_by_prefix(
             &self,
             request: tonic::Request<
@@ -439,7 +448,7 @@ pub mod api_server {
             tonic::Response<super::super::responses::GetAccountStateDeltaResponse>,
             tonic::Status,
         >;
-        /// Retrieves block data by given block number.
+        /// Returns raw block data for the specified block number.
         async fn get_block_by_number(
             &self,
             request: tonic::Request<super::super::requests::GetBlockByNumberRequest>,
@@ -476,10 +485,15 @@ pub mod api_server {
             tonic::Response<super::super::responses::SubmitProvenTransactionResponse>,
             tonic::Status,
         >;
-        /// Note synchronization request.
+        /// Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
         ///
-        /// Specifies note tags that client is interested in. The server will return the first block which
-        /// contains a note matching `note_tags` or the chain tip.
+        /// Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+        /// matching notes for. The request will then return the next block containing any note matching the provided tags.
+        ///
+        /// The response includes each note's metadata and inclusion proof.
+        ///
+        /// A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+        /// tip of the chain.
         async fn sync_notes(
             &self,
             request: tonic::Request<super::super::requests::SyncNoteRequest>,

--- a/crates/proto/src/generated/store.rs
+++ b/crates/proto/src/generated/store.rs
@@ -112,7 +112,7 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("store.Api", "ApplyBlock"));
             self.inner.unary(req, path, codec).await
         }
-        /// Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+        /// Returns a nullifier proof for each of the requested nullifiers.
         pub async fn check_nullifiers(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -139,6 +139,8 @@ pub mod api_client {
             self.inner.unary(req, path, codec).await
         }
         /// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+        ///
+        /// Note that only 16-bit prefixes are supported at this time.
         pub async fn check_nullifiers_by_prefix(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -247,7 +249,7 @@ pub mod api_client {
                 .insert(GrpcMethod::new("store.Api", "GetAccountStateDelta"));
             self.inner.unary(req, path, codec).await
         }
-        /// Retrieves block data by given block number.
+        /// Returns raw block data for the specified block number.
         pub async fn get_block_by_number(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -402,10 +404,15 @@ pub mod api_client {
                 .insert(GrpcMethod::new("store.Api", "GetTransactionInputs"));
             self.inner.unary(req, path, codec).await
         }
-        /// Note synchronization request.
+        /// Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
         ///
-        /// Specifies note tags that client is interested in. The server will return the first block which
-        /// contains a note matching `note_tags` or the chain tip.
+        /// Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+        /// matching notes for. The request will then return the next block containing any note matching the provided tags.
+        ///
+        /// The response includes each note's metadata and inclusion proof.
+        ///
+        /// A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+        /// tip of the chain.
         pub async fn sync_notes(
             &mut self,
             request: impl tonic::IntoRequest<super::super::requests::SyncNoteRequest>,
@@ -486,7 +493,7 @@ pub mod api_server {
             tonic::Response<super::super::responses::ApplyBlockResponse>,
             tonic::Status,
         >;
-        /// Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+        /// Returns a nullifier proof for each of the requested nullifiers.
         async fn check_nullifiers(
             &self,
             request: tonic::Request<super::super::requests::CheckNullifiersRequest>,
@@ -495,6 +502,8 @@ pub mod api_server {
             tonic::Status,
         >;
         /// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+        ///
+        /// Note that only 16-bit prefixes are supported at this time.
         async fn check_nullifiers_by_prefix(
             &self,
             request: tonic::Request<
@@ -529,7 +538,7 @@ pub mod api_server {
             tonic::Response<super::super::responses::GetAccountStateDeltaResponse>,
             tonic::Status,
         >;
-        /// Retrieves block data by given block number.
+        /// Returns raw block data for the specified block number.
         async fn get_block_by_number(
             &self,
             request: tonic::Request<super::super::requests::GetBlockByNumberRequest>,
@@ -582,10 +591,15 @@ pub mod api_server {
             tonic::Response<super::super::responses::GetTransactionInputsResponse>,
             tonic::Status,
         >;
-        /// Note synchronization request.
+        /// Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
         ///
-        /// Specifies note tags that client is interested in. The server will return the first block which
-        /// contains a note matching `note_tags` or the chain tip.
+        /// Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+        /// matching notes for. The request will then return the next block containing any note matching the provided tags.
+        ///
+        /// The response includes each note's metadata and inclusion proof.
+        ///
+        /// A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+        /// tip of the chain.
         async fn sync_notes(
             &self,
             request: tonic::Request<super::super::requests::SyncNoteRequest>,

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -20,7 +20,7 @@ message CheckNullifiersByPrefixRequest {
     repeated uint32 nullifiers = 2;
 }
 
-// Get a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+// Returns a nullifier proof for each of the requested nullifiers.
 message CheckNullifiersRequest {
     // List of nullifiers to return proofs for.
     repeated digest.Digest nullifiers = 1;

--- a/crates/rpc-proto/proto/rpc.proto
+++ b/crates/rpc-proto/proto/rpc.proto
@@ -6,10 +6,12 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
-    // Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+    // Returns a nullifier proof for each of the requested nullifiers.
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
 
     // Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+    //
+    // Note that only 16-bit prefixes are supported at this time.
     rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
 
     // Returns the latest state of an account with the specified ID.
@@ -22,7 +24,7 @@ service Api {
     // `to_block_num` (inclusive).
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
 
-    // Retrieves block data by given block number.
+    // Returns raw block data for the specified block number.
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}
 
     // Retrieves block header by given block number. Optionally, it also returns the MMR path
@@ -35,10 +37,15 @@ service Api {
     // Submits proven transaction to the Miden network.
     rpc SubmitProvenTransaction(requests.SubmitProvenTransactionRequest) returns (responses.SubmitProvenTransactionResponse) {}
 
-    // Note synchronization request.
+    // Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
     //
-    // Specifies note tags that client is interested in. The server will return the first block which
-    // contains a note matching `note_tags` or the chain tip.
+    // Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+    // matching notes for. The request will then return the next block containing any note matching the provided tags.
+    //
+    // The response includes each note's metadata and inclusion proof.
+    //
+    // A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+    // tip of the chain. 
     rpc SyncNotes(requests.SyncNoteRequest) returns (responses.SyncNoteResponse) {}
 
     // Returns info which can be used by the client to sync up to the latest state of the chain

--- a/crates/rpc-proto/proto/store.proto
+++ b/crates/rpc-proto/proto/store.proto
@@ -11,10 +11,12 @@ service Api {
     // Applies changes of a new block to the DB and in-memory data structures.
     rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
 
-    // Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+    // Returns a nullifier proof for each of the requested nullifiers.
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
 
     // Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+    //
+    // Note that only 16-bit prefixes are supported at this time.
     rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
 
     // Returns the latest state of an account with the specified ID.
@@ -27,7 +29,7 @@ service Api {
     // `to_block_num` (inclusive).
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
 
-    // Retrieves block data by given block number.
+    // Returns raw block data for the specified block number.
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}
 
     // Retrieves block header by given block number. Optionally, it also returns the MMR path
@@ -46,10 +48,15 @@ service Api {
     // Returns data required to validate a new transaction.
     rpc GetTransactionInputs(requests.GetTransactionInputsRequest) returns (responses.GetTransactionInputsResponse) {}
 
-    // Note synchronization request.
+    // Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
     //
-    // Specifies note tags that client is interested in. The server will return the first block which
-    // contains a note matching `note_tags` or the chain tip.
+    // Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+    // matching notes for. The request will then return the next block containing any note matching the provided tags.
+    //
+    // The response includes each note's metadata and inclusion proof.
+    //
+    // A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+    // tip of the chain. 
     rpc SyncNotes(requests.SyncNoteRequest) returns (responses.SyncNoteResponse) {}
 
     // Returns info which can be used by the client to sync up to the latest state of the chain

--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -1,129 +1,88 @@
 # Miden node RPC
 
-The **RPC** is an externally-facing component through which clients can interact with the node. It receives client requests
-(e.g., to synchronize with the latest state of the chain, or to submit transactions), performs basic validation,
-and forwards the requests to the appropriate components.
-**RPC** is one of components of the [Miden node](..).
+Contains the code defining the [Miden node's RPC component](/README.md#architecture). This component serves the
+user-facing [gRPC](https://grpc.io) methods used to submit transactions and sync with the state of the network.
 
-## Architecture
+This is the **only** set of node RPC methods intended to be publicly available.
 
-`TODO`
+For more information on the installation and operation of this component, please see the [node's readme](/README.md).
 
-## Usage
+## API overview
 
-### Installing the RPC
+The full gRPC method definitions can be found in the [rpc-proto](../rpc-proto/README.md) crate.
 
-The RPC can be installed and run as part of [Miden node](../README.md#installing-the-node).
-
-## API
-
-The **RPC** serves connections using the [gRPC protocol](https://grpc.io) on a port, set in the previously mentioned configuration file.
-Here is a brief description of supported methods.
+<!--toc:start-->
+- [CheckNullifiers](#checknullifiers)
+- [CheckNullifiersByPrefix](#checknullifiersbyprefix)
+- [GetAccountDetails](#getaccountdetails)
+- [GetAccountProofs](#getaccountproofs)
+- [GetAccountStateDelta](#getaccountstatedelta)
+- [GetBlockByNumber](#getblockbynumber)
+- [GetBlockHeaderByNumber](#getblockheaderbynumber)
+- [GetNotesById](#getnotesbyid)
+- [SubmitProvenTransaction](#submitproventransaction)
+- [SyncNotes](#syncnotes)
+- [SyncState](#syncstate)
+<!--toc:end-->
 
 ### CheckNullifiers
 
 Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
 
-**Parameters:**
+### CheckNullifiersByPrefix
 
-- `nullifiers`: `[Digest]` – array of nullifier hashes.
-
-**Returns:**
-
-- `proofs`: `[NullifierProof]` – array of nullifier proofs, positions correspond to the ones in request.
-
-### GetBlockHeaderByNumber
-
-Retrieves block header by given block number, optionally alongside a Merkle path and the current chain length to validate its inclusion.
-
-**Parameters**
-
-- `block_num`: `uint32` _(optional)_ – the block number of the target block. If not provided, the latest known block will be returned.
-
-**Returns:**
-
-- `block_header`: `BlockHeader` – block header.
-
-### GetBlockByNumber
-
-Retrieves block data by given block number.
-
-**Parameters**
-
-- `block_num`: `uint32` – the block number of the target block.
-
-**Returns:**
-
-- `block`: `Block` – block data encoded using [winter_utils::Serializable](https://github.com/facebook/winterfell/blob/main/utils/core/src/serde/mod.rs#L26) implementation for [miden_objects::block::Block](https://github.com/0xPolygonMiden/miden-base/blob/main/objects/src/block/mod.rs#L43).
-
-### GetNotesById
-
-Returns a list of notes matching the provided note IDs.
-
-**Parameters**
-
-- `note_ids`: `[NoteId]` - list of IDs of the notes we want to query.
-
-**Returns**
-
-- `notes`: `[Note]` - List of notes matching the list of requested NoteIds.
+Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 
 ### GetAccountDetails
 
 Returns the latest state of an account with the specified ID.
 
-**Parameters**
+### GetAccountProofs
 
-- `account_id`: `AccountId` – account ID.
+Returns the latest state proofs of the specified accounts.
 
-**Returns**
+### GetAccountStateDelta
 
-- `account`: `AccountInfo` – latest state of the account. For public accounts, this will include full details describing the current account state. For private accounts, only the hash of the latest state and the time of the last update is returned.
+Returns delta of the account states in the range from `from_block_num` (exclusive) to `to_block_num` (inclusive).
 
-### SyncState
+### GetBlockByNumber
 
-Returns info which can be used by the client to sync up to the latest state of the chain
-for the objects (accounts, notes, nullifiers) the client is interested in.
+Retrieves block data by given block number.
 
-This request returns the next block containing requested data. It also returns `chain_tip` which is the latest block number in the chain.
-Client is expected to repeat these requests in a loop until `response.block_header.block_num == response.chain_tip`, at which point the client is fully synchronized with the chain.
+### GetBlockHeaderByNumber
 
-Each request also returns info about new notes, nullifiers etc. created. It also returns Chain MMR delta that can be used to update the state of Chain MMR.
-This includes both chain MMR peaks and chain MMR nodes.
+Retrieves block header by given block number. Optionally, it also returns the MMR path and current chain length to
+authenticate the block's inclusion.
 
-For preserving some degree of privacy, note tags and nullifiers filters contain only high part of hashes. Thus, returned data
-contains excessive notes and nullifiers, client can make additional filtering of that data on its side.
+### GetNotesById
 
-**Parameters**
-
-- `block_num`: `uint32` – send updates to the client starting at this block.
-- `account_ids`: `[AccountId]` – accounts filter.
-- `note_tags`: `[uint32]` – note tags filter. Corresponds to the high 16 bits of the real values.
-- `nullifiers`: `[uint32]` – nullifiers filter. Corresponds to the high 16 bits of the real values.
-
-**Returns**
-
-- `chain_tip`: `uint32` – number of the latest block in the chain.
-- `block_header`: `BlockHeader` – block header of the block with the first note matching the specified criteria.
-- `mmr_delta`: `MmrDelta` – data needed to update the partial MMR from `request.block_num + 1` to `response.block_header.block_num`.
-- `accounts`: `[AccountSummary]` – account summaries for accounts updated after `request.block_num + 1` but not after `response.block_header.block_num`.
-- `transactions`: `[TransactionSummary]` – transaction summaries for transactions included after `request.block_num + 1` but not after `response.block_header.block_num`.
-    - Each `TransactionSummary` consists of the `transaction_id` the transaction identifier, `account_id` of the account that executed that transaction, `block_num` the block number in which the transaction was included.
-- `notes`: `[NoteSyncRecord]` – a list of all notes together with the Merkle paths from `response.block_header.note_root`.
-- `nullifiers`: `[NullifierUpdate]` – a list of nullifiers created between `request.block_num + 1` and `response.block_header.block_num`.
-    - Each `NullifierUpdate` consists of the `nullifier` and `block_num` the block number in which the note corresponding to that nullifier was consumed.
+Returns a list of notes matching the provided note IDs.
 
 ### SubmitProvenTransaction
 
 Submits proven transaction to the Miden network.
 
-**Parameters**
+### SyncNotes
 
-- `transaction`: `bytes` - transaction encoded using [winter_utils::Serializable](https://github.com/facebook/winterfell/blob/main/utils/core/src/serde/mod.rs#L26) implementation for [miden_objects::transaction::proven_tx::ProvenTransaction](https://github.com/0xPolygonMiden/miden-base/blob/main/objects/src/transaction/proven_tx.rs#L22).
+Note synchronization request.
 
-**Returns**
+Specifies note tags that client is interested in. The server will return the first block which contains a note matching
+`note_tags` or the chain tip.
 
-This method doesn't return any data.
+### SyncState
+
+Returns info which can be used by the client to sync up to the latest state of the chain for the objects (accounts,
+notes, nullifiers) the client is interested in.
+
+This request returns the next block containing requested data. It also returns `chain_tip` which is the latest block
+number in the chain. Client is expected to repeat these requests in a loop until
+`response.block_header.block_num == response.chain_tip`, at which point the client is fully synchronized with the chain.
+
+Each request also returns info about new notes, nullifiers etc. created. It also returns Chain MMR delta that can be
+used to update the state of Chain MMR. This includes both chain MMR peaks and chain MMR nodes.
+
+For preserving some degree of privacy, note tags and nullifiers filters contain only high part of hashes. Thus, returned
+data contains excessive notes and nullifiers, client can make additional filtering of that data on its side.
 
 ## License
 

--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -12,6 +12,7 @@ For more information on the installation and operation of this component, please
 The full gRPC method definitions can be found in the [rpc-proto](../rpc-proto/README.md) crate.
 
 <!--toc:start-->
+
 - [CheckNullifiers](#checknullifiers)
 - [CheckNullifiersByPrefix](#checknullifiersbyprefix)
 - [GetAccountDetails](#getaccountdetails)
@@ -23,19 +24,22 @@ The full gRPC method definitions can be found in the [rpc-proto](../rpc-proto/RE
 - [SubmitProvenTransaction](#submitproventransaction)
 - [SyncNotes](#syncnotes)
 - [SyncState](#syncstate)
+
 <!--toc:end-->
 
 ---
 
 ### CheckNullifiers
 
-Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+Returns a nullifier proof for each of the requested nullifiers.
 
 ---
 
 ### CheckNullifiersByPrefix
 
 Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+
+Only 16-bit prefixes are supported at this time.
 
 ---
 
@@ -59,7 +63,7 @@ Returns delta of the account states in the range from `from_block_num` (exclusiv
 
 ### GetBlockByNumber
 
-Retrieves block data by given block number.
+Returns raw block data for the specified block number.
 
 ---
 
@@ -84,10 +88,15 @@ Submits proven transaction to the Miden network.
 
 ### SyncNotes
 
-Note synchronization request.
+Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
 
-Specifies note tags that client is interested in. The server will return the first block which contains a note matching
-`note_tags` or the chain tip.
+Client specifies the `note_tags` they are interested in, and the block height from which to search for new for matching
+notes for. The request will then return the next block containing any note matching the provided tags.
+
+The response includes each note's metadata and inclusion proof.
+
+A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the tip of
+the chain.
 
 ---
 

--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -25,42 +25,62 @@ The full gRPC method definitions can be found in the [rpc-proto](../rpc-proto/RE
 - [SyncState](#syncstate)
 <!--toc:end-->
 
+---
+
 ### CheckNullifiers
 
 Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+
+---
 
 ### CheckNullifiersByPrefix
 
 Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 
+---
+
 ### GetAccountDetails
 
 Returns the latest state of an account with the specified ID.
+
+---
 
 ### GetAccountProofs
 
 Returns the latest state proofs of the specified accounts.
 
+---
+
 ### GetAccountStateDelta
 
 Returns delta of the account states in the range from `from_block_num` (exclusive) to `to_block_num` (inclusive).
 
+---
+
 ### GetBlockByNumber
 
 Retrieves block data by given block number.
+
+---
 
 ### GetBlockHeaderByNumber
 
 Retrieves block header by given block number. Optionally, it also returns the MMR path and current chain length to
 authenticate the block's inclusion.
 
+---
+
 ### GetNotesById
 
 Returns a list of notes matching the provided note IDs.
 
+---
+
 ### SubmitProvenTransaction
 
 Submits proven transaction to the Miden network.
+
+---
 
 ### SyncNotes
 
@@ -68,6 +88,8 @@ Note synchronization request.
 
 Specifies note tags that client is interested in. The server will return the first block which contains a note matching
 `note_tags` or the chain tip.
+
+---
 
 ### SyncState
 
@@ -83,6 +105,8 @@ used to update the state of Chain MMR. This includes both chain MMR peaks and ch
 
 For preserving some degree of privacy, note tags and nullifiers filters contain only high part of hashes. Thus, returned
 data contains excessive notes and nullifiers, client can make additional filtering of that data on its side.
+
+---
 
 ## License
 

--- a/crates/store/README.md
+++ b/crates/store/README.md
@@ -28,54 +28,80 @@ The full gRPC API can be found [here](../../proto/store.proto).
 - [SyncState](#syncstate)
 <!--toc:end-->
 
+---
+
 ### ApplyBlock
 
 Applies changes of a new block to the DB and in-memory data structures.
+
+---
 
 ### CheckNullifiers
 
 Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
 
+---
+
 ### CheckNullifiersByPrefix
 
 Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+
+---
 
 ### GetAccountDetails
 
 Returns the latest state of an account with the specified ID.
 
+---
+
 ### GetAccountProofs
 
 Returns the latest state proofs of the specified accounts.
+
+---
 
 ### GetAccountStateDelta
 
 Returns delta of the account states in the range from `from_block_num` (exclusive) to `to_block_num` (inclusive).
 
+---
+
 ### GetBlockByNumber
 
 Retrieves block data by given block number.
+
+---
 
 ### GetBlockHeaderByNumber
 
 Retrieves block header by given block number. Optionally, it also returns the MMR path and current chain length to
 authenticate the block's inclusion.
 
+---
+
 ### GetBlockInputs
 
 Returns data required to prove the next block.
+
+---
 
 ### GetNoteAuthenticationInfo
 
 Returns a list of Note inclusion proofs for the specified Note IDs.
 
+---
+
 ### GetNotesById
 
 Returns a list of notes matching the provided note IDs.
 
+---
+
 ### GetTransactionInputs
 
 Returns data required to validate a new transaction.
+
+---
 
 ### SyncNotes
 
@@ -83,6 +109,8 @@ Note synchronization request.
 
 Specifies note tags that client is interested in. The server will return the first block which contains a note matching
 `note_tags` or the chain tip.
+
+---
 
 ### SyncState
 
@@ -98,6 +126,8 @@ used to update the state of Chain MMR. This includes both chain MMR peaks and ch
 
 For preserving some degree of privacy, note tags and nullifiers filters contain only high part of hashes. Thus, returned
 data contains excessive notes and nullifiers, client can make additional filtering of that data on its side.
+
+---
 
 ## License
 

--- a/crates/store/README.md
+++ b/crates/store/README.md
@@ -1,163 +1,103 @@
 # Miden node store
 
-The **Store** maintains the state of the chain. It serves as the "source of truth" for the chain - i.e., if it is not in
-the store, the node does not consider it to be part of the chain.
-Incoming requests to the store are trusted because they are validated in the RPC component.
+Contains the code defining the [Miden node's store component](/README.md#architecture). This component stores the
+network's state and acts as the networks source of truth. It serves a [gRPC](https://grpc.io) API which allow the other
+node components to interact with the store. This API is **internal** only and is considered trusted i.e. the node
+operator must take care that the store's API endpoint is **only** exposed to the other node components.
 
-**Store** is one of components of the [Miden node](..).
+For more information on the installation and operation of this component, please see the [node's readme](/README.md).
 
-## Architecture
+## API overview
 
-`TODO`
+The full gRPC API can be found [here](../../proto/store.proto).
 
-## Usage
-
-### Installing the Store
-
-The Store can be installed and run as part of [Miden node](../README.md#installing-the-node).
-
-## API
-
-The **Store** serves connections using the [gRPC protocol](https://grpc.io) on a port, set in the previously mentioned configuration file. 
-Here is a brief description of supported methods.
+<!--toc:start-->
+- [ApplyBlock](#applyblock)
+- [CheckNullifiers](#checknullifiers)
+- [CheckNullifiersByPrefix](#checknullifiersbyprefix)
+- [GetAccountDetails](#getaccountdetails)
+- [GetAccountProofs](#getaccountproofs)
+- [GetAccountStateDelta](#getaccountstatedelta)
+- [GetBlockByNumber](#getblockbynumber)
+- [GetBlockHeaderByNumber](#getblockheaderbynumber)
+- [GetBlockInputs](#getblockinputs)
+- [GetNoteAuthenticationInfo](#getnoteauthenticationinfo)
+- [GetNotesById](#getnotesbyid)
+- [GetTransactionInputs](#gettransactioninputs)
+- [SyncNotes](#syncnotes)
+- [SyncState](#syncstate)
+<!--toc:end-->
 
 ### ApplyBlock
 
 Applies changes of a new block to the DB and in-memory data structures.
 
-**Parameters**
-
-- `block`: `BlockHeader` – block header ([src](../proto/proto/block_header.proto)).
-- `accounts`: `[AccountUpdate]` – a list of account updates.
-- `nullifiers`: `[Digest]` – a list of nullifier hashes.
-- `notes`: `[NoteCreated]` – a list of notes created.
-
-**Returns**
-
-This method doesn't return any data.
-
 ### CheckNullifiers
 
-Get a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree
+Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
 
-**Parameters:**
+### CheckNullifiersByPrefix
 
-- `nullifiers`: `[Digest]` – array of nullifier hashes.
-
-**Returns:**
-
-- `proofs`: `[NullifierProof]` – array of nullifier proofs, positions correspond to the ones in request.
-
-### GetBlockHeaderByNumber
-
-Retrieves block header by given block number. Optionally, it also returns the MMR path and current chain length to authenticate the block's inclusion.
-
-**Parameters**
-
-- `block_num`: `uint32` _(optional)_ – the block number of the target block. If not provided, the latest known block will be returned.
-
-**Returns:**
-
-- `block_header`: `BlockHeader` – block header.
-
-### GetBlockByNumber
-
-Retrieves block data by given block number.
-
-**Parameters**
-
-- `block_num`: `uint32` – the block number of the target block.
-
-**Returns:**
-
-- `block`: `Block` – block data encoded using [winter_utils::Serializable](https://github.com/facebook/winterfell/blob/main/utils/core/src/serde/mod.rs#L26) implementation for [miden_objects::block::Block](https://github.com/0xPolygonMiden/miden-base/blob/main/objects/src/block/mod.rs#L43).
-
-### GetBlockInputs
-
-Returns data required to prove the next block.
-
-**Parameters**
-
-- `account_ids`: `[AccountId]` – array of account IDs.
-- `nullifiers`: `[Digest]` – array of nullifier hashes (not currently in use).
-
-**Returns**
-
-- `block_header`: `[BlockHeader]` – the latest block header.
-- `mmr_peaks`: `[Digest]` – peaks of the above block's mmr, The `forest` value is equal to the block number.
-- `account_states`: `[AccountBlockInputRecord]` – the hashes of the requested accounts and their authentication paths.
-- `nullifiers`: `[NullifierBlockInputRecord]` – the requested nullifiers and their authentication paths.
-
-### GetTransactionInputs
-
-Returns data required to validate a new transaction.
-
-**Parameters**
-
-- `account_id`: `AccountId` – ID of the account against which a transaction is executed.
-- `nullifiers`: `[Digest]` – set of nullifiers consumed by this transaction.
-
-**Returns**
-
-- `account_state`: `AccountTransactionInputRecord` – account's descriptors.
-- `nullifiers`: `[NullifierTransactionInputRecord]` – the block numbers at which corresponding nullifiers have been consumed, zero if not consumed.
-
-### GetNotesById
-
-Returns a list of notes matching the provided note IDs.
-
-**Parameters**
-
-- `note_ids`: `[NoteId]` - list of IDs of the notes we want to query.
-
-**Returns**
-
-- `notes`: `[Note]` - List of notes matching the list of requested NoteIds.
+Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 
 ### GetAccountDetails
 
 Returns the latest state of an account with the specified ID.
 
-**Parameters**
+### GetAccountProofs
 
-- `account_id`: `AccountId` – account ID.
+Returns the latest state proofs of the specified accounts.
 
-**Returns**
+### GetAccountStateDelta
 
-- `account`: `AccountInfo` – latest state of the account. For public accounts, this will include full details describing the current account state. For private accounts, only the hash of the latest state and the time of the last update is returned.
+Returns delta of the account states in the range from `from_block_num` (exclusive) to `to_block_num` (inclusive).
+
+### GetBlockByNumber
+
+Retrieves block data by given block number.
+
+### GetBlockHeaderByNumber
+
+Retrieves block header by given block number. Optionally, it also returns the MMR path and current chain length to
+authenticate the block's inclusion.
+
+### GetBlockInputs
+
+Returns data required to prove the next block.
+
+### GetNoteAuthenticationInfo
+
+Returns a list of Note inclusion proofs for the specified Note IDs.
+
+### GetNotesById
+
+Returns a list of notes matching the provided note IDs.
+
+### GetTransactionInputs
+
+Returns data required to validate a new transaction.
+
+### SyncNotes
+
+Note synchronization request.
+
+Specifies note tags that client is interested in. The server will return the first block which contains a note matching
+`note_tags` or the chain tip.
 
 ### SyncState
 
-Returns info which can be used by the client to sync up to the latest state of the chain
-for the objects (accounts, notes, nullifiers) the client is interested in.
+Returns info which can be used by the client to sync up to the latest state of the chain for the objects (accounts,
+notes, nullifiers) the client is interested in.
 
-This request returns the next block containing requested data. It also returns `chain_tip` which is the latest block number in the chain.
-Client is expected to repeat these requests in a loop until `response.block_header.block_num == response.chain_tip`, at which point the client is fully synchronized with the chain.
+This request returns the next block containing requested data. It also returns `chain_tip` which is the latest block
+number in the chain. Client is expected to repeat these requests in a loop until
+`response.block_header.block_num == response.chain_tip`, at which point the client is fully synchronized with the chain.
 
-Each request also returns info about new notes, nullifiers etc. created. It also returns Chain MMR delta that can be used to update the state of Chain MMR.
-This includes both chain MMR peaks and chain MMR nodes.
+Each request also returns info about new notes, nullifiers etc. created. It also returns Chain MMR delta that can be
+used to update the state of Chain MMR. This includes both chain MMR peaks and chain MMR nodes.
 
-For preserving some degree of privacy, note tags and nullifiers filters contain only high part of hashes. Thus, returned data
-contains excessive notes and nullifiers, client can make additional filtering of that data on its side.
-
-**Parameters**
-
-- `block_num`: `uint32` – send updates to the client starting at this block.
-- `account_ids`: `[AccountId]` – accounts filter.
-- `note_tags`: `[uint32]` – note tags filter. Corresponds to the high 16 bits of the real values.
-- `nullifiers`: `[uint32]` – nullifiers filter. Corresponds to the high 16 bits of the real values.
-
-**Returns**
-
-- `chain_tip`: `uint32` – number of the latest block in the chain.
-- `block_header`: `BlockHeader` – block header of the block with the first note matching the specified criteria.
-- `mmr_delta`: `MmrDelta` – data needed to update the partial MMR from `request.block_num + 1` to `response.block_header.block_num`.
-- `accounts`: `[AccountSummary]` – account summaries for accounts updated after `request.block_num + 1` but not after `response.block_header.block_num`.
-- `transactions`: `[TransactionSummary]` – transaction summaries for transactions included after `request.block_num + 1` but not after `response.block_header.block_num`.
-    - Each `TransactionSummary` consists of the `transaction_id` the transaction identifier, `account_id` of the account that executed that transaction, `block_num` the block number in which the transaction was included.
-- `notes`: `[NoteSyncRecord]` – a list of all notes together with the Merkle paths from `response.block_header.note_root`.
-- `nullifiers`: `[NullifierUpdate]` – a list of nullifiers created between `request.block_num + 1` and `response.block_header.block_num`.
-    - Each `NullifierUpdate` consists of the `nullifier` and `block_num` the block number in which the note corresponding to that nullifier was consumed.
+For preserving some degree of privacy, note tags and nullifiers filters contain only high part of hashes. Thus, returned
+data contains excessive notes and nullifiers, client can make additional filtering of that data on its side.
 
 ## License
 

--- a/crates/store/README.md
+++ b/crates/store/README.md
@@ -32,19 +32,21 @@ The full gRPC API can be found [here](../../proto/store.proto).
 
 ### ApplyBlock
 
-Applies changes of a new block to the DB and in-memory data structures.
+Applies changes of a new block to the DB and in-memory data structures. Raw block data is also stored as a flat file.
 
 ---
 
 ### CheckNullifiers
 
-Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+Returns a nullifier proof for each of the requested nullifiers.
 
 ---
 
 ### CheckNullifiersByPrefix
 
 Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+
+Only 16-bit prefixes are supported at this time.
 
 ---
 
@@ -68,7 +70,7 @@ Returns delta of the account states in the range from `from_block_num` (exclusiv
 
 ### GetBlockByNumber
 
-Retrieves block data by given block number.
+Returns raw block data for the specified block number.
 
 ---
 
@@ -81,13 +83,15 @@ authenticate the block's inclusion.
 
 ### GetBlockInputs
 
-Returns data required to prove the next block.
+Used by the `block-producer` to query state required to prove the next block.
 
 ---
 
 ### GetNoteAuthenticationInfo
 
 Returns a list of Note inclusion proofs for the specified Note IDs.
+
+This is used by the `block-producer` as part of the batch proving process.
 
 ---
 
@@ -99,16 +103,21 @@ Returns a list of notes matching the provided note IDs.
 
 ### GetTransactionInputs
 
-Returns data required to validate a new transaction.
+Used by the `block-producer` to query state required to verify a submitted transaction.
 
 ---
 
 ### SyncNotes
 
-Note synchronization request.
+Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
 
-Specifies note tags that client is interested in. The server will return the first block which contains a note matching
-`note_tags` or the chain tip.
+Client specifies the `note_tags` they are interested in, and the block height from which to search for new for matching
+notes for. The request will then return the next block containing any note matching the provided tags.
+
+The response includes each note's metadata and inclusion proof.
+
+A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the tip of
+the chain.
 
 ---
 

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -20,7 +20,7 @@ message CheckNullifiersByPrefixRequest {
     repeated uint32 nullifiers = 2;
 }
 
-// Get a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+// Returns a nullifier proof for each of the requested nullifiers.
 message CheckNullifiersRequest {
     // List of nullifiers to return proofs for.
     repeated digest.Digest nullifiers = 1;

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -6,10 +6,12 @@ import "requests.proto";
 import "responses.proto";
 
 service Api {
-    // Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+    // Returns a nullifier proof for each of the requested nullifiers.
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
 
     // Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+    //
+    // Note that only 16-bit prefixes are supported at this time.
     rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
 
     // Returns the latest state of an account with the specified ID.
@@ -22,7 +24,7 @@ service Api {
     // `to_block_num` (inclusive).
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
 
-    // Retrieves block data by given block number.
+    // Returns raw block data for the specified block number.
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}
 
     // Retrieves block header by given block number. Optionally, it also returns the MMR path
@@ -35,10 +37,15 @@ service Api {
     // Submits proven transaction to the Miden network.
     rpc SubmitProvenTransaction(requests.SubmitProvenTransactionRequest) returns (responses.SubmitProvenTransactionResponse) {}
 
-    // Note synchronization request.
+    // Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
     //
-    // Specifies note tags that client is interested in. The server will return the first block which
-    // contains a note matching `note_tags` or the chain tip.
+    // Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+    // matching notes for. The request will then return the next block containing any note matching the provided tags.
+    //
+    // The response includes each note's metadata and inclusion proof.
+    //
+    // A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+    // tip of the chain. 
     rpc SyncNotes(requests.SyncNoteRequest) returns (responses.SyncNoteResponse) {}
 
     // Returns info which can be used by the client to sync up to the latest state of the chain

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -11,10 +11,12 @@ service Api {
     // Applies changes of a new block to the DB and in-memory data structures.
     rpc ApplyBlock(requests.ApplyBlockRequest) returns (responses.ApplyBlockResponse) {}
 
-    // Gets a list of proofs for given nullifier hashes, each proof as a sparse Merkle Tree.
+    // Returns a nullifier proof for each of the requested nullifiers.
     rpc CheckNullifiers(requests.CheckNullifiersRequest) returns (responses.CheckNullifiersResponse) {}
 
     // Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
+    //
+    // Note that only 16-bit prefixes are supported at this time.
     rpc CheckNullifiersByPrefix(requests.CheckNullifiersByPrefixRequest) returns (responses.CheckNullifiersByPrefixResponse) {}
 
     // Returns the latest state of an account with the specified ID.
@@ -27,7 +29,7 @@ service Api {
     // `to_block_num` (inclusive).
     rpc GetAccountStateDelta(requests.GetAccountStateDeltaRequest) returns (responses.GetAccountStateDeltaResponse) {}
 
-    // Retrieves block data by given block number.
+    // Returns raw block data for the specified block number.
     rpc GetBlockByNumber(requests.GetBlockByNumberRequest) returns (responses.GetBlockByNumberResponse) {}
 
     // Retrieves block header by given block number. Optionally, it also returns the MMR path
@@ -46,10 +48,15 @@ service Api {
     // Returns data required to validate a new transaction.
     rpc GetTransactionInputs(requests.GetTransactionInputsRequest) returns (responses.GetTransactionInputsResponse) {}
 
-    // Note synchronization request.
+    // Returns info which can be used by the client to sync up to the tip of chain for the notes they are interested in.
     //
-    // Specifies note tags that client is interested in. The server will return the first block which
-    // contains a note matching `note_tags` or the chain tip.
+    // Client specifies the `note_tags` they are interested in, and the block height from which to search for new for
+    // matching notes for. The request will then return the next block containing any note matching the provided tags.
+    //
+    // The response includes each note's metadata and inclusion proof.
+    //
+    // A basic note sync can be implemented by repeatedly requesting the previous response's block until reaching the
+    // tip of the chain. 
     rpc SyncNotes(requests.SyncNoteRequest) returns (responses.SyncNoteResponse) {}
 
     // Returns info which can be used by the client to sync up to the latest state of the chain


### PR DESCRIPTION
This PR re-aligns the various RPC docs with the proto files.

I've opted to only provide a summary and not a full parameter doxygen style documentation as there was before as I don't think its trivial to keep aligned with reality, nor sufficient -- users will always have to use and/or read the proto files.

Closes #626 