### PR TITLE
Update itertools and axum versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,8 +197,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -206,7 +233,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -231,6 +258,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
  "bytes",
  "futures-util",
  "http",
@@ -1413,6 +1459,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,7 +1545,7 @@ name = "miden-faucet"
 version = "0.8.0"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.8.1",
  "clap",
  "http",
  "http-body-util",
@@ -3072,7 +3124,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64",
  "bytes",
  "h2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,6 +1204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,7 +1608,7 @@ version = "0.8.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "miden-air",
  "miden-lib",
  "miden-node-proto",
@@ -1689,7 +1698,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "figment",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "miden-objects",
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ version      = "0.8.0"
 
 [workspace.dependencies]
 assert_matches            = { version = "1.5" }
+itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.12" }
 miden-lib                 = { version = "0.7" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.8" }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow           = "1.0"
-axum             = { version = "0.7", features = ["tokio"] }
+axum             = { version = "0.8", features = ["tokio"] }
 clap             = { version = "4.5", features = ["derive", "string"] }
 http             = "1.1"
 http-body-util   = "0.1"

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -19,7 +19,7 @@ tracing-forest = ["miden-node-utils/tracing-forest"]
 
 [dependencies]
 async-trait      = { version = "0.1" }
-itertools        = { version = "0.13" }
+itertools        = { workspace = true }
 miden-lib        = { workspace = true }
 miden-node-proto = { workspace = true }
 miden-node-utils = { workspace = true }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -21,7 +21,7 @@ vergen = ["dep:vergen", "dep:vergen-gitcl"]
 [dependencies]
 anyhow             = { version = "1.0" }
 figment            = { version = "0.10", features = ["env", "toml"] }
-itertools          = { version = "0.12" }
+itertools          = { workspace = true }
 miden-objects      = { workspace = true }
 rand               = { workspace = true }
 serde              = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Closes #642

* Updates itertools and axum dependancy versions
* Adds itertools as a workspace dependancy

Noting that rusqlite must remain at 0.32.1 due to deadpool-sqlite's version requirements [here](https://crates.io/crates/deadpool-sqlite/0.9.0/dependencies).
```
╰─➤  cargo upgrades
miden-node-store
dependency  current  upgrade
rusqlite    0.32.1   0.33.0
```