### PR TITLE
feat: deployment related fixes

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -100,8 +100,8 @@ runs:
       env:
         repo-url: ${{ github.server_url }}/${{ github.repository }}
       run: |
-        cargo install miden-node   --root . --locked --features testing --git ${{ env.repo-url }} --rev ${{ steps.git-sha.outputs.sha }}
-        cargo install miden-faucet --root . --locked --features testing --git ${{ env.repo-url }} --rev ${{ steps.git-sha.outputs.sha }}
+        cargo install miden-node   --root . --locked --git ${{ env.repo-url }} --rev ${{ steps.git-sha.outputs.sha }}
+        cargo install miden-faucet --root . --locked --git ${{ env.repo-url }} --rev ${{ steps.git-sha.outputs.sha }}
 
     - name: Copy binary files
       shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: string
 
+# Limit concurrency to 1 per network.
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.network }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,9 @@ jobs:
       oidcrole: midendev
       instance-id: ${{ inputs.network == 'testnet' && 'TESTNET_INSTANCE_TF' || 'DEVNET_INSTANCE_TF' }}
 
-      # Define the expected package names.
-      node-package:   miden-node-${{ inputs.gitref }}-arm64.deb
-      faucet-package: miden-faucet-${{ inputs.gitref }}-arm64.deb
-
+      # Unique name for each package file per workflow run so there are no clashes on s3.
+      node-package: node-${{ github.run_id }}-${{ github.run_number }}.arm64.deb
+      faucet-package: faucet-${{ github.run_id }}-${{ github.run_number }}.arm64.deb
         
     steps:
       # S3 path where packages are stored; used to send packages to instance as this isn't trivially possible directly.
@@ -55,14 +54,19 @@ jobs:
         if: ${{ startsWith(inputs.gitref, 'v') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          node-artifact:   miden-node-${{ inputs.gitref }}-arm64.deb
+          faucet-artifact: miden-faucet-${{ inputs.gitref }}-arm64.deb
         run: |
-          gh release download ${{ inputs.gitref }} -p ${{ env.node-package }}
-          gh release download ${{ inputs.gitref }} -p ${{ env.node-package }}.checksum
-          gh release download ${{ inputs.gitref }} -p ${{ env.faucet-package }}
-          gh release download ${{ inputs.gitref }} -p ${{ env.faucet-package }}.checksum
+          gh release download ${{ inputs.gitref }} -p ${{ env.node-artifact }}
+          gh release download ${{ inputs.gitref }} -p ${{ env.node-artifact }}.checksum
+          gh release download ${{ inputs.gitref }} -p ${{ env.faucet-artifact }}
+          gh release download ${{ inputs.gitref }} -p ${{ env.faucet-artifact }}.checksum
 
-          sha256sum --check ${{ env.node-package }}.checksum
-          sha256sum --check ${{ env.faucet-package }}.checksum
+          sha256sum --check ${{ env.node-artifact }}.checksum
+          sha256sum --check ${{ env.faucet-artifact }}.checksum
+
+          mv ${{ env.node-artifact }} ${{ env.node-package }}
+          mv ${{ env.faucet-artifact }} ${{ env.faucet-package }}
 
       # Otherwise build the packages from source.
       #

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,6 @@ jobs:
         run: |
           mv miden-node.deb   ${{ env.node-package }} 
           mv miden-faucet.deb ${{ env.faucet-package }} 
-          
 
       # Configure AWS communication via SSM.
       - name: Configure AWS credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- [BREAKING] Default faucet endpoint is now public instead of localhost.
+
 ## v0.7.0 (2025-01-23)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- [BREAKING] Default faucet endpoint is now public instead of localhost.
+- [BREAKING] Default faucet endpoint is now public instead of localhost (#647).
 
 ## v0.7.0 (2025-01-23)
 

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -3,7 +3,9 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::{Endpoint, DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT};
+use miden_node_utils::config::{
+    Endpoint, Protocol, DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT,
+};
 use serde::{Deserialize, Serialize};
 
 // Faucet config
@@ -42,7 +44,11 @@ impl Display for FaucetConfig {
 impl Default for FaucetConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::localhost(DEFAULT_FAUCET_SERVER_PORT),
+            endpoint: Endpoint {
+                host: "0.0.0.0".to_string(),
+                port: DEFAULT_FAUCET_SERVER_PORT,
+                protocol: Protocol::Http,
+            },
             node_url: Endpoint::localhost(DEFAULT_NODE_RPC_PORT).to_string(),
             timeout_ms: DEFAULT_RPC_TIMEOUT_MS,
             asset_amount_options: vec![100, 500, 1000],

--- a/bin/faucet/src/errors.rs
+++ b/bin/faucet/src/errors.rs
@@ -29,9 +29,6 @@ pub enum HandlerError {
 
     #[error("invalid asset amount {requested} requested, valid options are {options:?}")]
     InvalidAssetAmount { requested: u64, options: Vec<u64> },
-
-    #[error("not found")]
-    NotFound,
 }
 
 impl HandlerError {
@@ -41,7 +38,6 @@ impl HandlerError {
                 StatusCode::BAD_REQUEST
             },
             Self::ClientError(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::NotFound => StatusCode::NOT_FOUND,
         }
     }
 

--- a/bin/faucet/src/errors.rs
+++ b/bin/faucet/src/errors.rs
@@ -29,6 +29,9 @@ pub enum HandlerError {
 
     #[error("invalid asset amount {requested} requested, valid options are {options:?}")]
     InvalidAssetAmount { requested: u64, options: Vec<u64> },
+
+    #[error("not found")]
+    NotFound,
 }
 
 impl HandlerError {
@@ -38,6 +41,7 @@ impl HandlerError {
                 StatusCode::BAD_REQUEST
             },
             Self::ClientError(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotFound => StatusCode::NOT_FOUND,
         }
     }
 

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use axum::{
-    extract::State,
+    extract::{Path, State},
     http::{Response, StatusCode},
     response::IntoResponse,
     Json,
@@ -116,10 +116,13 @@ pub async fn get_tokens(
         .map_err(Into::into)
 }
 
-pub async fn get_index(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
-    info!(target: COMPONENT, "Serving `index.html`");
+pub async fn get_static_file(
+    State(state): State<FaucetState>,
+    Path(path): Path<String>,
+) -> Result<impl IntoResponse, HandlerError> {
+    info!(target: COMPONENT, path, "Serving static file");
 
-    let static_file = state.static_files.get("index.html").expect("index.html should be bundled");
+    let static_file = state.static_files.get(path.as_str()).ok_or(HandlerError::NotFound)?;
 
     Response::builder()
         .status(StatusCode::OK)

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use axum::{
-    extract::{Path, State},
+    extract::State,
     http::{Response, StatusCode},
     response::IntoResponse,
     Json,
@@ -116,13 +116,30 @@ pub async fn get_tokens(
         .map_err(Into::into)
 }
 
-pub async fn get_static_file(
-    State(state): State<FaucetState>,
-    Path(path): Path<String>,
-) -> Result<impl IntoResponse, HandlerError> {
-    info!(target: COMPONENT, path, "Serving static file");
+pub async fn get_index_html(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
+    get_static_file(state, "index.html")
+}
 
-    let static_file = state.static_files.get(path.as_str()).ok_or(HandlerError::NotFound)?;
+pub async fn get_index_js(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
+    get_static_file(state, "index.js")
+}
+
+pub async fn get_index_css(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
+    get_static_file(state, "index.css")
+}
+
+/// Returns a static file bundled with the app state.
+///
+/// # Panics
+///
+/// Panics if the file does not exist.
+fn get_static_file(
+    State(state): State<FaucetState>,
+    file: &'static str,
+) -> Result<impl IntoResponse, HandlerError> {
+    info!(target: COMPONENT, file, "Serving static file");
+
+    let static_file = state.static_files.get(file).expect("static file not found");
 
     Response::builder()
         .status(StatusCode::OK)

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use axum::{
+    extract::Path,
     routing::{get, post},
     Router,
 };
@@ -102,6 +103,7 @@ async fn main() -> anyhow::Result<()> {
             info!(target: COMPONENT, %config, "Initializing server");
 
             let app = Router::new()
+                .route("/", get(|state| get_static_file(state, Path("index.html".to_string()))))
                 .route("/get_metadata", get(get_metadata))
                 .route("/get_tokens", post(get_tokens))
                 .route("/*path", get(get_static_file))

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -9,12 +9,12 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use axum::{
-    extract::Path,
     routing::{get, post},
     Router,
 };
 use clap::{Parser, Subcommand};
 use client::initialize_faucet_client;
+use handlers::{get_index_css, get_index_html, get_index_js};
 use http::HeaderValue;
 use miden_lib::{account::faucets::create_basic_fungible_faucet, AuthScheme};
 use miden_node_utils::{config::load_config, crypto::get_rpo_random_coin, version::LongVersion};
@@ -34,7 +34,7 @@ use tracing::info;
 
 use crate::{
     config::{FaucetConfig, DEFAULT_FAUCET_ACCOUNT_PATH},
-    handlers::{get_metadata, get_static_file, get_tokens},
+    handlers::{get_metadata, get_tokens},
 };
 
 // CONSTANTS
@@ -103,10 +103,11 @@ async fn main() -> anyhow::Result<()> {
             info!(target: COMPONENT, %config, "Initializing server");
 
             let app = Router::new()
-                .route("/", get(|state| get_static_file(state, Path("index.html".to_string()))))
+                .route("/", get(get_index_html))
+                .route("/index.js", get(get_index_js))
+                .route("/index.css", get(get_index_css))
                 .route("/get_metadata", get(get_metadata))
                 .route("/get_tokens", post(get_tokens))
-                .route("/*path", get(get_static_file))
                 .layer(
                     ServiceBuilder::new()
                         .layer(TraceLayer::new_for_http())

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -33,7 +33,7 @@ use tracing::info;
 
 use crate::{
     config::{FaucetConfig, DEFAULT_FAUCET_ACCOUNT_PATH},
-    handlers::{get_index, get_metadata, get_tokens},
+    handlers::{get_metadata, get_static_file, get_tokens},
 };
 
 // CONSTANTS
@@ -102,9 +102,9 @@ async fn main() -> anyhow::Result<()> {
             info!(target: COMPONENT, %config, "Initializing server");
 
             let app = Router::new()
-                .route("/", get(get_index))
                 .route("/get_metadata", get(get_metadata))
                 .route("/get_tokens", post(get_tokens))
+                .route("/*path", get(get_static_file))
                 .layer(
                     ServiceBuilder::new()
                         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
This PR has a variety of fixes for the faucet and deployment scripts.

## Faucet fixes

Changes actually affecting other operators.

- Faucet webpage was broken because I removed `/*path` which removed serving of `index.css` and `index.js`. I re-added them as constant paths instead. Note that I also tried supporting `/index.html` which is a common entry-point/alias for `/` but this didn't work - the `html` script attempts to fetch `/index.html/index.js`.
- Faucet webpage endpoint is now public: `localhost` -> `0.0.0.0` by default. This is so deployments are automatically public instead of private.

## Deployment changes

Changes to our deployment workflow scripts.

- Remove `--features testing` vestiges (fix).
- Limit workflow concurrency to 1-per-network.
- Fix naming of deb packages when deploying a branch. The naming scheme used the branch name - however this causes issues when the branch name contains a `/` e.g. `mirko/fixup_deploy`. Instead we now assign a unique name per workflow run. This name is only used to transfer between `github -> S3 -> deploy instance`.

## Good news

With these changes the deployment did #just-work alongside the DNS related devops changes.

`faucet.devnet.miden.io` works as expected.

`rpc.devnet.miden.io` works with the client once the TLS issue (https://github.com/0xPolygonMiden/miden-client/issues/696) is addressed.

## Release versions

How do we want to handle versioning given that `v0.7.0` is already on crates.io? At minimum we need the faucet route fixes; which we could separate out and release as `v0.7.1`. Though ideally for deployment we want to also just deploy the release version, so having both would be nice.

Ideally we also need to make the github release so we can tag `v0.7.0` for `crates.io` to link against properly.

## Future facing notes

### `toml` configuration

Using `toml` as the sole configuration format is pretty painful for scripting. As an example, ideally we would keep the defaults of all endpoints as `localhost` as this is safer.

We also want to use internal DNS values without making them the default e.g. `store.devnet.miden.io` but we cannot do that without additional scripting.

How does one edit toml files using a script? I guess one could get an additional binary that performs `toml` edit'ing. However this now becomes an additional tool that needs to be deployed on servers.

You might consider using `sed` however that becomes tricky because `toml` can have identical lines under different sections i.e. you cannot simply replace `endpoint = ...` because there are multiple such lines -- so you need some section awareness.

It basically makes it painful to change defaults in a non-manual manner.

Personally I would advocate that we should default to `cli` configuration, with `env` variable support (trivial with clap). We could even keep the `toml` files; though I would argue that they are obsolete because one just as easily create a `.env` file with environment variables.

### Endpoints

We use the `Endpoint` type which splits the concern of `host`, `port` and `protocol`. I think we should remove it entirely and delegate that responsibility entirely to the `http` client/server crates we use. I think all of them take a `&str` or similar argument in any case.

They're a leaky abstraction imo; just take a string and let the experts deal with it.

### Static files

Low priority, but we could consider a better html solution. Especially if we want to add more in the future as a configuration/admin dashboard.

There are some interesting developments with htmx and crates like [maud](https://github.com/lambda-fairy/maud?tab=readme-ov-file) and [askama](https://github.com/rinja-rs/askama?tab=readme-ov-file) for embedding html. 

# Status

`faucet.devnet.miden.io` is down after re-deploying. Waiting on support.