### PR TITLE
ci: add workspace-lints to Makefile and lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,11 +59,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
         with:
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+          tool: cargo-workspace-lints
       - run: |
-          cargo install cargo-workspace-lints --locked
           make workspace-check
 
   doc:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,18 @@ jobs:
           tool: taplo-cli
       - run: make toml-check
 
+  workspace-lints:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - run: |
+          cargo install cargo-workspace-lints --locked
+          make workspace-check
+
   doc:
     name: doc
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ toml-check: ## Runs Format for all TOML files but only in check mode
 	taplo fmt --check --verbose
 
 
+.PHONY: workspace-check
+workspace-check: ## Runs a check that all packages have `lints.workspace = true`
+	cargo workspace-lints
+
+
 .PHONY: lint
 lint: format fix clippy toml ## Runs all linting tasks at once (Clippy, fixing, formatting)
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ workspace-check: ## Runs a check that all packages have `lints.workspace = true`
 
 
 .PHONY: lint
-lint: format fix clippy toml ## Runs all linting tasks at once (Clippy, fixing, formatting)
+lint: format fix clippy toml workspace-check ## Runs all linting tasks at once (Clippy, fixing, formatting, workspace)
 
 # --- docs ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #635

Adds a make target for performing workspace lint check in all packages and runs this in PR workflow. See [crate](https://crates.io/crates/cargo-workspace-lints).