### PR TITLE
Prepare v0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.1 (2025-01-28)
+
 ### Changes
 
 - [BREAKING] Default faucet endpoint is now public instead of localhost (#647).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06bf3ad2a85f3f8f0da73b6357c77e482b1ceb36cacda8a2d85caae3bd1f702"
+checksum = "1945918276152bd9b8e8434643ad24d4968e075b68a5ed03927b53ac75490a79"
 dependencies = [
  "blake3",
  "cc",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "miden-node-proto",
  "miden-node-utils",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_matches",
  "deadpool-sqlite",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "figment",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7532561ba51c1edcdc510e4e4a097357d49a2b6ea899d9982176dc5608bfd32e"
+checksum = "4622f71888d4641577d145dd561165824b9b9293fd0be2306326f11bcf39e67d"
 dependencies = [
  "getrandom",
  "miden-assembly",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "miden-rpc-proto"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "miden-stdlib"
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -3338,9 +3338,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3785,9 +3785,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.82"
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT"
 authors = ["Miden contributors"]
 homepage = "https://polygon.technology/polygon-miden"


### PR DESCRIPTION
This PR increments crate versions to v0.7.1 and updates the changelog.