### PR TITLE
chore: remove Endpoint and Protocol types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [BREAKING] Updated minimum Rust version to 1.84.
+- [BREAKING] Replace `Endpoint` and `Protocol` types with `url::Url` and update node TOML configuration to treat endpoints as a single string (#654).
 
 ## v0.7.2 (2025-01-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 - [BREAKING] Updated minimum Rust version to 1.84.
-- [BREAKING] Replace `Endpoint` and `Protocol` types with `url::Url` and update node TOML configuration to treat endpoints as a single string (#654).
+- [BREAKING] `Endpoint` configuration simplified to a single string (#654).
 
 ## v0.7.2 (2025-01-29)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,6 +4208,7 @@ dependencies = [
  "bitflags",
 ]
 
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,10 +1196,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indenter"
@@ -1394,6 +1544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1734,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http 0.6.2",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1664,6 +1821,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1691,6 +1849,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "url",
  "winterfell",
 ]
 
@@ -1725,6 +1884,7 @@ dependencies = [
  "tonic",
  "tonic-web",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1746,6 +1906,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2814,6 +2975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static-files"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +3056,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "target-triple"
@@ -3041,6 +3219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -3438,6 +3626,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3996,11 +4208,46 @@ dependencies = [
  "bitflags",
 ]
 
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
 [[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -4017,6 +4264,49 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tokio-stream              = { version = "0.1" }
 tonic                     = { version = "0.12" }
 tracing                   = { version = "0.1" }
 tracing-subscriber        = { version = "0.3", features = ["env-filter", "fmt", "json"] }
-url                       = { version = "2.5.4", features = ["serde"] }
+url                       = { version = "2.5", features = ["serde"] }
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio-stream              = { version = "0.1" }
 tonic                     = { version = "0.12" }
 tracing                   = { version = "0.1" }
 tracing-subscriber        = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+url                       = { version = "2.5.4", features = ["serde"] }
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -37,6 +37,7 @@ tonic            = { workspace = true }
 tower            = "0.5"
 tower-http       = { version = "0.6", features = ["cors", "set-header", "trace"] }
 tracing          = { workspace = true }
+url              = { workspace = true }
 
 [build-dependencies]
 # Required to inject build metadata.

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -200,7 +200,7 @@ impl FaucetClient {
 pub async fn initialize_faucet_client(
     config: &FaucetConfig,
 ) -> Result<(ApiClient<Channel>, BlockHeader, ChainMmr), ClientError> {
-    let endpoint = tonic::transport::Endpoint::try_from(config.node_url.clone())
+    let endpoint = tonic::transport::Endpoint::try_from(config.node_url.to_string())
         .context("Failed to parse node URL from configuration file")?
         .timeout(Duration::from_millis(config.timeout_ms));
 

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -56,8 +56,9 @@ impl Default for FaucetConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::FaucetConfig;
     use tokio::net::TcpListener;
+
+    use super::FaucetConfig;
 
     #[tokio::test]
     async fn default_faucet_config() {

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -43,12 +43,23 @@ impl Display for FaucetConfig {
 impl Default for FaucetConfig {
     fn default() -> Self {
         Self {
-            endpoint: Url::parse(format!("0.0.0.0:{DEFAULT_FAUCET_SERVER_PORT}").as_str()).unwrap(),
+            endpoint: Url::parse(format!("http://0.0.0.0:{DEFAULT_FAUCET_SERVER_PORT}").as_str())
+                .unwrap(),
             node_url: Url::parse(format!("http://127.0.0.1:{DEFAULT_NODE_RPC_PORT}").as_str())
                 .unwrap(),
             timeout_ms: DEFAULT_RPC_TIMEOUT_MS,
             asset_amount_options: vec![100, 500, 1000],
             faucet_account_path: DEFAULT_FAUCET_ACCOUNT_PATH.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FaucetConfig;
+
+    #[test]
+    fn default_faucet_config() {
+        let _config = FaucetConfig::default();
     }
 }

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -3,9 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::{
-    Endpoint, Protocol, DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT,
-};
+use miden_node_utils::config::{DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT};
 use serde::{Deserialize, Serialize};
 
 // Faucet config
@@ -20,8 +18,8 @@ pub const DEFAULT_RPC_TIMEOUT_MS: u64 = 10000;
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FaucetConfig {
-    /// Endpoint of the faucet
-    pub endpoint: Endpoint,
+    /// Endpoint of the faucet in the format `<ip>:<port>`
+    pub endpoint: String,
     /// Node RPC gRPC endpoint in the format `http://<host>[:<port>]`
     pub node_url: String,
     /// Timeout for RPC requests in milliseconds
@@ -44,12 +42,8 @@ impl Display for FaucetConfig {
 impl Default for FaucetConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint {
-                host: "0.0.0.0".to_string(),
-                port: DEFAULT_FAUCET_SERVER_PORT,
-                protocol: Protocol::Http,
-            },
-            node_url: Endpoint::localhost(DEFAULT_NODE_RPC_PORT).to_string(),
+            endpoint: format!("0.0.0.0:{DEFAULT_FAUCET_SERVER_PORT}"),
+            node_url: format!("http://127.0.0.1:{DEFAULT_NODE_RPC_PORT}"),
             timeout_ms: DEFAULT_RPC_TIMEOUT_MS,
             asset_amount_options: vec![100, 500, 1000],
             faucet_account_path: DEFAULT_FAUCET_ACCOUNT_PATH.into(),

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -5,6 +5,7 @@ use std::{
 
 use miden_node_utils::config::{DEFAULT_FAUCET_SERVER_PORT, DEFAULT_NODE_RPC_PORT};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 // Faucet config
 // ================================================================================================
@@ -19,9 +20,9 @@ pub const DEFAULT_RPC_TIMEOUT_MS: u64 = 10000;
 #[serde(deny_unknown_fields)]
 pub struct FaucetConfig {
     /// Endpoint of the faucet in the format `<ip>:<port>`
-    pub endpoint: String,
+    pub endpoint: Url,
     /// Node RPC gRPC endpoint in the format `http://<host>[:<port>]`
-    pub node_url: String,
+    pub node_url: Url,
     /// Timeout for RPC requests in milliseconds
     pub timeout_ms: u64,
     /// Possible options on the amount of asset that should be dispersed on each faucet request
@@ -42,8 +43,9 @@ impl Display for FaucetConfig {
 impl Default for FaucetConfig {
     fn default() -> Self {
         Self {
-            endpoint: format!("0.0.0.0:{DEFAULT_FAUCET_SERVER_PORT}"),
-            node_url: format!("http://127.0.0.1:{DEFAULT_NODE_RPC_PORT}"),
+            endpoint: Url::parse(format!("0.0.0.0:{DEFAULT_FAUCET_SERVER_PORT}").as_str()).unwrap(),
+            node_url: Url::parse(format!("http://127.0.0.1:{DEFAULT_NODE_RPC_PORT}").as_str())
+                .unwrap(),
             timeout_ms: DEFAULT_RPC_TIMEOUT_MS,
             asset_amount_options: vec![100, 500, 1000],
             faucet_account_path: DEFAULT_FAUCET_ACCOUNT_PATH.into(),

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -57,9 +57,15 @@ impl Default for FaucetConfig {
 #[cfg(test)]
 mod tests {
     use super::FaucetConfig;
+    use tokio::net::TcpListener;
 
-    #[test]
-    fn default_faucet_config() {
-        let _config = FaucetConfig::default();
+    #[tokio::test]
+    async fn default_faucet_config() {
+        // Default does not panic
+        let config = FaucetConfig::default();
+        // Default can bind
+        let socket_addrs = config.endpoint.socket_addrs(|| None).unwrap();
+        let socket_addr = socket_addrs.into_iter().next().unwrap();
+        let _listener = TcpListener::bind(socket_addr).await.unwrap();
     }
 }

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -123,9 +123,11 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .with_state(faucet_state);
 
-            let listener = TcpListener::bind(&config.endpoint)
-                .await
-                .context("Failed to bind TCP listener")?;
+            let socket_addr = config.endpoint.socket_addrs(|| None)?.into_iter().next().ok_or(
+                anyhow::anyhow!("Couldn't get any socket addrs for endpoint: {}", config.endpoint),
+            )?;
+            let listener =
+                TcpListener::bind(socket_addr).await.context("Failed to bind TCP listener")?;
 
             info!(target: COMPONENT, endpoint = %config.endpoint, "Server started");
 

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -123,7 +123,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .with_state(faucet_state);
 
-            let listener = TcpListener::bind((config.endpoint.host.as_str(), config.endpoint.port))
+            let listener = TcpListener::bind(&config.endpoint)
                 .await
                 .context("Failed to bind TCP listener")?;
 

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -32,6 +32,7 @@ serde                     = { version = "1.0", features = ["derive"] }
 tokio                     = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
 toml                      = { version = "0.8" }
 tracing                   = { workspace = true }
+url                       = { workspace = true }
 
 [dev-dependencies]
 figment          = { version = "0.10", features = ["env", "test", "toml"] }

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -75,13 +75,13 @@ mod tests {
     use figment::Jail;
     use miden_node_store::config::StoreConfig;
     use miden_node_utils::config::load_config;
+    use url::Url;
 
     use super::NodeConfig;
     use crate::{
         config::{NormalizedBlockProducerConfig, NormalizedRpcConfig},
         NODE_CONFIG_FILE_PATH,
     };
-    use url::Url;
 
     #[test]
     fn node_config() {
@@ -90,7 +90,7 @@ mod tests {
                 NODE_CONFIG_FILE_PATH,
                 r#"
                     [block_producer]
-                    endpoint = "127.0.0.1:8080"
+                    endpoint = "http://127.0.0.1:8080"
                     verify_tx_proofs = true
 
                     [rpc]
@@ -110,7 +110,7 @@ mod tests {
                 config,
                 NodeConfig {
                     block_producer: NormalizedBlockProducerConfig {
-                        endpoint: Url::parse("127.0.0.1:8080").unwrap(),
+                        endpoint: Url::parse("http://127.0.0.1:8080").unwrap(),
                         verify_tx_proofs: true
                     },
                     rpc: NormalizedRpcConfig {

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -1,7 +1,6 @@
 use miden_node_block_producer::config::BlockProducerConfig;
 use miden_node_rpc::config::RpcConfig;
 use miden_node_store::config::StoreConfig;
-use miden_node_utils::config::Endpoint;
 use serde::{Deserialize, Serialize};
 
 /// Node top-level configuration.
@@ -17,7 +16,7 @@ pub struct NodeConfig {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct NormalizedRpcConfig {
-    endpoint: Endpoint,
+    endpoint: String,
 }
 
 /// A specialized variant of [`BlockProducerConfig`] with redundant fields within [`NodeConfig`]
@@ -25,7 +24,7 @@ struct NormalizedRpcConfig {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct NormalizedBlockProducerConfig {
-    endpoint: Endpoint,
+    endpoint: String,
     verify_tx_proofs: bool,
 }
 
@@ -56,13 +55,13 @@ impl NodeConfig {
 
         let block_producer = BlockProducerConfig {
             endpoint: block_producer.endpoint,
-            store_url: store.endpoint_url(),
+            store_url: store.endpoint.clone(),
             verify_tx_proofs: block_producer.verify_tx_proofs,
         };
 
         let rpc = RpcConfig {
             endpoint: rpc.endpoint,
-            store_url: store.endpoint_url(),
+            store_url: store.endpoint.clone(),
             block_producer_url: block_producer.endpoint_url(),
         };
 
@@ -74,7 +73,7 @@ impl NodeConfig {
 mod tests {
     use figment::Jail;
     use miden_node_store::config::StoreConfig;
-    use miden_node_utils::config::{load_config, Endpoint, Protocol};
+    use miden_node_utils::config::load_config;
 
     use super::NodeConfig;
     use crate::{
@@ -89,14 +88,14 @@ mod tests {
                 NODE_CONFIG_FILE_PATH,
                 r#"
                     [block_producer]
-                    endpoint = { host = "127.0.0.1",  port = 8080 }
+                    endpoint = "127.0.0.1:8080"
                     verify_tx_proofs = true
 
                     [rpc]
-                    endpoint = { host = "127.0.0.1",  port = 8080, protocol = "Http" }
+                    endpoint = "http://127.0.0.1:8080"
 
                     [store]
-                    endpoint = { host = "127.0.0.1",  port = 8080, protocol = "Https" }
+                    endpoint = "https://127.0.0.1:8080"
                     database_filepath = "local.sqlite3"
                     genesis_filepath = "genesis.dat"
                     blockstore_dir = "blocks"
@@ -109,26 +108,14 @@ mod tests {
                 config,
                 NodeConfig {
                     block_producer: NormalizedBlockProducerConfig {
-                        endpoint: Endpoint {
-                            host: "127.0.0.1".to_string(),
-                            port: 8080,
-                            protocol: Protocol::default()
-                        },
+                        endpoint: "127.0.0.1:8080".to_string(),
                         verify_tx_proofs: true
                     },
                     rpc: NormalizedRpcConfig {
-                        endpoint: Endpoint {
-                            host: "127.0.0.1".to_string(),
-                            port: 8080,
-                            protocol: Protocol::Http
-                        },
+                        endpoint: "http://127.0.0.1:8080".to_string()
                     },
                     store: StoreConfig {
-                        endpoint: Endpoint {
-                            host: "127.0.0.1".to_string(),
-                            port: 8080,
-                            protocol: Protocol::Https
-                        },
+                        endpoint: "https://127.0.0.1:8080".to_string(),
                         database_filepath: "local.sqlite3".into(),
                         genesis_filepath: "genesis.dat".into(),
                         blockstore_dir: "blocks".into()

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -2,6 +2,7 @@ use miden_node_block_producer::config::BlockProducerConfig;
 use miden_node_rpc::config::RpcConfig;
 use miden_node_store::config::StoreConfig;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 /// Node top-level configuration.
 #[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
@@ -16,7 +17,7 @@ pub struct NodeConfig {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct NormalizedRpcConfig {
-    endpoint: String,
+    endpoint: Url,
 }
 
 /// A specialized variant of [`BlockProducerConfig`] with redundant fields within [`NodeConfig`]
@@ -24,7 +25,7 @@ struct NormalizedRpcConfig {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct NormalizedBlockProducerConfig {
-    endpoint: String,
+    endpoint: Url,
     verify_tx_proofs: bool,
 }
 
@@ -62,7 +63,7 @@ impl NodeConfig {
         let rpc = RpcConfig {
             endpoint: rpc.endpoint,
             store_url: store.endpoint.clone(),
-            block_producer_url: block_producer.endpoint_url(),
+            block_producer_url: block_producer.endpoint.clone(),
         };
 
         (block_producer, rpc, store)
@@ -80,6 +81,7 @@ mod tests {
         config::{NormalizedBlockProducerConfig, NormalizedRpcConfig},
         NODE_CONFIG_FILE_PATH,
     };
+    use url::Url;
 
     #[test]
     fn node_config() {
@@ -108,14 +110,14 @@ mod tests {
                 config,
                 NodeConfig {
                     block_producer: NormalizedBlockProducerConfig {
-                        endpoint: "127.0.0.1:8080".to_string(),
+                        endpoint: Url::parse("127.0.0.1:8080").unwrap(),
                         verify_tx_proofs: true
                     },
                     rpc: NormalizedRpcConfig {
-                        endpoint: "http://127.0.0.1:8080".to_string()
+                        endpoint: Url::parse("http://127.0.0.1:8080").unwrap(),
                     },
                     store: StoreConfig {
-                        endpoint: "https://127.0.0.1:8080".to_string(),
+                        endpoint: Url::parse("https://127.0.0.1:8080").unwrap(),
                         database_filepath: "local.sqlite3".into(),
                         genesis_filepath: "genesis.dat".into(),
                         blockstore_dir: "blocks".into()

--- a/config/miden-node.toml
+++ b/config/miden-node.toml
@@ -2,18 +2,18 @@
 
 [block_producer]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
-endpoint = "127.0.0.1:48046"
+endpoint = "http://127.0.0.1:48046"
 # enables or disables the verification of transaction proofs before they are accepted into the
 # transaction queue.
 verify_tx_proofs = true
 
 [rpc]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16
-endpoint = "0.0.0.0:57291"
+endpoint = "http://0.0.0.0:57291"
 
 [store]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-store', 1)) % 2**16
 blockstore_dir    = "/opt/miden/blocks"
 database_filepath = "/opt/miden/miden-store.sqlite3"
-endpoint          = "127.0.0.1:28943"
+endpoint          = "http://127.0.0.1:28943"
 genesis_filepath  = "/opt/miden/genesis.dat"

--- a/config/miden-node.toml
+++ b/config/miden-node.toml
@@ -2,18 +2,18 @@
 
 [block_producer]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
-endpoint = { host = "localhost", port = 48046 }
+endpoint = "127.0.0.1:48046"
 # enables or disables the verification of transaction proofs before they are accepted into the
 # transaction queue.
 verify_tx_proofs = true
 
 [rpc]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16
-endpoint = { host = "0.0.0.0", port = 57291 }
+endpoint = "0.0.0.0:57291"
 
 [store]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-store', 1)) % 2**16
 blockstore_dir    = "/opt/miden/blocks"
 database_filepath = "/opt/miden/miden-store.sqlite3"
-endpoint          = { host = "localhost", port = 28943 }
+endpoint          = "127.0.0.1:28943"
 genesis_filepath  = "/opt/miden/genesis.dat"

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -34,6 +34,7 @@ tokio            = { workspace = true, features = ["macros", "net", "rt-multi-th
 tokio-stream     = { workspace = true, features = ["net"] }
 tonic            = { workspace = true }
 tracing          = { workspace = true }
+url              = { workspace = true }
 
 [dev-dependencies]
 assert_matches        = { workspace = true }

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -50,8 +50,9 @@ impl Default for BlockProducerConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::BlockProducerConfig;
     use tokio::net::TcpListener;
+
+    use super::BlockProducerConfig;
 
     #[tokio::test]
     async fn default_block_producer_config() {

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -37,11 +37,23 @@ impl Display for BlockProducerConfig {
 impl Default for BlockProducerConfig {
     fn default() -> Self {
         Self {
-            endpoint: Url::parse(format!("127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}").as_str())
-                .unwrap(),
+            endpoint: Url::parse(
+                format!("http://127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}").as_str(),
+            )
+            .unwrap(),
             store_url: Url::parse(format!("http://127.0.0.1:{DEFAULT_STORE_PORT}").as_str())
                 .unwrap(),
             verify_tx_proofs: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BlockProducerConfig;
+
+    #[test]
+    fn default_block_producer_config() {
+        let _config = BlockProducerConfig::default();
     }
 }

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -51,9 +51,15 @@ impl Default for BlockProducerConfig {
 #[cfg(test)]
 mod tests {
     use super::BlockProducerConfig;
+    use tokio::net::TcpListener;
 
-    #[test]
-    fn default_block_producer_config() {
-        let _config = BlockProducerConfig::default();
+    #[tokio::test]
+    async fn default_block_producer_config() {
+        // Default does not panic
+        let config = BlockProducerConfig::default();
+        // Default can bind
+        let socket_addrs = config.endpoint.socket_addrs(|| None).unwrap();
+        let socket_addr = socket_addrs.into_iter().next().unwrap();
+        let _listener = TcpListener::bind(socket_addr).await.unwrap();
     }
 }

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use miden_node_utils::config::{Endpoint, DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_STORE_PORT};
+use miden_node_utils::config::{DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_STORE_PORT};
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BlockProducerConfig {
-    pub endpoint: Endpoint,
+    pub endpoint: String,
 
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_url: String,
@@ -42,8 +42,8 @@ impl Display for BlockProducerConfig {
 impl Default for BlockProducerConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint::localhost(DEFAULT_BLOCK_PRODUCER_PORT),
-            store_url: Endpoint::localhost(DEFAULT_STORE_PORT).to_string(),
+            endpoint: format!("127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}"),
+            store_url: format!("http://127.0.0.1:{DEFAULT_STORE_PORT}"),
             verify_tx_proofs: true,
         }
     }

--- a/crates/block-producer/src/config.rs
+++ b/crates/block-producer/src/config.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use miden_node_utils::config::{DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_STORE_PORT};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 // Main config
 // ================================================================================================
@@ -10,10 +11,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BlockProducerConfig {
-    pub endpoint: String,
+    pub endpoint: Url,
 
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
-    pub store_url: String,
+    pub store_url: Url,
 
     /// Enable or disable the verification of transaction proofs before they are accepted into the
     /// transaction queue.
@@ -22,12 +23,6 @@ pub struct BlockProducerConfig {
     /// verification may take ~15ms/proof. This is OK when all transactions are forwarded to the
     /// block producer from the RPC component as transaction proofs are also verified there.
     pub verify_tx_proofs: bool,
-}
-
-impl BlockProducerConfig {
-    pub fn endpoint_url(&self) -> String {
-        self.endpoint.to_string()
-    }
 }
 
 impl Display for BlockProducerConfig {
@@ -42,8 +37,10 @@ impl Display for BlockProducerConfig {
 impl Default for BlockProducerConfig {
     fn default() -> Self {
         Self {
-            endpoint: format!("127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}"),
-            store_url: format!("http://127.0.0.1:{DEFAULT_STORE_PORT}"),
+            endpoint: Url::parse(format!("127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}").as_str())
+                .unwrap(),
+            store_url: Url::parse(format!("http://127.0.0.1:{DEFAULT_STORE_PORT}").as_str())
+                .unwrap(),
             verify_tx_proofs: true,
         }
     }

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::ToSocketAddrs};
+use std::collections::HashMap;
 
 use miden_node_proto::generated::{
     block_producer::api_server, requests::SubmitProvenTransactionRequest,
@@ -66,8 +66,9 @@ impl BlockProducer {
 
         let rpc_listener = config
             .endpoint
-            .to_socket_addrs()
+            .socket_addrs(|| None)
             .map_err(ApiError::EndpointToSocketFailed)?
+            .into_iter()
             .next()
             .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))
             .map(TcpListener::bind)?

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -25,6 +25,7 @@ tokio-stream     = { workspace = true, features = ["net"] }
 tonic            = { workspace = true }
 tonic-web        = { version = "0.12" }
 tracing          = { workspace = true }
+url              = { workspace = true }
 
 [dev-dependencies]
 miden-node-utils = { workspace = true, features = ["tracing-forest"] }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use miden_node_utils::config::{
-    Endpoint, Protocol, DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_NODE_RPC_PORT, DEFAULT_STORE_PORT,
+    DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_NODE_RPC_PORT, DEFAULT_STORE_PORT,
 };
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RpcConfig {
-    pub endpoint: Endpoint,
+    pub endpoint: String,
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
     pub store_url: String,
     /// Block producer gRPC endpoint in the format `http://<host>[:<port>]`.
@@ -36,13 +36,9 @@ impl Display for RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            endpoint: Endpoint {
-                host: "0.0.0.0".to_string(),
-                port: DEFAULT_NODE_RPC_PORT,
-                protocol: Protocol::default(),
-            },
-            store_url: Endpoint::localhost(DEFAULT_STORE_PORT).to_string(),
-            block_producer_url: Endpoint::localhost(DEFAULT_BLOCK_PRODUCER_PORT).to_string(),
+            endpoint: format!("0.0.0.0:{DEFAULT_NODE_RPC_PORT}"),
+            store_url: format!("http://127.0.0.1:{DEFAULT_STORE_PORT}"),
+            block_producer_url: format!("http://127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}"),
         }
     }
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -52,9 +52,15 @@ impl Default for RpcConfig {
 #[cfg(test)]
 mod tests {
     use super::RpcConfig;
+    use tokio::net::TcpListener;
 
-    #[test]
-    fn default_rpc_config() {
-        let _config = RpcConfig::default();
+    #[tokio::test]
+    async fn default_rpc_config() {
+        // Default does not panic
+        let config = RpcConfig::default();
+        // Default can bind
+        let socket_addrs = config.endpoint.socket_addrs(|| None).unwrap();
+        let socket_addr = socket_addrs.into_iter().next().unwrap();
+        let _listener = TcpListener::bind(socket_addr).await.unwrap();
     }
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -51,8 +51,9 @@ impl Default for RpcConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::RpcConfig;
     use tokio::net::TcpListener;
+
+    use super::RpcConfig;
 
     #[tokio::test]
     async fn default_rpc_config() {

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -4,6 +4,7 @@ use miden_node_utils::config::{
     DEFAULT_BLOCK_PRODUCER_PORT, DEFAULT_NODE_RPC_PORT, DEFAULT_STORE_PORT,
 };
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 // Main config
 // ================================================================================================
@@ -11,11 +12,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RpcConfig {
-    pub endpoint: String,
+    pub endpoint: Url,
     /// Store gRPC endpoint in the format `http://<host>[:<port>]`.
-    pub store_url: String,
+    pub store_url: Url,
     /// Block producer gRPC endpoint in the format `http://<host>[:<port>]`.
-    pub block_producer_url: String,
+    pub block_producer_url: Url,
 }
 
 impl RpcConfig {
@@ -36,9 +37,26 @@ impl Display for RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            endpoint: format!("0.0.0.0:{DEFAULT_NODE_RPC_PORT}"),
-            store_url: format!("http://127.0.0.1:{DEFAULT_STORE_PORT}"),
-            block_producer_url: format!("http://127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}"),
+            endpoint: Url::parse(format!("0.0.0.0:{DEFAULT_NODE_RPC_PORT}").as_str()).unwrap(),
+            store_url: Url::parse(format!("http://127.0.0.1:{DEFAULT_STORE_PORT}").as_str())
+                .unwrap(),
+            block_producer_url: Url::parse(
+                format!("http://127.0.0.1:{DEFAULT_BLOCK_PRODUCER_PORT}").as_str(),
+            )
+            .unwrap(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_rpc_config() {
+        let config = RpcConfig::default();
+        assert_eq!(config.endpoint.path(), "");
+        assert_eq!(config.endpoint.host().unwrap().to_string(), "0.0.0.0");
+        assert_eq!(config.endpoint.scheme(), "http");
     }
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -37,7 +37,8 @@ impl Display for RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            endpoint: Url::parse(format!("0.0.0.0:{DEFAULT_NODE_RPC_PORT}").as_str()).unwrap(),
+            endpoint: Url::parse(format!("http://0.0.0.0:{DEFAULT_NODE_RPC_PORT}").as_str())
+                .unwrap(),
             store_url: Url::parse(format!("http://127.0.0.1:{DEFAULT_STORE_PORT}").as_str())
                 .unwrap(),
             block_producer_url: Url::parse(
@@ -50,13 +51,10 @@ impl Default for RpcConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::RpcConfig;
 
     #[test]
     fn default_rpc_config() {
-        let config = RpcConfig::default();
-        assert_eq!(config.endpoint.path(), "");
-        assert_eq!(config.endpoint.host().unwrap().to_string(), "0.0.0.0");
-        assert_eq!(config.endpoint.scheme(), "http");
+        let _config = RpcConfig::default();
     }
 }

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -41,14 +41,15 @@ pub struct RpcApi {
 
 impl RpcApi {
     pub(super) async fn from_config(config: &RpcConfig) -> Result<Self, Error> {
-        let store = store_client::ApiClient::connect(config.store_url.clone()).await?;
-        info!(target: COMPONENT, store_endpoint = config.store_url, "Store client initialized");
+        let store = store_client::ApiClient::connect(config.store_url.to_string()).await?;
+        info!(target: COMPONENT, store_endpoint = config.store_url.as_str(), "Store client initialized");
 
         let block_producer =
-            block_producer_client::ApiClient::connect(config.block_producer_url.clone()).await?;
+            block_producer_client::ApiClient::connect(config.block_producer_url.to_string())
+                .await?;
         info!(
             target: COMPONENT,
-            block_producer_endpoint = config.block_producer_url,
+            block_producer_endpoint = config.block_producer_url.as_str(),
             "Block producer client initialized",
         );
 

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -1,5 +1,3 @@
-use std::net::ToSocketAddrs;
-
 use api::RpcApi;
 use miden_node_proto::generated::rpc::api_server;
 use miden_node_utils::errors::ApiError;
@@ -33,8 +31,9 @@ impl Rpc {
 
         let addr = config
             .endpoint
-            .to_socket_addrs()
+            .socket_addrs(|| None)
             .map_err(ApiError::EndpointToSocketFailed)?
+            .into_iter()
             .next()
             .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))?;
 

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -29,6 +29,7 @@ tokio              = { workspace = true, features = ["fs", "macros", "net", "rt-
 tokio-stream       = { workspace = true, features = ["net"] }
 tonic              = { workspace = true }
 tracing            = { workspace = true }
+url                = { workspace = true }
 
 [dev-dependencies]
 assert_matches   = { workspace = true }

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -48,9 +48,15 @@ impl Default for StoreConfig {
 #[cfg(test)]
 mod tests {
     use super::StoreConfig;
+    use tokio::net::TcpListener;
 
-    #[test]
-    fn default_store_config() {
-        let _config = StoreConfig::default();
+    #[tokio::test]
+    async fn default_store_config() {
+        // Default does not panic
+        let config = StoreConfig::default();
+        // Default can bind
+        let socket_addrs = config.endpoint.socket_addrs(|| None).unwrap();
+        let socket_addr = socket_addrs.into_iter().next().unwrap();
+        let _listener = TcpListener::bind(socket_addr).await.unwrap();
     }
 }

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -36,10 +36,21 @@ impl Default for StoreConfig {
     fn default() -> Self {
         const NODE_STORE_DIR: &str = "./";
         Self {
-            endpoint: Url::parse(format!("127.0.0.1:{DEFAULT_STORE_PORT}").as_str()).unwrap(),
+            endpoint: Url::parse(format!("http://127.0.0.1:{DEFAULT_STORE_PORT}").as_str())
+                .unwrap(),
             database_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "miden-store.sqlite3"),
             genesis_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "genesis.dat"),
             blockstore_dir: PathBuf::from(NODE_STORE_DIR.to_string() + "blocks"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StoreConfig;
+
+    #[test]
+    fn default_store_config() {
+        let _config = StoreConfig::default();
     }
 }

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -47,8 +47,9 @@ impl Default for StoreConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::StoreConfig;
     use tokio::net::TcpListener;
+
+    use super::StoreConfig;
 
     #[tokio::test]
     async fn default_store_config() {

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use miden_node_utils::config::{Endpoint, DEFAULT_STORE_PORT};
+use miden_node_utils::config::DEFAULT_STORE_PORT;
 use serde::{Deserialize, Serialize};
 
 // Main config
@@ -13,19 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct StoreConfig {
     /// Defines the listening socket.
-    pub endpoint: Endpoint,
+    pub endpoint: String,
     /// `SQLite` database file
     pub database_filepath: PathBuf,
     /// Genesis file
     pub genesis_filepath: PathBuf,
     /// Block store directory
     pub blockstore_dir: PathBuf,
-}
-
-impl StoreConfig {
-    pub fn endpoint_url(&self) -> String {
-        self.endpoint.to_string()
-    }
 }
 
 impl Display for StoreConfig {
@@ -41,7 +35,7 @@ impl Default for StoreConfig {
     fn default() -> Self {
         const NODE_STORE_DIR: &str = "./";
         Self {
-            endpoint: Endpoint::localhost(DEFAULT_STORE_PORT),
+            endpoint: format!("127.0.0.1:{DEFAULT_STORE_PORT}"),
             database_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "miden-store.sqlite3"),
             genesis_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "genesis.dat"),
             blockstore_dir: PathBuf::from(NODE_STORE_DIR.to_string() + "blocks"),

--- a/crates/store/src/config.rs
+++ b/crates/store/src/config.rs
@@ -5,6 +5,7 @@ use std::{
 
 use miden_node_utils::config::DEFAULT_STORE_PORT;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 // Main config
 // ================================================================================================
@@ -13,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct StoreConfig {
     /// Defines the listening socket.
-    pub endpoint: String,
+    pub endpoint: Url,
     /// `SQLite` database file
     pub database_filepath: PathBuf,
     /// Genesis file
@@ -35,7 +36,7 @@ impl Default for StoreConfig {
     fn default() -> Self {
         const NODE_STORE_DIR: &str = "./";
         Self {
-            endpoint: format!("127.0.0.1:{DEFAULT_STORE_PORT}"),
+            endpoint: Url::parse(format!("127.0.0.1:{DEFAULT_STORE_PORT}").as_str()).unwrap(),
             database_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "miden-store.sqlite3"),
             genesis_filepath: PathBuf::from(NODE_STORE_DIR.to_string() + "genesis.dat"),
             blockstore_dir: PathBuf::from(NODE_STORE_DIR.to_string() + "blocks"),

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -1,4 +1,4 @@
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::sync::Arc;
 
 use miden_node_proto::generated::store::api_server;
 use miden_node_utils::errors::ApiError;
@@ -44,8 +44,9 @@ impl Store {
 
         let addr = config
             .endpoint
-            .to_socket_addrs()
+            .socket_addrs(|| None)
             .map_err(ApiError::EndpointToSocketFailed)?
+            .into_iter()
             .next()
             .ok_or_else(|| ApiError::AddressResolutionFailed(config.endpoint.to_string()))?;
 

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -1,72 +1,15 @@
-use std::{
-    fmt::{Display, Formatter},
-    io,
-    net::{SocketAddr, ToSocketAddrs},
-    path::Path,
-    vec,
-};
+use std::path::Path;
 
 use figment::{
     providers::{Format, Toml},
     Figment,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 pub const DEFAULT_NODE_RPC_PORT: u16 = 57291;
 pub const DEFAULT_BLOCK_PRODUCER_PORT: u16 = 48046;
 pub const DEFAULT_STORE_PORT: u16 = 28943;
 pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
-
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize, Default)]
-pub enum Protocol {
-    #[default]
-    Http,
-    Https,
-}
-/// The `(host, port)` pair for the server's listening socket.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
-pub struct Endpoint {
-    /// Host used by the store.
-    pub host: String,
-    /// Port number used by the store.
-    pub port: u16,
-    /// Protocol type: http or https.
-    #[serde(default)]
-    pub protocol: Protocol,
-}
-
-impl Endpoint {
-    pub fn localhost(port: u16) -> Self {
-        Endpoint {
-            host: "localhost".to_string(),
-            port,
-            protocol: Protocol::default(),
-        }
-    }
-}
-
-impl ToSocketAddrs for Endpoint {
-    type Iter = vec::IntoIter<SocketAddr>;
-    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
-        (self.host.as_ref(), self.port).to_socket_addrs()
-    }
-}
-
-impl Display for Endpoint {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let Endpoint { protocol, host, port } = self;
-        f.write_fmt(format_args!("{protocol}://{host}:{port}"))
-    }
-}
-
-impl Display for Protocol {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Protocol::Http => f.write_str("http"),
-            Protocol::Https => f.write_str("https"),
-        }
-    }
-}
 
 /// Loads the user configuration.
 ///


### PR DESCRIPTION
Closes #651

* Remove Endpoint and Protocol types from util crate
* Use url::Url for handling endpoints both in TOML configuration and runtime