### PR TITLE
fix: faucet webpage rejects valid account IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.2 (2025-01-29)
+
 ### Fixes
 
 - Faucet webpage rejects valid account IDs (#655).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
+### Fixes
+
+- Faucet webpage rejects valid account IDs (#655).
+
 ## v0.7.1 (2025-01-28)
+
+### Fixes
+
+- Faucet webpage fails to load styling (index.css) and script (index.js) (#647).
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "miden-node-proto",
  "miden-node-utils",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_matches",
  "deadpool-sqlite",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "figment",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "miden-rpc-proto"
-version = "0.7.1"
+version = "0.7.2"
 
 [[package]]
 name = "miden-stdlib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.82"
-version = "0.7.1"
+version = "0.7.2"
 license = "MIT"
 authors = ["Miden contributors"]
 homepage = "https://polygon.technology/polygon-miden"

--- a/bin/faucet/src/static/index.js
+++ b/bin/faucet/src/static/index.js
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function () {
         let accountId = accountIdInput.value.trim();
         errorMessage.style.display = 'none';
 
-        if (!accountId || !/^0x[0-9a-fA-F]{16}$/i.test(accountId)) {
+        if (!accountId || !/^0x[0-9a-fA-F]{30}$/i.test(accountId)) {
             errorMessage.textContent = !accountId ? "Account ID is required." : "Invalid Account ID.";
             errorMessage.style.display = 'block';
             return;


### PR DESCRIPTION
We forgot to update the faucet's script file when upgrading account ID from 1 to 2 felts.

I've also added in a changelog entry for the previous version's bugfix.