### PR TITLE
ci: fix release tag reference

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: Release packages
 run-name: Release packaging for ${{ inputs.version || github.ref }}
 
 env:
-  version: ${{ inputs.version || github.ref }}
+  version: ${{ inputs.version || github.ref_name }}
 
 on:
   release:


### PR DESCRIPTION
Packaging release artifacts fails because the `github.ref` returns the full git reference instead of the tag. i.e. it gives `refs/tags/vA.B.C`.

The fix is to use `github.ref_name` 🫤

Thankfully the workflow can be triggered manually where it correctly uses the input version as the tag. This PR just fixes it for the next release trigger; though we'll have to create a fake release to actually test this ahead of time.