### PR TITLE
feat: open-telemetry exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Add an optional open-telemetry trace exporter (#659).
+
 ### Changes
 
 - [BREAKING] Updated minimum Rust version to 1.84.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,10 +926,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -940,10 +972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1925,12 +1959,16 @@ dependencies = [
  "figment",
  "itertools 0.14.0",
  "miden-objects",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rand",
  "serde",
  "thiserror 2.0.11",
  "tonic",
  "tracing",
  "tracing-forest",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "vergen",
  "vergen-gitcl",
@@ -2248,6 +2286,78 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
 
 [[package]]
 name = "overload"
@@ -2708,6 +2818,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,6 +2900,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +2986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +3005,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3018,6 +3228,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -3259,6 +3475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,8 +3563,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -3518,6 +3747,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,6 +3873,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3823,6 +4076,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4291,6 +4554,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,17 +19,21 @@ workspace = true
 vergen = ["dep:vergen", "dep:vergen-gitcl"]
 
 [dependencies]
-anyhow             = { version = "1.0" }
-figment            = { version = "0.10", features = ["env", "toml"] }
-itertools          = { workspace = true }
-miden-objects      = { workspace = true }
-rand               = { workspace = true }
-serde              = { version = "1.0", features = ["derive"] }
-thiserror          = { workspace = true }
-tonic              = { workspace = true }
-tracing            = { workspace = true }
-tracing-forest     = { version = "0.1", optional = true, features = ["chrono"] }
-tracing-subscriber = { workspace = true }
+anyhow                = { version = "1.0" }
+figment               = { version = "0.10", features = ["env", "toml"] }
+itertools             = { workspace = true }
+miden-objects         = { workspace = true }
+opentelemetry         = "0.27.1"
+opentelemetry-otlp    = { version = "0.27.0", features = ["tls-roots"] }
+opentelemetry_sdk     = { version = "0.27.1", features = ["rt-tokio"] }
+rand                  = { workspace = true }
+serde                 = { version = "1.0", features = ["derive"] }
+thiserror             = { workspace = true }
+tonic                 = { workspace = true }
+tracing               = { workspace = true }
+tracing-forest        = { version = "0.1", optional = true, features = ["chrono"] }
+tracing-opentelemetry = "0.28.0"
+tracing-subscriber    = { workspace = true }
 # Optional dependencies enabled by `vergen` feature.
 # This must match the version expected by `vergen-gitcl`.
 vergen       = { "version" = "9.0", optional = true }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -23,16 +23,16 @@ anyhow                = { version = "1.0" }
 figment               = { version = "0.10", features = ["env", "toml"] }
 itertools             = { workspace = true }
 miden-objects         = { workspace = true }
-opentelemetry         = "0.27.1"
-opentelemetry-otlp    = { version = "0.27.0", features = ["tls-roots"] }
-opentelemetry_sdk     = { version = "0.27.1", features = ["rt-tokio"] }
+opentelemetry         = "0.27"
+opentelemetry-otlp    = { version = "0.27", features = ["tls-roots"] }
+opentelemetry_sdk     = { version = "0.27", features = ["rt-tokio"] }
 rand                  = { workspace = true }
 serde                 = { version = "1.0", features = ["derive"] }
 thiserror             = { workspace = true }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
 tracing-forest        = { version = "0.1", optional = true, features = ["chrono"] }
-tracing-opentelemetry = "0.28.0"
+tracing-opentelemetry = "0.28"
 tracing-subscriber    = { workspace = true }
 # Optional dependencies enabled by `vergen` feature.
 # This must match the version expected by `vergen-gitcl`.

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -1,11 +1,82 @@
 use anyhow::Result;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithTonicConfig;
 use tracing::subscriber::{self, Subscriber};
-use tracing_subscriber::EnvFilter;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
+
+/// Configures tracing and optionally enables an open-telemetry OTLP exporter.
+///
+/// The open-telemetry configuration is controlled via environment variables as defined in the
+/// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)
+pub fn setup_tracing(enable_otel: bool) -> Result<()> {
+    let otel_layer = enable_otel.then_some(open_telemetry_layer());
+    let subscriber = Registry::default().with(stdout_layer()).with(otel_layer);
+    tracing::subscriber::set_global_default(subscriber).map_err(Into::into)
+}
 
 pub fn setup_logging() -> Result<()> {
     subscriber::set_global_default(subscriber())?;
 
     Ok(())
+}
+
+fn open_telemetry_layer<S>() -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>
+where
+    S: Subscriber + Sync + Send,
+    for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots())
+        .build()
+        .unwrap();
+
+    let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+        .build();
+
+    let tracer = tracer.tracer("tracing-otel-subscriber");
+    OpenTelemetryLayer::new(tracer).boxed()
+}
+
+#[cfg(not(feature = "tracing-forest"))]
+fn stdout_layer<S>() -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>
+where
+    S: Subscriber,
+    for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
+{
+    use tracing_subscriber::fmt::format::FmtSpan;
+
+    tracing_subscriber::fmt::layer()
+        .pretty()
+        .compact()
+        .with_level(true)
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            // axum logs rejections from built-in extracts on the trace level, so we enable this
+            // manually.
+            "info,axum::rejection=trace".into()
+        }))
+        .boxed()
+}
+
+#[cfg(feature = "tracing-forest")]
+fn stdout_layer<S>() -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>
+where
+    S: Subscriber,
+    for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracing_forest::ForestLayer::default()
+        .with_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            // axum logs rejections from built-in extracts on the trace level, so we enable this
+            // manually.
+            "info,axum::rejection=trace".into()
+        }))
+        .boxed()
 }
 
 #[cfg(not(feature = "tracing-forest"))]


### PR DESCRIPTION
This PR adds a `--open-telemetry` flag to the node's `start` command. This exports traces to an open-telemetry backend.

The various settings of this exporter can be controlled by the various environment variables specified by the standard e.g.

```
export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
```
sets the target endpoint.

This is just initial support for this; our actual traces are still _very_ non-conforming to the standard.