### PR TITLE
fix(faucet): missing background and favicon routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Faucet webpage is missing `background.png` and `favicon.ico` (#672).
+
 ### Enhancements
 
 - Add an optional open-telemetry trace exporter (#659).

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -128,6 +128,14 @@ pub async fn get_index_css(state: State<FaucetState>) -> Result<impl IntoRespons
     get_static_file(state, "index.css")
 }
 
+pub async fn get_background(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
+    get_static_file(state, "background.png")
+}
+
+pub async fn get_favicon(state: State<FaucetState>) -> Result<impl IntoResponse, HandlerError> {
+    get_static_file(state, "favicon.ico")
+}
+
 /// Returns a static file bundled with the app state.
 ///
 /// # Panics

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use clap::{Parser, Subcommand};
 use client::initialize_faucet_client;
-use handlers::{get_index_css, get_index_html, get_index_js};
+use handlers::{get_background, get_favicon, get_index_css, get_index_html, get_index_js};
 use http::HeaderValue;
 use miden_lib::{account::faucets::create_basic_fungible_faucet, AuthScheme};
 use miden_node_utils::{config::load_config, crypto::get_rpo_random_coin, version::LongVersion};
@@ -106,6 +106,8 @@ async fn main() -> anyhow::Result<()> {
                 .route("/", get(get_index_html))
                 .route("/index.js", get(get_index_js))
                 .route("/index.css", get(get_index_css))
+                .route("/background.png", get(get_background))
+                .route("/favicon.ico", get(get_favicon))
                 .route("/get_metadata", get(get_metadata))
                 .route("/get_tokens", post(get_tokens))
                 .layer(


### PR DESCRIPTION
Closes #671.

Created #673 to create tests for this.

--------------

I've deployed this to devnet and confirmed that 

- both background and favicon load as expected, and
- no console errors

Did require clearing my cache first.