### PR TITLE
feat(block-producer): instrument block building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add an optional open-telemetry trace exporter (#659).
 - Support tracing across gRPC boundaries using remote tracing context (#669).
+- Instrument the block-producer's block building process (#676).
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -971,10 +972,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1863,6 +1867,7 @@ version = "0.8.0"
 dependencies = [
  "assert_matches",
  "async-trait",
+ "futures",
  "itertools 0.14.0",
  "miden-air",
  "miden-lib",
@@ -1874,6 +1879,7 @@ dependencies = [
  "miden-stdlib",
  "miden-tx",
  "miden-tx-batch-prover",
+ "opentelemetry",
  "pretty_assertions",
  "rand",
  "rand_chacha",
@@ -1883,6 +1889,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "tracing-opentelemetry",
  "url",
  "winterfell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,6 @@ dependencies = [
  "miden-stdlib",
  "miden-tx",
  "miden-tx-batch-prover",
- "opentelemetry",
  "pretty_assertions",
  "rand",
  "rand_chacha",
@@ -1889,7 +1888,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
- "tracing-opentelemetry",
  "url",
  "winterfell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ miden-processor           = { version = "0.12" }
 miden-stdlib              = { version = "0.12", default-features = false }
 miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
 miden-tx-batch-prover     = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
-opentelemetry             = { version = "0.27" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.8" }
 thiserror                 = { version = "2.0", default-features = false }
@@ -48,7 +47,6 @@ tokio                     = { version = "1.40", features = ["rt-multi-thread"] }
 tokio-stream              = { version = "0.1" }
 tonic                     = { version = "0.12" }
 tracing                   = { version = "0.1" }
-tracing-opentelemetry     = { version = "0.28" }
 tracing-subscriber        = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 url                       = { version = "2.5", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ miden-processor           = { version = "0.12" }
 miden-stdlib              = { version = "0.12", default-features = false }
 miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
 miden-tx-batch-prover     = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
+opentelemetry             = { version = "0.27" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.8" }
 thiserror                 = { version = "2.0", default-features = false }
@@ -47,6 +48,7 @@ tokio                     = { version = "1.40", features = ["rt-multi-thread"] }
 tokio-stream              = { version = "0.1" }
 tonic                     = { version = "0.12" }
 tracing                   = { version = "0.1" }
+tracing-opentelemetry     = { version = "0.28" }
 tracing-subscriber        = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 url                       = { version = "2.5", features = ["serde"] }
 

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -19,6 +19,7 @@ tracing-forest = ["miden-node-utils/tracing-forest"]
 
 [dependencies]
 async-trait           = { version = "0.1" }
+futures               = { version = "0.3" }
 itertools             = { workspace = true }
 miden-lib             = { workspace = true }
 miden-node-proto      = { workspace = true }
@@ -28,6 +29,7 @@ miden-processor       = { workspace = true }
 miden-stdlib          = { workspace = true }
 miden-tx              = { workspace = true }
 miden-tx-batch-prover = { workspace = true }
+opentelemetry         = { workspace = true }
 rand                  = { version = "0.8" }
 serde                 = { version = "1.0", features = ["derive"] }
 thiserror             = { workspace = true }
@@ -35,6 +37,7 @@ tokio                 = { workspace = true, features = ["macros", "net", "rt-mul
 tokio-stream          = { workspace = true, features = ["net"] }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 url                   = { workspace = true }
 
 [dev-dependencies]

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -29,7 +29,6 @@ miden-processor       = { workspace = true }
 miden-stdlib          = { workspace = true }
 miden-tx              = { workspace = true }
 miden-tx-batch-prover = { workspace = true }
-opentelemetry         = { workspace = true }
 rand                  = { version = "0.8" }
 serde                 = { version = "1.0", features = ["derive"] }
 thiserror             = { workspace = true }
@@ -37,7 +36,6 @@ tokio                 = { workspace = true, features = ["macros", "net", "rt-mul
 tokio-stream          = { workspace = true, features = ["net"] }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
-tracing-opentelemetry = { workspace = true }
 url                   = { workspace = true }
 
 [dev-dependencies]

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -1,20 +1,22 @@
 use std::{collections::BTreeSet, ops::Range};
 
-use miden_node_utils::formatting::format_array;
+use futures::FutureExt;
 use miden_objects::{
     account::AccountId,
     batch::ProvenBatch,
-    block::Block,
-    note::{NoteHeader, Nullifier},
+    block::{Block, BlockNumber},
+    note::{NoteHeader, NoteId, Nullifier},
     transaction::{InputNoteCommitment, OutputNote},
 };
+use opentelemetry::trace::Status;
 use rand::Rng;
 use tokio::time::Duration;
-use tracing::{debug, info, instrument};
+use tracing::{instrument, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
-    errors::BuildBlockError, mempool::SharedMempool, store::StoreClient, COMPONENT,
-    SERVER_BLOCK_FREQUENCY,
+    block::BlockInputs, errors::BuildBlockError, mempool::SharedMempool, store::StoreClient,
+    COMPONENT, SERVER_BLOCK_FREQUENCY,
 };
 
 pub(crate) mod prover;
@@ -32,7 +34,7 @@ pub struct BlockBuilder {
     /// Simulated block failure rate as a percentage.
     ///
     /// Note: this _must_ be sign positive and less than 1.0.
-    pub failure_rate: f32,
+    pub failure_rate: f64,
 
     pub store: StoreClient,
     pub block_kernel: BlockProver,
@@ -72,37 +74,153 @@ impl BlockBuilder {
         loop {
             interval.tick().await;
 
-            let (block_number, batches) = mempool.lock().await.select_block();
-
-            let mut result = self.build_block(&batches).await;
-            let proving_duration = rand::thread_rng().gen_range(self.simulated_proof_time.clone());
-
-            tokio::time::sleep(proving_duration).await;
-
-            // Randomly inject failures at the given rate.
-            //
-            // Note: Rng::gen rolls between [0, 1.0) for f32, so this works as expected.
-            if rand::thread_rng().gen::<f32>() < self.failure_rate {
-                result = Err(BuildBlockError::InjectedFailure);
-            }
-
-            let mut mempool = mempool.lock().await;
-            match result {
-                Ok(_) => mempool.block_committed(block_number),
-                Err(_) => mempool.block_failed(block_number),
-            }
+            self.build_block(&mempool).await;
         }
     }
 
-    #[instrument(target = COMPONENT, skip_all, err)]
-    async fn build_block(&self, batches: &[ProvenBatch]) -> Result<(), BuildBlockError> {
-        info!(
-            target: COMPONENT,
-            num_batches = batches.len(),
-            batches = %format_array(batches.iter().map(ProvenBatch::id)),
-        );
+    #[instrument(parent = None, target = COMPONENT, name = "block_builder.build_block", skip_all)]
+    async fn build_block(&self, mempool: &SharedMempool) {
+        use futures::TryFutureExt;
 
-        let updated_account_set: BTreeSet<AccountId> = batches
+        // Run the block building stages and add open-telemetry trace information where applicable.
+        //
+        // Important telemetry is added to the root span, and stages are free to add additional data
+        // to their subspans. Each stage has its own span and is expected to emit an error
+        // event if it fails. This automatically marks the span as an error, however the
+        // root span must be manually marked as this function does not return a result.
+        Self::select_block(mempool)
+            .inspect(SelectedBlock::inject_telemetry)
+            .then(|selected| self.get_block_inputs(selected))
+            .inspect_ok(BlockPreimage::inject_telemetry)
+            .and_then(|inputs| self.prove_block(inputs))
+            .inspect_ok(ProvenBlock::inject_telemetry)
+            // Failure must be injected before the final pipeline stage i.e. before commit is called. The system cannot
+            // handle errors after it considers the process complete (which makes sense).
+            .and_then(|proven_block| async { self.inject_failure(proven_block) })
+            .and_then(|proven_block| self.commit_block(mempool, proven_block))
+            // Handle errors by propagating the error to the root span and rolling back the block.
+            .inspect_err(|err| Span::current().set_status(Status::Error { description: format!("{err:?}").into() }))
+            .or_else(|_err| self.rollback_block(mempool).never_error())
+            // Error has been handled, this is just type manipulation to remove the result wrapper.
+            .unwrap_or_else(|_| ())
+            .await;
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.select_block", skip_all)]
+    async fn select_block(mempool: &SharedMempool) -> SelectedBlock {
+        let (block_number, batches) = mempool.lock().await.select_block();
+        SelectedBlock { block_number, batches }
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.get_block_inputs", skip_all, err)]
+    async fn get_block_inputs(
+        &self,
+        selected_block: SelectedBlock,
+    ) -> Result<BlockPreimage, BuildBlockError> {
+        let SelectedBlock { block_number: _, batches } = selected_block;
+        let summary = BlockSummary::summarize_batches(&batches);
+
+        let inputs = self
+            .store
+            .get_block_inputs(
+                summary.updated_accounts.iter().copied(),
+                summary.nullifiers.iter(),
+                summary.dangling_notes.iter(),
+            )
+            .await
+            .map_err(BuildBlockError::GetBlockInputsFailed)?;
+
+        let missing_notes: Vec<_> = summary
+            .dangling_notes
+            .difference(&inputs.found_unauthenticated_notes.note_ids())
+            .copied()
+            .collect();
+        if !missing_notes.is_empty() {
+            return Err(BuildBlockError::UnauthenticatedNotesNotFound(missing_notes));
+        }
+
+        Ok(BlockPreimage { batches, summary, inputs })
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.prove_block", skip_all, err)]
+    async fn prove_block(&self, preimage: BlockPreimage) -> Result<ProvenBlock, BuildBlockError> {
+        let BlockPreimage { batches, summary, inputs } = preimage;
+
+        let (block_header_witness, updated_accounts) = BlockWitness::new(inputs, &batches)?;
+
+        let new_block_header = self.block_kernel.prove(block_header_witness)?;
+
+        let block = Block::new(
+            new_block_header,
+            updated_accounts,
+            summary.output_notes,
+            summary.nullifiers,
+        )
+        .expect("invalid block components");
+
+        self.simulate_proving().await;
+
+        Ok(ProvenBlock { block })
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.commit_block", skip_all, err)]
+    async fn commit_block(
+        &self,
+        mempool: &SharedMempool,
+        proven_block: ProvenBlock,
+    ) -> Result<(), BuildBlockError> {
+        self.store
+            .apply_block(&proven_block.block)
+            .await
+            .map_err(BuildBlockError::StoreApplyBlockFailed)?;
+
+        mempool.lock().await.commit_block();
+
+        Ok(())
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.rollback_block", skip_all)]
+    async fn rollback_block(&self, mempool: &SharedMempool) {
+        mempool.lock().await.rollback_block();
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.simulate_proving", skip_all)]
+    async fn simulate_proving(&self) {
+        let proving_duration = rand::thread_rng().gen_range(self.simulated_proof_time.clone());
+
+        Span::current().set_attribute("range.min_s", self.simulated_proof_time.start.as_secs_f64());
+        Span::current().set_attribute("range.max_s", self.simulated_proof_time.end.as_secs_f64());
+        Span::current().set_attribute("dice_roll_s", proving_duration.as_secs_f64());
+
+        tokio::time::sleep(proving_duration).await;
+    }
+
+    #[instrument(target = COMPONENT, name = "block_builder.inject_failure", skip_all, err)]
+    fn inject_failure<T>(&self, value: T) -> Result<T, BuildBlockError> {
+        let roll = rand::thread_rng().gen::<f64>();
+
+        Span::current().set_attribute("failure_rate", self.failure_rate);
+        Span::current().set_attribute("dice_roll", roll);
+
+        if roll < self.failure_rate {
+            Err(BuildBlockError::InjectedFailure)
+        } else {
+            Ok(value)
+        }
+    }
+}
+
+struct BlockSummary {
+    updated_accounts: BTreeSet<AccountId>,
+    nullifiers: Vec<Nullifier>,
+    output_notes: Vec<Vec<OutputNote>>,
+    dangling_notes: BTreeSet<NoteId>,
+}
+
+impl BlockSummary {
+    #[instrument(target = COMPONENT, name = "block_builder.summarize_batches", skip_all)]
+    fn summarize_batches(batches: &[ProvenBatch]) -> Self {
+        let updated_accounts: BTreeSet<AccountId> = batches
             .iter()
             .flat_map(ProvenBatch::account_updates)
             .map(|(account_id, _)| *account_id)
@@ -111,7 +229,7 @@ impl BlockBuilder {
         let output_notes: Vec<_> =
             batches.iter().map(|batch| batch.output_notes().to_vec()).collect();
 
-        let produced_nullifiers: Vec<Nullifier> =
+        let nullifiers: Vec<Nullifier> =
             batches.iter().flat_map(ProvenBatch::produced_nullifiers).collect();
 
         // Populate set of output notes from all batches
@@ -120,8 +238,8 @@ impl BlockBuilder {
             .flat_map(|output_notes| output_notes.iter().map(OutputNote::id))
             .collect();
 
-        // Build a set of unauthenticated input notes for this block which do not have a matching
-        // output note produced in this block
+        // Build a set of unauthenticated input notes for this block which do not have a
+        // matching output note produced in this block
         let dangling_notes: BTreeSet<_> = batches
             .iter()
             .flat_map(ProvenBatch::input_notes)
@@ -130,47 +248,79 @@ impl BlockBuilder {
             .filter(|note_id| !output_notes_set.contains(note_id))
             .collect();
 
-        // Request information needed for block building from the store
-        let block_inputs = self
-            .store
-            .get_block_inputs(
-                updated_account_set.into_iter(),
-                produced_nullifiers.iter(),
-                dangling_notes.iter(),
-            )
-            .await
-            .map_err(BuildBlockError::GetBlockInputsFailed)?;
-
-        let missing_notes: Vec<_> = dangling_notes
-            .difference(&block_inputs.found_unauthenticated_notes.note_ids())
-            .copied()
-            .collect();
-        if !missing_notes.is_empty() {
-            return Err(BuildBlockError::UnauthenticatedNotesNotFound(missing_notes));
+        Self {
+            updated_accounts,
+            nullifiers,
+            output_notes,
+            dangling_notes,
         }
+    }
+}
 
-        let (block_header_witness, updated_accounts) = BlockWitness::new(block_inputs, batches)?;
+struct SelectedBlock {
+    block_number: BlockNumber,
+    batches: Vec<ProvenBatch>,
+}
+struct BlockPreimage {
+    batches: Vec<ProvenBatch>,
+    summary: BlockSummary,
+    inputs: BlockInputs,
+}
+struct ProvenBlock {
+    block: Block,
+}
 
-        let new_block_header = self.block_kernel.prove(block_header_witness)?;
+impl SelectedBlock {
+    fn inject_telemetry(&self) {
+        let span = Span::current();
+        span.set_attribute("block.number", i64::from(self.block_number.as_u32()));
+        span.set_attribute("block.batches.count", i64::from(self.batches.len() as u32));
+    }
+}
 
-        // TODO: return an error?
-        let block =
-            Block::new(new_block_header, updated_accounts, output_notes, produced_nullifiers)
-                .expect("invalid block components");
+impl BlockPreimage {
+    fn inject_telemetry(&self) {
+        let span = Span::current();
 
-        let block_hash = block.hash();
-        let block_num = new_block_header.block_num();
+        // SAFETY: We do not expect to have more than u32::MAX of any count per block.
+        span.set_attribute(
+            "block.updated_accounts.count",
+            i64::try_from(self.summary.updated_accounts.len())
+                .expect("less than u32::MAX account updates"),
+        );
+        span.set_attribute(
+            "block.output_notes.count",
+            i64::try_from(self.summary.output_notes.len())
+                .expect("less than u32::MAX output notes"),
+        );
+        span.set_attribute(
+            "block.nullifiers.count",
+            i64::try_from(self.summary.nullifiers.len()).expect("less than u32::MAX nullifiers"),
+        );
+        span.set_attribute(
+            "block.dangling_notes.count",
+            i64::try_from(self.summary.dangling_notes.len())
+                .expect("less than u32::MAX dangling notes"),
+        );
+    }
+}
 
-        info!(target: COMPONENT, %block_num, %block_hash, "block built");
-        debug!(target: COMPONENT, ?block);
+impl ProvenBlock {
+    fn inject_telemetry(&self) {
+        let span = Span::current();
+        let header = self.block.header();
 
-        self.store
-            .apply_block(&block)
-            .await
-            .map_err(BuildBlockError::StoreApplyBlockFailed)?;
+        span.set_attribute("block.hash", header.hash().to_hex());
+        span.set_attribute("block.sub_hash", header.sub_hash().to_hex());
+        span.set_attribute("block.parent_hash", header.prev_hash().to_hex());
 
-        info!(target: COMPONENT, %block_num, %block_hash, "block committed");
+        span.set_attribute("block.protocol.version", i64::from(header.version()));
 
-        Ok(())
+        span.set_attribute("block.roots.kernel", header.kernel_root().to_hex());
+        span.set_attribute("block.roots.nullifier", header.nullifier_root().to_hex());
+        span.set_attribute("block.roots.account", header.account_root().to_hex());
+        span.set_attribute("block.roots.chain", header.chain_root().to_hex());
+        span.set_attribute("block.roots.note", header.note_root().to_hex());
+        span.set_attribute("block.roots.transation", header.tx_hash().to_hex());
     }
 }

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -165,8 +165,7 @@ impl BlockBuilder {
             updated_accounts,
             summary.output_notes,
             summary.nullifiers,
-        )
-        .expect("invalid block components");
+        )?;
 
         self.simulate_proving().await;
 
@@ -300,7 +299,7 @@ impl BlockSummaryAndInputs {
         );
         span.set_attribute(
             "block.output_notes.count",
-            i64::try_from(self.summary.output_notes.len())
+            i64::try_from(self.summary.output_notes.iter().fold(0, |acc, x| acc.add(x.len())))
                 .expect("less than u32::MAX output notes"),
         );
         span.set_attribute(
@@ -326,11 +325,11 @@ impl ProvenBlock {
 
         span.set_attribute("block.protocol.version", i64::from(header.version()));
 
-        span.set_attribute("block.roots.kernel", header.kernel_root().to_hex());
-        span.set_attribute("block.roots.nullifier", header.nullifier_root().to_hex());
-        span.set_attribute("block.roots.account", header.account_root().to_hex());
-        span.set_attribute("block.roots.chain", header.chain_root().to_hex());
-        span.set_attribute("block.roots.note", header.note_root().to_hex());
-        span.set_attribute("block.roots.transation", header.tx_hash().to_hex());
+        span.set_attribute("block.commitments.kernel", header.kernel_root().to_hex());
+        span.set_attribute("block.commitments.nullifier", header.nullifier_root().to_hex());
+        span.set_attribute("block.commitments.account", header.account_root().to_hex());
+        span.set_attribute("block.commitments.chain", header.chain_root().to_hex());
+        span.set_attribute("block.commitments.note", header.note_root().to_hex());
+        span.set_attribute("block.commitments.transaction", header.tx_hash().to_hex());
     }
 }

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -6,7 +6,7 @@ use miden_objects::{
     crypto::merkle::MerkleError,
     note::{NoteId, Nullifier},
     transaction::TransactionId,
-    AccountDeltaError, Digest, ProposedBatchError,
+    AccountDeltaError, BlockError, Digest, ProposedBatchError,
 };
 use miden_processor::ExecutionError;
 use miden_tx_batch_prover::errors::BatchProveError;
@@ -187,6 +187,8 @@ pub enum BuildBlockError {
         account_id: AccountId,
         source: AccountDeltaError,
     },
+    #[error("block construction failed")]
+    BlockConstructionError(#[from] BlockError),
     /// We sometimes randomly inject errors into the batch building process to test our failure
     /// responses.
     #[error("nothing actually went wrong, failure was injected on purpose")]

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -138,7 +138,7 @@ impl StoreClient {
     }
 
     /// Returns the latest block's header from the store.
-    #[instrument(target = COMPONENT, skip_all, err)]
+    #[instrument(target = COMPONENT, name = "store.client.latest_header", skip_all, err)]
     pub async fn latest_header(&self) -> Result<BlockHeader, StoreError> {
         let response = self
             .inner
@@ -156,7 +156,7 @@ impl StoreClient {
         BlockHeader::try_from(response).map_err(Into::into)
     }
 
-    #[instrument(target = COMPONENT, skip_all, err)]
+    #[instrument(target = COMPONENT, name = "store.client.get_tx_inputs", skip_all, err)]
     pub async fn get_tx_inputs(
         &self,
         proven_tx: &ProvenTransaction,
@@ -193,7 +193,7 @@ impl StoreClient {
         Ok(tx_inputs)
     }
 
-    #[instrument(target = COMPONENT, skip_all, err)]
+    #[instrument(target = COMPONENT, name = "store.client.get_block_inputs", skip_all, err)]
     pub async fn get_block_inputs(
         &self,
         updated_accounts: impl Iterator<Item = AccountId> + Send,
@@ -211,7 +211,7 @@ impl StoreClient {
         store_response.try_into().map_err(Into::into)
     }
 
-    #[instrument(target = COMPONENT, skip_all, err)]
+    #[instrument(target = COMPONENT, name = "store.client.get_batch_inputs", skip_all, err)]
     pub async fn get_batch_inputs(
         &self,
         block_references: impl Iterator<Item = (BlockNumber, Digest)> + Send,
@@ -227,7 +227,7 @@ impl StoreClient {
         store_response.try_into().map_err(Into::into)
     }
 
-    #[instrument(target = COMPONENT, skip_all, err)]
+    #[instrument(target = COMPONENT, name = "store.client.apply_block", skip_all, err)]
     pub async fn apply_block(&self, block: &Block) -> Result<(), StoreError> {
         let request = tonic::Request::new(ApplyBlockRequest { block: block.to_bytes() });
 

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -56,7 +56,7 @@ impl api_server::Api for StoreApi {
     /// If the block number is not provided, block header for the latest block is returned.
     #[instrument(
         target = COMPONENT,
-        name = "store:get_block_header_by_number",
+        name = "store.server.get_block_header_by_number",
         skip_all,
         ret(level = "debug"),
         err
@@ -88,7 +88,7 @@ impl api_server::Api for StoreApi {
     /// be verified against the latest root of the nullifier database.
     #[instrument(
         target = COMPONENT,
-        name = "store:check_nullifiers",
+        name = "store.server.check_nullifiers",
         skip_all,
         ret(level = "debug"),
         err
@@ -112,7 +112,7 @@ impl api_server::Api for StoreApi {
     /// Currently the only supported prefix length is 16 bits.
     #[instrument(
         target = COMPONENT,
-        name = "store:check_nullifiers_by_prefix",
+        name = "store.server.check_nullifiers_by_prefix",
         skip_all,
         ret(level = "debug"),
         err
@@ -145,7 +145,7 @@ impl api_server::Api for StoreApi {
     /// for the objects the client is interested in.
     #[instrument(
         target = COMPONENT,
-        name = "store:sync_state",
+        name = "store.server.sync_state",
         skip_all,
         ret(level = "debug"),
         err
@@ -214,7 +214,7 @@ impl api_server::Api for StoreApi {
     /// Returns info which can be used by the client to sync note state.
     #[instrument(
         target = COMPONENT,
-        name = "store:sync_notes",
+        name = "store.server.sync_notes",
         skip_all,
         ret(level = "debug"),
         err
@@ -246,7 +246,7 @@ impl api_server::Api for StoreApi {
     /// If the list is empty or no Note matched the requested NoteId and empty list is returned.
     #[instrument(
         target = COMPONENT,
-        name = "store:get_notes_by_id",
+        name = "store.server.get_notes_by_id",
         skip_all,
         ret(level = "debug"),
         err
@@ -278,7 +278,7 @@ impl api_server::Api for StoreApi {
     /// Returns details for public (public) account by id.
     #[instrument(
         target = COMPONENT,
-        name = "store:get_account_details",
+        name = "store.server.get_account_details",
         skip_all,
         ret(level = "debug"),
         err
@@ -302,7 +302,7 @@ impl api_server::Api for StoreApi {
     /// Updates the local DB by inserting a new block header and the related data.
     #[instrument(
         target = COMPONENT,
-        name = "store:apply_block",
+        name = "store.server.apply_block",
         skip_all,
         ret(level = "debug"),
         err
@@ -338,7 +338,7 @@ impl api_server::Api for StoreApi {
     /// Returns data needed by the block producer to construct and prove the next block.
     #[instrument(
         target = COMPONENT,
-        name = "store:get_block_inputs",
+        name = "store.server.get_block_inputs",
         skip_all,
         ret(level = "debug"),
         err
@@ -367,7 +367,7 @@ impl api_server::Api for StoreApi {
     /// See [`State::get_batch_inputs`] for details.
     #[instrument(
       target = COMPONENT,
-      name = "store:get_batch_inputs",
+      name = "store.server.get_batch_inputs",
       skip_all,
       ret(level = "debug"),
       err
@@ -397,7 +397,7 @@ impl api_server::Api for StoreApi {
 
     #[instrument(
         target = COMPONENT,
-        name = "store:get_transaction_inputs",
+        name = "store.server.get_transaction_inputs",
         skip_all,
         ret(level = "debug"),
         err
@@ -445,7 +445,7 @@ impl api_server::Api for StoreApi {
 
     #[instrument(
         target = COMPONENT,
-        name = "store:get_block_by_number",
+        name = "store.server.get_block_by_number",
         skip_all,
         ret(level = "debug"),
         err
@@ -465,7 +465,7 @@ impl api_server::Api for StoreApi {
 
     #[instrument(
         target = COMPONENT,
-        name = "store:get_account_proofs",
+        name = "store.server.get_account_proofs",
         skip_all,
         ret(level = "debug"),
         err
@@ -503,7 +503,7 @@ impl api_server::Api for StoreApi {
 
     #[instrument(
         target = COMPONENT,
-        name = "store:get_account_state_delta",
+        name = "store.server.get_account_state_delta",
         skip_all,
         ret(level = "debug"),
         err

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -24,7 +24,7 @@ figment               = { version = "0.10", features = ["env", "toml"] }
 http                  = "1.2"
 itertools             = { workspace = true }
 miden-objects         = { workspace = true }
-opentelemetry         = "0.27"
+opentelemetry         = { workspace = true }
 opentelemetry-otlp    = { version = "0.27", features = ["tls-roots"] }
 opentelemetry_sdk     = { version = "0.27", features = ["rt-tokio"] }
 rand                  = { workspace = true }
@@ -33,7 +33,7 @@ thiserror             = { workspace = true }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
 tracing-forest        = { version = "0.1", optional = true, features = ["chrono"] }
-tracing-opentelemetry = "0.28"
+tracing-opentelemetry = { workspace = true }
 tracing-subscriber    = { workspace = true }
 # Optional dependencies enabled by `vergen` feature.
 # This must match the version expected by `vergen-gitcl`.

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -24,7 +24,7 @@ figment               = { version = "0.10", features = ["env", "toml"] }
 http                  = "1.2"
 itertools             = { workspace = true }
 miden-objects         = { workspace = true }
-opentelemetry         = { workspace = true }
+opentelemetry         = { version = "0.27" }
 opentelemetry-otlp    = { version = "0.27", features = ["tls-roots"] }
 opentelemetry_sdk     = { version = "0.27", features = ["rt-tokio"] }
 rand                  = { workspace = true }
@@ -33,7 +33,7 @@ thiserror             = { workspace = true }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
 tracing-forest        = { version = "0.1", optional = true, features = ["chrono"] }
-tracing-opentelemetry = { workspace = true }
+tracing-opentelemetry = { version = "0.28" }
 tracing-subscriber    = { workspace = true }
 # Optional dependencies enabled by `vergen` feature.
 # This must match the version expected by `vergen-gitcl`.

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithTonicConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::subscriber::{self, Subscriber};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
@@ -10,6 +11,10 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)
 pub fn setup_tracing(enable_otel: bool) -> Result<()> {
+    if enable_otel {
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    }
+
     let otel_layer = enable_otel.then_some(open_telemetry_layer());
     let subscriber = Registry::default().with(stdout_layer()).with(otel_layer);
     tracing::subscriber::set_global_default(subscriber).map_err(Into::into)

--- a/crates/utils/src/tracing/mod.rs
+++ b/crates/utils/src/tracing/mod.rs
@@ -1,1 +1,6 @@
 pub mod grpc;
+
+// Re-export useful traits for open-telemetry traces. This avoids requiring other crates from
+// importing that family of crates directly.
+pub use opentelemetry::trace::Status as OtelStatus;
+pub use tracing_opentelemetry::OpenTelemetrySpanExt;


### PR DESCRIPTION
This PR reworks the instrumentation of the block builder to

1. align it more closely with open-telemetry standards, and
2. improve the telemetry and span information emitted

I also fix remote span context not being sent (propagator was not being set).

## Implementation

I've leant heavily on `#[instrument]` because manually instrumenting sync and async function calls is painful and error prone. The former requires `span.enter()` and `span.exit()`, and the latter requires `async_call.instrument(span).await`. This is easy to forget.

The downside is that code must first be structured by function/stage because `#[instrument]` cannot be applied to code blocks `{ ... }`. Though maybe this is an upside as well. I essentially structured the pipeline based on how I wanted the span information to be tracked.

## Updated spans

- refactored block building to better structure spans
- store client to `store.client.{method}` though maybe this should be `store.client/{method}`
- mempool to `mempool.{method}`

## Visual aid

Visualized span result using `tracing-forest` (note: forest cannot trace across RPC boundaries so I've manually merged those in and marked them with `*`).

Note that I haven't really focussed on the store server aspect here, I'm on the fence about the naming convention to use. The standard mentions namespacing via periods aka `x.y.z`, but RPC routes should follow `{package}.{service}/{method}`. All this to say that the store client/server have several styles currently.

```
INFO     block_builder.build_block [ 1.62ms | 3.67% / 100.00% ]
INFO     ┝━ block_builder.select_block [ 28.6µs | 0.28% / 1.76% ]
INFO     │  ┝━ mempool.lock [ 957ns | 0.06% ]
INFO     │  ┕━ mempool.block.select [ 23.1µs | 1.43% ]
INFO     ┝━ block_builder.get_block_inputs [ 144µs | 0.23% / 8.89% ]
INFO     │  ┝━ block_builder.summarize_batches [ 958ns | 0.06% ]
INFO     │  ┕━ store.client.get_block_inputs [ 139µs | 8.60% ]
INFO     │     ┕━ * store.rpc/GetBlockInputs [ 181µs | 27.20% / 100.00% ]
INFO     │        * ┕━ store.server.get_block_inputs [ 132µs | 54.00% / 72.80% ]
INFO     │        *   ┝━ validate_nullifiers [ 958ns | 0.53% ]
INFO     │        *   ┝━ read_account_ids [ 375ns | 0.21% ]
INFO     │        *   ┝━ validate_notes [ 583ns | 0.32% ]
INFO     │        *   ┝━ select_block_header_by_block_num [ 11.5µs | 6.37% ]
INFO     │        *   ┝━ select_note_inclusion_proofs [ 12.3µs | 6.83% ]
INFO     │        *   ┕━ select_block_headers [ 8.21µs | 4.54% ]
INFO     ┝━ block_builder.prove_block [ 1.34ms | 25.23% / 82.92% ]
INFO     │  ┝━ execute_program [ 926µs | 57.10% ]
INFO     │  ┕━ block_builder.simulate_proving [ 9.50µs | 0.59% ]
INFO     ┝━ block_builder.inject_failure [ 3.38µs | 0.21% ]
INFO     ┕━ block_builder.commit_block [ 41.4µs | 0.13% / 2.56% ]
INFO        ┝━ store.client.apply_block [ 23.3µs | 1.44% ]
INFO        │   ┕━ * store.rpc/ApplyBlock [ 182µs | 24.24% / 100.00% ]
INFO        │      * ┕━ store.server.apply_block [ 138µs | 24.95% / 75.76% ]
INFO        │      *    ┕━ apply_block [ 92.5µs | 27.65% / 50.80% ]
INFO        │      *       ┝━ select_block_header_by_block_num [ 10.3µs | 5.65% ]
INFO        │      *       ┝━ update_in_memory_structs [ 31.9µs | 17.50% ]
INFO        │      *       ┕━ ｉ [info]: apply_block successful
INFO        ┝━ mempool.lock [ 250ns | 0.02% ]
INFO        ┕━ mempool.block.commit [ 15.8µs | 0.85% / 0.97% ]
INFO           ┕━ mempool.transactions.revert [ 2.00µs | 0.12% ]
```

Tidbits:
- I included the lock time of the mempool so we can see contention. I think this will make an interesting stat to monitor.
- I'm unsure about sub-namespacing the `mempool` i.e. `mempool.block.xxx` vs `mempool.block_xxx`.
- The transactions revert in mempool is due to the tx expiring - I should maybe add a span there to make it obvious? 

