### PR TITLE
chore: Use `miden-base`'s `next`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?rev=e82dee03de7589ef3fb12b7fd901cef25ae5535d#e82dee03de7589ef3fb12b7fd901cef25ae5535d"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?rev=e82dee03de7589ef3fb12b7fd901cef25ae5535d#e82dee03de7589ef3fb12b7fd901cef25ae5535d"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "getrandom 0.2.15",
  "miden-assembly",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?rev=e82dee03de7589ef3fb12b7fd901cef25ae5535d#e82dee03de7589ef3fb12b7fd901cef25ae5535d"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?rev=e82dee03de7589ef3fb12b7fd901cef25ae5535d#e82dee03de7589ef3fb12b7fd901cef25ae5535d"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "miden-core",
  "miden-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,17 +28,17 @@ version      = "0.8.0"
 assert_matches            = { version = "1.5" }
 itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.12" }
-miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.8" }
 miden-node-proto          = { path = "crates/proto", version = "0.8" }
 miden-node-rpc            = { path = "crates/rpc", version = "0.8" }
 miden-node-store          = { path = "crates/store", version = "0.8" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.8" }
-miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 miden-processor           = { version = "0.12" }
 miden-stdlib              = { version = "0.12", default-features = false }
-miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 miden-tx-batch-prover     = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,18 @@ version      = "0.8.0"
 assert_matches            = { version = "1.5" }
 itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.12" }
-miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.8" }
 miden-node-proto          = { path = "crates/proto", version = "0.8" }
 miden-node-rpc            = { path = "crates/rpc", version = "0.8" }
 miden-node-store          = { path = "crates/store", version = "0.8" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.8" }
-miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 miden-processor           = { version = "0.12" }
 miden-stdlib              = { version = "0.12", default-features = false }
-miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
-miden-tx-batch-prover     = { git = "https://github.com/0xPolygonMiden/miden-base.git", rev = "e82dee03de7589ef3fb12b7fd901cef25ae5535d" }
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-tx-batch-prover     = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.8" }
 thiserror                 = { version = "2.0", default-features = false }

--- a/crates/block-producer/src/test_utils/batch.rs
+++ b/crates/block-producer/src/test_utils/batch.rs
@@ -4,6 +4,7 @@ use miden_objects::{
     batch::{BatchAccountUpdate, BatchId, BatchNoteTree, ProvenBatch},
     block::BlockNumber,
     transaction::{InputNotes, ProvenTransaction},
+    Digest,
 };
 
 use crate::test_utils::MockProvenTxBuilder;
@@ -57,6 +58,8 @@ impl TransactionBatchConstructor for ProvenBatch {
 
         ProvenBatch::new(
             BatchId::from_transactions(txs.into_iter()),
+            Digest::default(),
+            BlockNumber::GENESIS,
             account_updates,
             InputNotes::new_unchecked(input_notes),
             BatchNoteTree::with_contiguous_leaves(

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -131,7 +131,7 @@ impl MockBlockBuilder {
     pub fn account_updates(mut self, updated_accounts: Vec<BlockAccountUpdate>) -> Self {
         for update in &updated_accounts {
             self.store_accounts
-                .insert(update.account_id().into(), update.new_state_hash().into());
+                .insert(update.account_id().into(), update.final_state_commitment().into());
         }
 
         self.updated_accounts = Some(updated_accounts);

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -199,7 +199,8 @@ impl MockStoreSuccess {
 
         // update accounts
         for update in block.updated_accounts() {
-            locked_accounts.insert(update.account_id().into(), update.new_state_hash().into());
+            locked_accounts
+                .insert(update.account_id().into(), update.final_state_commitment().into());
         }
         let header = block.header();
         debug_assert_eq!(locked_accounts.root(), header.account_root());

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -48,7 +48,7 @@ impl GenesisState {
 
         let account_smt: SimpleSmt<ACCOUNT_TREE_DEPTH> =
             SimpleSmt::with_leaves(accounts.iter().map(|update| {
-                (update.account_id().prefix().into(), update.new_state_hash().into())
+                (update.account_id().prefix().into(), update.final_state_commitment().into())
             }))?;
 
         let header = BlockHeader::new(

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -264,7 +264,7 @@ impl State {
                 block.updated_accounts().iter().map(|update| {
                     (
                         LeafIndex::new_max_depth(update.account_id().prefix().into()),
-                        update.new_state_hash().into(),
+                        update.final_state_commitment().into(),
                     )
                 }),
             );


### PR DESCRIPTION
We needed the branch to test some features on the client properly.

EDIT: Didn't realize the `next` branch was already using a pinned commit from `miden-base`. Not sure if there is a specific reason for this but we still need a newer version.