### PR TITLE
chore: upgrade otel crates and apply filters to exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
-- Add an optional open-telemetry trace exporter (#659).
+- Add an optional open-telemetry trace exporter (#659, #690).
 - Support tracing across gRPC boundaries using remote tracing context (#669).
 - Instrument the block-producer's block building process (#676).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,23 +2312,23 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -2337,17 +2337,16 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2357,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2370,7 +2369,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3764,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -17,7 +17,9 @@ use client::initialize_faucet_client;
 use handlers::{get_background, get_favicon, get_index_css, get_index_html, get_index_js};
 use http::HeaderValue;
 use miden_lib::{account::faucets::create_basic_fungible_faucet, AuthScheme};
-use miden_node_utils::{config::load_config, crypto::get_rpo_random_coin, version::LongVersion};
+use miden_node_utils::{
+    config::load_config, crypto::get_rpo_random_coin, logging::OpenTelemetry, version::LongVersion,
+};
 use miden_objects::{
     account::{AccountFile, AccountStorageMode, AuthSecretKey},
     asset::TokenSymbol,
@@ -89,7 +91,8 @@ pub enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    miden_node_utils::logging::setup_logging().context("Failed to initialize logging")?;
+    miden_node_utils::logging::setup_tracing(OpenTelemetry::Disabled)
+        .context("Failed to initialize logging")?;
 
     let cli = Cli::parse();
 

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -92,14 +92,14 @@ pub enum Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     miden_node_utils::logging::setup_tracing(OpenTelemetry::Disabled)
-        .context("Failed to initialize logging")?;
+        .context("failed to initialize logging")?;
 
     let cli = Cli::parse();
 
     match &cli.command {
         Command::Start { config } => {
             let config: FaucetConfig =
-                load_config(config).context("Failed to load configuration file")?;
+                load_config(config).context("failed to load configuration file")?;
 
             let faucet_state = FaucetState::new(config.clone()).await?;
 
@@ -132,7 +132,7 @@ async fn main() -> anyhow::Result<()> {
                 anyhow::anyhow!("Couldn't get any socket addrs for endpoint: {}", config.endpoint),
             )?;
             let listener =
-                TcpListener::bind(socket_addr).await.context("Failed to bind TCP listener")?;
+                TcpListener::bind(socket_addr).await.context("failed to bind TCP listener")?;
 
             info!(target: COMPONENT, endpoint = %config.endpoint, "Server started");
 
@@ -149,12 +149,12 @@ async fn main() -> anyhow::Result<()> {
             println!("Generating new faucet account. This may take a few minutes...");
 
             let config: FaucetConfig =
-                load_config(config_path).context("Failed to load configuration file")?;
+                load_config(config_path).context("failed to load configuration file")?;
 
             let (_, root_block_header, _) = initialize_faucet_client(&config).await?;
 
             let current_dir =
-                std::env::current_dir().context("Failed to open current directory")?;
+                std::env::current_dir().context("failed to open current directory")?;
 
             let mut rng = ChaCha20Rng::from_seed(rand::random());
 
@@ -162,16 +162,16 @@ async fn main() -> anyhow::Result<()> {
 
             let (account, account_seed) = create_basic_fungible_faucet(
                 rng.gen(),
-                (&root_block_header).try_into().context("Failed to create anchor block")?,
+                (&root_block_header).try_into().context("failed to create anchor block")?,
                 TokenSymbol::try_from(token_symbol.as_str())
-                    .context("Failed to parse token symbol")?,
+                    .context("failed to parse token symbol")?,
                 *decimals,
                 Felt::try_from(*max_supply)
                     .expect("max supply value is greater than or equal to the field modulus"),
                 AccountStorageMode::Public,
                 AuthScheme::RpoFalcon512 { pub_key: secret.public_key() },
             )
-            .context("Failed to create basic fungible faucet account")?;
+            .context("failed to create basic fungible faucet account")?;
 
             let account_data =
                 AccountFile::new(account, Some(account_seed), AuthSecretKey::RpoFalcon512(secret));
@@ -179,14 +179,14 @@ async fn main() -> anyhow::Result<()> {
             let output_path = current_dir.join(output_path);
             account_data
                 .write(&output_path)
-                .context("Failed to write account data to file")?;
+                .context("failed to write account data to file")?;
 
             println!("Faucet account file successfully created at: {output_path:?}");
         },
 
         Command::Init { config_path, faucet_account_path } => {
             let current_dir =
-                std::env::current_dir().context("Failed to open current directory")?;
+                std::env::current_dir().context("failed to open current directory")?;
 
             let config_file_path = current_dir.join(config_path);
 
@@ -196,10 +196,10 @@ async fn main() -> anyhow::Result<()> {
             };
 
             let config_as_toml_string =
-                toml::to_string(&config).context("Failed to serialize default config")?;
+                toml::to_string(&config).context("failed to serialize default config")?;
 
             std::fs::write(&config_file_path, config_as_toml_string)
-                .context("Error writing config to file")?;
+                .context("error writing config to file")?;
 
             println!("Config file successfully created at: {config_file_path:?}");
         },

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -88,9 +88,10 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Open telemetry exporting is only valid for running the node.
-    let open_telemetry = match &cli.command {
-        Command::Start { open_telemetry, .. } if *open_telemetry => OpenTelemetry::Enabled,
-        _ => OpenTelemetry::Disabled,
+    let open_telemetry = if let Command::Start { open_telemetry: true, .. } = &cli.command {
+        OpenTelemetry::Enabled
+    } else {
+        OpenTelemetry::Disabled
     };
     miden_node_utils::logging::setup_tracing(open_telemetry)?;
 

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -6,7 +6,7 @@ use commands::{init::init_config_files, start::start_node};
 use miden_node_block_producer::server::BlockProducer;
 use miden_node_rpc::server::Rpc;
 use miden_node_store::server::Store;
-use miden_node_utils::{config::load_config, version::LongVersion};
+use miden_node_utils::{config::load_config, logging::OpenTelemetry, version::LongVersion};
 
 mod commands;
 mod config;
@@ -89,8 +89,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Open telemetry exporting is only valid for running the node.
     let open_telemetry = match &cli.command {
-        Command::Start { open_telemetry, .. } => *open_telemetry,
-        _ => false,
+        Command::Start { open_telemetry, .. } if *open_telemetry => OpenTelemetry::Enabled,
+        _ => OpenTelemetry::Disabled,
     };
     miden_node_utils::logging::setup_tracing(open_telemetry)?;
 

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -10,7 +10,9 @@ pub fn enable_logging(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let stmts = function.block.stmts;
     let block: Block = parse_quote! {{
         if ::std::env::args().any(|e| e == "--nocapture") {
-            let subscriber = ::tracing::subscriber::set_default(::miden_node_utils::logging::subscriber());
+            ::miden_node_utils::logging::setup_tracing(
+                ::miden_node_utils::logging::OpenTelemetry::Disabled
+            ).expect("logging setup should succeed");
             let span = ::tracing::span!(::tracing::Level::INFO, #name).entered();
 
             #(#stmts)*

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -21,19 +21,19 @@ vergen = ["dep:vergen", "dep:vergen-gitcl"]
 [dependencies]
 anyhow                = { version = "1.0" }
 figment               = { version = "0.10", features = ["env", "toml"] }
-http                  = "1.2"
+http                  = { version = "1.2" }
 itertools             = { workspace = true }
 miden-objects         = { workspace = true }
-opentelemetry         = { version = "0.27" }
-opentelemetry-otlp    = { version = "0.27", features = ["tls-roots"] }
-opentelemetry_sdk     = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry         = { version = "0.28" }
+opentelemetry-otlp    = { version = "0.28", default-features = false, features = ["grpc-tonic", "tls-roots", "trace"] }
+opentelemetry_sdk     = { version = "0.28", features = ["rt-tokio"] }
 rand                  = { workspace = true }
 serde                 = { version = "1.0", features = ["derive"] }
 thiserror             = { workspace = true }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
 tracing-forest        = { version = "0.1", optional = true, features = ["chrono"] }
-tracing-opentelemetry = { version = "0.28" }
+tracing-opentelemetry = { version = "0.29" }
 tracing-subscriber    = { workspace = true }
 # Optional dependencies enabled by `vergen` feature.
 # This must match the version expected by `vergen-gitcl`.

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -37,8 +37,8 @@ where
         .build()
         .unwrap();
 
-    let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
-        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+    let tracer = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
         .build();
 
     let tracer = tracer.tracer("tracing-otel-subscriber");

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -1,29 +1,46 @@
+use std::str::FromStr;
+
 use anyhow::Result;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithTonicConfig;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use tracing::subscriber::{self, Subscriber};
+use tracing::subscriber::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
+use tracing_subscriber::{
+    layer::{Filter, SubscriberExt},
+    Layer, Registry,
+};
+
+#[derive(Clone, Copy)]
+pub enum OpenTelemetry {
+    Enabled,
+    Disabled,
+}
+
+impl OpenTelemetry {
+    fn is_enabled(self) -> bool {
+        matches!(self, OpenTelemetry::Enabled)
+    }
+}
 
 /// Configures tracing and optionally enables an open-telemetry OTLP exporter.
 ///
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)
-pub fn setup_tracing(enable_otel: bool) -> Result<()> {
-    if enable_otel {
+pub fn setup_tracing(otel: OpenTelemetry) -> Result<()> {
+    if otel.is_enabled() {
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     }
 
-    let otel_layer = enable_otel.then_some(open_telemetry_layer());
-    let subscriber = Registry::default().with(stdout_layer()).with(otel_layer);
+    // Note: open-telemetry requires a tokio-runtime, so this _must_ be lazily evaluated (aka not
+    // `then_some`) to avoid crashing sync callers (with OpenTelemetry::Disabled set). Examples of
+    // such callers are tests with logging enabled.
+    let otel_layer = otel.is_enabled().then(open_telemetry_layer);
+
+    let subscriber = Registry::default()
+        .with(stdout_layer().with_filter(env_or_default_filter()))
+        .with(otel_layer.with_filter(env_or_default_filter()));
     tracing::subscriber::set_global_default(subscriber).map_err(Into::into)
-}
-
-pub fn setup_logging() -> Result<()> {
-    subscriber::set_global_default(subscriber())?;
-
-    Ok(())
 }
 
 fn open_telemetry_layer<S>() -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>
@@ -61,11 +78,6 @@ where
         .with_line_number(true)
         .with_target(true)
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .with_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            // axum logs rejections from built-in extracts on the trace level, so we enable this
-            // manually.
-            "info,axum::rejection=trace".into()
-        }))
         .boxed()
 }
 
@@ -75,45 +87,36 @@ where
     S: Subscriber,
     for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
 {
-    tracing_forest::ForestLayer::default()
-        .with_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            // axum logs rejections from built-in extracts on the trace level, so we enable this
-            // manually.
-            "info,axum::rejection=trace".into()
-        }))
-        .boxed()
+    tracing_forest::ForestLayer::default().boxed()
 }
 
-#[cfg(not(feature = "tracing-forest"))]
-pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
-    use tracing_subscriber::fmt::format::FmtSpan;
+/// Creates a filter from the `RUST_LOG` env var with a default of `INFO` if unset.
+///
+/// # Panics
+///
+/// Panics if `RUST_LOG` fails to parse.
+fn env_or_default_filter<S>() -> Box<dyn Filter<S> + Send + Sync + 'static> {
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::{
+        filter::{FilterExt, Targets},
+        EnvFilter,
+    };
 
-    tracing_subscriber::fmt()
-        .pretty()
-        .compact()
-        .with_level(true)
-        .with_file(true)
-        .with_line_number(true)
-        .with_target(true)
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            // axum logs rejections from built-in extracts on the trace level, so we enable this
-            // manually.
-            "info,axum::rejection=trace".into()
-        }))
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .finish()
-}
-
-#[cfg(feature = "tracing-forest")]
-pub fn subscriber() -> impl Subscriber + core::fmt::Debug {
-    pub use tracing_forest::ForestLayer;
-    pub use tracing_subscriber::{layer::SubscriberExt, Registry};
-
-    Registry::default().with(ForestLayer::default()).with(
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            // axum logs rejections from built-in extracts on the trace level, so we enable this
-            // manually.
-            "info,axum::rejection=trace".into()
-        }),
-    )
+    // `tracing` does not allow differentiating between invalid and missing env var so we manually
+    // do this instead. The alternative is to silently ignore parsing errors which I think is worse.
+    match std::env::var(EnvFilter::DEFAULT_ENV) {
+        Ok(rust_log) => FilterExt::boxed(
+            EnvFilter::from_str(&rust_log)
+                .expect("RUST_LOG should contain a valid filter configuration"),
+        ),
+        Err(std::env::VarError::NotUnicode(_)) => panic!("RUST_LOG contained non-unicode"),
+        Err(std::env::VarError::NotPresent) => {
+            // Default level is INFO, and additionally enable logs from axum extractor rejections.
+            FilterExt::boxed(
+                Targets::new()
+                    .with_default(LevelFilter::INFO)
+                    .with_target("axum::rejection", LevelFilter::TRACE),
+            )
+        },
+    }
 }

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::{
     Layer, Registry,
 };
 
+/// Configures [`setup_tracing`] to enable or disable the open-telemetry exporter.
 #[derive(Clone, Copy)]
 pub enum OpenTelemetry {
     Enabled,
@@ -23,7 +24,10 @@ impl OpenTelemetry {
     }
 }
 
-/// Configures tracing and optionally enables an open-telemetry OTLP exporter.
+/// Initializes tracing to stdout and optionally an open-telemetry exporter.
+///
+/// Trace filtering defaults to `INFO` and can be configured using the conventional `RUST_LOG`
+/// environment variable.
 ///
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)


### PR DESCRIPTION
This PR upgrades the `otel` family of crates from v0.27 to v0.28. The `tracing_opentelemetry` crate is off-by-one.

I've added filtering to the open-telemetry trace exporter. Previously it was exporting everything at a rate of ~150 spans/events per second, which has now dropped to ~3.

I've also refactored the tracing/logging setup to get rid of the redundancy and make setup more obvious.

I'm not adding this to the changelog since no release contains otel exporting yet.

Closes #688 and closes #682 