### PR TITLE
feat(store): track network notes

### DIFF
--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -33,5 +33,6 @@ url                = { workspace = true }
 
 [dev-dependencies]
 assert_matches   = { workspace = true }
+miden-lib        = { workspace = true, features = ["testing"] }
 miden-node-utils = { workspace = true, features = ["tracing-forest"] }
 miden-objects    = { workspace = true, features = ["testing"] }

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -35,6 +35,7 @@ CREATE TABLE
     execution_hint INTEGER NOT NULL,
     merkle_path    BLOB    NOT NULL,
     consumed       INTEGER NOT NULL, -- boolean
+    nullifier      BLOB,             -- Only known for public notes, null for private notes
     details        BLOB,
 
     PRIMARY KEY (block_num, batch_index, note_index),

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -149,4 +149,4 @@ CREATE TABLE
 
 CREATE INDEX idx_transactions_account_id ON transactions(account_id);
 CREATE INDEX idx_transactions_block_num ON transactions(block_num);
-CREATE INDEX note_execution_mode ON notes(execution_mode);
+CREATE INDEX unconsumed_network_notes ON notes(execution_mode, consumed);

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -28,16 +28,20 @@ CREATE TABLE
     note_index     INTEGER NOT NULL, -- Index of note in batch, starting from 0
     note_id        BLOB    NOT NULL,
     note_type      INTEGER NOT NULL, -- 1-Public (0b01), 2-Private (0b10), 3-Encrypted (0b11)
-    sender         BLOB NOT NULL,
+    sender         BLOB    NOT NULL,
     tag            INTEGER NOT NULL,
+    execution_mode INTEGER NOT NULL, -- 0-Network, 1-Local
     aux            INTEGER NOT NULL,
     execution_hint INTEGER NOT NULL,
     merkle_path    BLOB    NOT NULL,
+    consumed       INTEGER NOT NULL, -- boolean
     details        BLOB,
 
     PRIMARY KEY (block_num, batch_index, note_index),
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
     CONSTRAINT notes_type_in_enum CHECK (note_type BETWEEN 1 AND 3),
+    CONSTRAINT notes_execution_mode_in_enum CHECK (execution_mode BETWEEN 0 AND 1),
+    CONSTRAINT notes_consumed_is_bool CHECK (execution_mode BETWEEN 0 AND 1),
     CONSTRAINT notes_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF),
     CONSTRAINT notes_batch_index_is_u32 CHECK (batch_index BETWEEN 0 AND 0xFFFFFFFF),
     CONSTRAINT notes_note_index_is_u32 CHECK (note_index BETWEEN 0 AND 0xFFFFFFFF)
@@ -145,3 +149,4 @@ CREATE TABLE
 
 CREATE INDEX idx_transactions_account_id ON transactions(account_id);
 CREATE INDEX idx_transactions_block_num ON transactions(block_num);
+CREATE INDEX note_execution_mode ON notes(execution_mode);

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -46,7 +46,7 @@ CREATE TABLE
     CONSTRAINT notes_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF),
     CONSTRAINT notes_batch_index_is_u32 CHECK (batch_index BETWEEN 0 AND 0xFFFFFFFF),
     CONSTRAINT notes_note_index_is_u32 CHECK (note_index BETWEEN 0 AND 0xFFFFFFFF)
-) STRICT, WITHOUT ROWID;
+) STRICT;
 
 CREATE TABLE
     accounts

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -63,6 +63,7 @@ pub struct NoteRecord {
     pub note_id: RpoDigest,
     pub metadata: NoteMetadata,
     pub details: Option<Vec<u8>>,
+    pub nullifier: Option<Nullifier>,
     pub merkle_path: MerklePath,
 }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -18,6 +18,7 @@ use miden_objects::{
     utils::Serializable,
 };
 use rusqlite::vtab::array;
+use sql::utils::{column_value_as_u64, read_block_number};
 use tokio::sync::oneshot;
 use tracing::{info, info_span, instrument};
 
@@ -65,6 +66,61 @@ pub struct NoteRecord {
     pub details: Option<Vec<u8>>,
     pub nullifier: Option<Nullifier>,
     pub merkle_path: MerklePath,
+}
+
+impl NoteRecord {
+    /// Columns from the `notes` table ordered to match [`Self::from_row`].
+    const SELECT_COLUMNS: &'static str = "
+            block_num,
+            batch_index,
+            note_index,
+            note_id,
+            note_type,
+            sender,
+            tag,
+            aux,
+            execution_hint,
+            merkle_path,
+            details,
+            nullifier
+    ";
+
+    /// Parses a row from the `notes` table. The sql selection must use [`Self::SELECT_COLUMNS`] to
+    /// ensure ordering is correct.
+    fn from_row(row: &rusqlite::Row<'_>) -> Result<Self> {
+        let block_num = read_block_number(row, 0)?;
+        let note_index = BlockNoteIndex::new(row.get(1)?, row.get(2)?)?;
+        let note_id = row.get_ref(3)?.as_blob()?;
+        let note_id = RpoDigest::read_from_bytes(note_id)?;
+        let note_type = row.get::<_, u8>(4)?.try_into()?;
+        let sender = AccountId::read_from_bytes(row.get_ref(5)?.as_blob()?)?;
+        let tag: u32 = row.get(6)?;
+        let aux: u64 = row.get(7)?;
+        let aux = aux.try_into().map_err(DatabaseError::InvalidFelt)?;
+        let execution_hint = column_value_as_u64(row, 8)?;
+        let merkle_path_data = row.get_ref(9)?.as_blob()?;
+        let merkle_path = MerklePath::read_from_bytes(merkle_path_data)?;
+        let details_data = row.get_ref(10)?.as_blob_or_null()?;
+        let details = details_data.map(<Vec<u8>>::read_from_bytes).transpose()?;
+        let nullifier = row
+            .get_ref(11)?
+            .as_blob_or_null()?
+            .map(Nullifier::read_from_bytes)
+            .transpose()?;
+
+        let metadata =
+            NoteMetadata::new(sender, note_type, tag.into(), execution_hint.try_into()?, aux)?;
+
+        Ok(NoteRecord {
+            block_num,
+            note_index,
+            note_id,
+            metadata,
+            details,
+            nullifier,
+            merkle_path,
+        })
+    }
 }
 
 impl From<NoteRecord> for proto::Note {

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -963,6 +963,7 @@ pub fn unconsumed_network_notes(
         SELECT {}, rowid FROM notes
         WHERE
             execution_mode = 0 AND consumed = FALSE AND rowid >= ?
+        ORDER BY rowid
         LIMIT ?
         ",
         NoteRecord::SELECT_COLUMNS

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -797,9 +797,11 @@ pub fn insert_notes(transaction: &Transaction, notes: &[NoteRecord]) -> Result<u
         note_type,
         sender,
         tag,
+        execution_mode,
         aux,
         execution_hint,
         merkle_path,
+        consumed,
         details,
     }))?;
 
@@ -814,9 +816,12 @@ pub fn insert_notes(transaction: &Transaction, notes: &[NoteRecord]) -> Result<u
             note.metadata.note_type() as u8,
             note.metadata.sender().to_bytes(),
             note.metadata.tag().inner(),
+            note.metadata.tag().execution_mode() as u8,
             u64_to_value(note.metadata.aux().into()),
-            Into::<u64>::into(note.metadata.execution_hint()),
+            u64_to_value(note.metadata.execution_hint().into()),
             note.merkle_path.to_bytes(),
+            // New notes are always uncomsumed.
+            false,
             details,
         ])?;
     }

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -187,12 +187,11 @@ fn sql_select_notes() {
             .unwrap(),
             details: Some(vec![1, 2, 3]),
             merkle_path: MerklePath::new(vec![]),
-            nullifier: None,
         };
         state.push(note.clone());
 
         let transaction = conn.transaction().unwrap();
-        let res = sql::insert_notes(&transaction, &[note]);
+        let res = sql::insert_notes(&transaction, &[(note, None)]);
         assert_eq!(res.unwrap(), 1, "One element must have been inserted");
         transaction.commit().unwrap();
         let notes = sql::select_all_notes(&mut conn).unwrap();
@@ -228,12 +227,11 @@ fn sql_select_notes_different_execution_hints() {
         .unwrap(),
         details: Some(vec![1, 2, 3]),
         merkle_path: MerklePath::new(vec![]),
-        nullifier: None,
     };
     state.push(note_none.clone());
 
     let transaction = conn.transaction().unwrap();
-    let res = sql::insert_notes(&transaction, &[note_none]);
+    let res = sql::insert_notes(&transaction, &[(note_none, None)]);
     assert_eq!(res.unwrap(), 1, "One element must have been inserted");
     transaction.commit().unwrap();
     let note = &sql::select_notes_by_id(&mut conn, &[num_to_rpo_digest(0).into()]).unwrap()[0];
@@ -253,12 +251,11 @@ fn sql_select_notes_different_execution_hints() {
         .unwrap(),
         details: Some(vec![1, 2, 3]),
         merkle_path: MerklePath::new(vec![]),
-        nullifier: None,
     };
     state.push(note_always.clone());
 
     let transaction = conn.transaction().unwrap();
-    let res = sql::insert_notes(&transaction, &[note_always]);
+    let res = sql::insert_notes(&transaction, &[(note_always, None)]);
     assert_eq!(res.unwrap(), 1, "One element must have been inserted");
     transaction.commit().unwrap();
     let note = &sql::select_notes_by_id(&mut conn, &[num_to_rpo_digest(1).into()]).unwrap()[0];
@@ -278,12 +275,11 @@ fn sql_select_notes_different_execution_hints() {
         .unwrap(),
         details: Some(vec![1, 2, 3]),
         merkle_path: MerklePath::new(vec![]),
-        nullifier: None,
     };
     state.push(note_after_block.clone());
 
     let transaction = conn.transaction().unwrap();
-    let res = sql::insert_notes(&transaction, &[note_after_block]);
+    let res = sql::insert_notes(&transaction, &[(note_after_block, None)]);
     assert_eq!(res.unwrap(), 1, "One element must have been inserted");
     transaction.commit().unwrap();
     let note = &sql::select_notes_by_id(&mut conn, &[num_to_rpo_digest(2).into()]).unwrap()[0];
@@ -911,11 +907,10 @@ fn notes() {
         .unwrap(),
         details,
         merkle_path: merkle_path.clone(),
-        nullifier: None,
     };
 
     let transaction = conn.transaction().unwrap();
-    sql::insert_notes(&transaction, &[note.clone()]).unwrap();
+    sql::insert_notes(&transaction, &[(note.clone(), None)]).unwrap();
     transaction.commit().unwrap();
 
     // test empty tags
@@ -949,11 +944,10 @@ fn notes() {
         metadata: note.metadata,
         details: None,
         merkle_path,
-        nullifier: None,
     };
 
     let transaction = conn.transaction().unwrap();
-    sql::insert_notes(&transaction, &[note2.clone()]).unwrap();
+    sql::insert_notes(&transaction, &[(note2.clone(), None)]).unwrap();
     transaction.commit().unwrap();
 
     // only first note is returned

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -187,6 +187,7 @@ fn sql_select_notes() {
             .unwrap(),
             details: Some(vec![1, 2, 3]),
             merkle_path: MerklePath::new(vec![]),
+            nullifier: None,
         };
         state.push(note.clone());
 
@@ -227,6 +228,7 @@ fn sql_select_notes_different_execution_hints() {
         .unwrap(),
         details: Some(vec![1, 2, 3]),
         merkle_path: MerklePath::new(vec![]),
+        nullifier: None,
     };
     state.push(note_none.clone());
 
@@ -251,6 +253,7 @@ fn sql_select_notes_different_execution_hints() {
         .unwrap(),
         details: Some(vec![1, 2, 3]),
         merkle_path: MerklePath::new(vec![]),
+        nullifier: None,
     };
     state.push(note_always.clone());
 
@@ -275,6 +278,7 @@ fn sql_select_notes_different_execution_hints() {
         .unwrap(),
         details: Some(vec![1, 2, 3]),
         merkle_path: MerklePath::new(vec![]),
+        nullifier: None,
     };
     state.push(note_after_block.clone());
 
@@ -907,6 +911,7 @@ fn notes() {
         .unwrap(),
         details,
         merkle_path: merkle_path.clone(),
+        nullifier: None,
     };
 
     let transaction = conn.transaction().unwrap();
@@ -944,6 +949,7 @@ fn notes() {
         metadata: note.metadata,
         details: None,
         merkle_path,
+        nullifier: None,
     };
 
     let transaction = conn.transaction().unwrap();

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::similar_names, reason = "naming dummy test values is hard")]
 #![allow(clippy::too_many_lines, reason = "test code can be long")]
 
+use std::num::NonZeroUsize;
+
 use miden_lib::transaction::TransactionKernel;
 use miden_node_proto::domain::account::AccountSummary;
 use miden_objects::{
@@ -12,10 +14,13 @@ use miden_objects::{
     asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree, BlockNumber},
     crypto::{hash::rpo::RpoDigest, merkle::MerklePath},
-    note::{NoteExecutionHint, NoteId, NoteMetadata, NoteType, Nullifier},
+    note::{
+        NoteExecutionHint, NoteExecutionMode, NoteId, NoteMetadata, NoteTag, NoteType, Nullifier,
+    },
     testing::account_id::{
         ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
         ACCOUNT_ID_OFF_CHAIN_SENDER, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
+        ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
     },
     Felt, FieldElement, Word, ZERO,
 };
@@ -287,6 +292,99 @@ fn sql_select_notes_different_execution_hints() {
         note.metadata.execution_hint(),
         NoteExecutionHint::after_block(12.into()).unwrap()
     );
+}
+
+#[test]
+fn sql_unconsumed_network_notes() {
+    // Number of notes to generate.
+    const N: u64 = 32;
+
+    let mut conn = create_db();
+
+    let block_num = BlockNumber::from(1);
+    // An arbitrary public account (network note tag requires public account).
+    let account_id = ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN.try_into().unwrap();
+    create_block(&mut conn, block_num);
+
+    // Create some notes, of which half are network notes.
+    let notes = (0..N)
+        .map(|i| {
+            let is_network = i % 2 == 0;
+            let execution_mode = if is_network {
+                NoteExecutionMode::Network
+            } else {
+                NoteExecutionMode::Local
+            };
+            let note = NoteRecord {
+                block_num,
+                note_index: BlockNoteIndex::new(0, i as usize).unwrap(),
+                note_id: num_to_rpo_digest(i),
+                metadata: NoteMetadata::new(
+                    account_id,
+                    NoteType::Public,
+                    NoteTag::from_account_id(account_id, execution_mode).unwrap(),
+                    NoteExecutionHint::none(),
+                    Felt::default(),
+                )
+                .unwrap(),
+                details: is_network.then_some(vec![1, 2, 3]),
+                merkle_path: MerklePath::new(vec![]),
+            };
+
+            (note, is_network.then_some(num_to_nullifier(i)))
+        })
+        .collect::<Vec<_>>();
+
+    // Copy out all network notes to assert against. These will be in chronological order already.
+    let network_notes = notes
+        .iter()
+        .filter_map(|(note, nullifier)| nullifier.is_some().then_some(note.clone()))
+        .collect::<Vec<_>>();
+
+    // Insert the set of notes.
+    let db_tx = conn.transaction().unwrap();
+    sql::insert_notes(&db_tx, &notes).unwrap();
+
+    // Fetch all network notes by setting a limit larger than the amount available.
+    let result =
+        sql::unconsumed_network_notes(&db_tx, 0, NonZeroUsize::new(N as usize * 10).unwrap())
+            .unwrap();
+    assert_eq!(result, network_notes);
+
+    // Check pagination works as expected.
+    let limit = 5;
+    network_notes.chunks(limit).enumerate().for_each(|(ichunk, expected)| {
+        let offset = ichunk * limit;
+        let result =
+            sql::unconsumed_network_notes(&db_tx, offset, NonZeroUsize::new(limit).unwrap())
+                .unwrap();
+        assert_eq!(result, expected);
+    });
+
+    // Returns empty when paging past the total.
+    let result =
+        sql::unconsumed_network_notes(&db_tx, N as usize + 1, NonZeroUsize::new(100).unwrap())
+            .unwrap();
+    assert!(result.is_empty());
+
+    // Consume every third network note and ensure these are now excluded from the results.
+    let consumed = notes
+        .iter()
+        .filter_map(|(_, nullifier)| *nullifier)
+        .step_by(3)
+        .collect::<Vec<_>>();
+    sql::insert_nullifiers_for_block(&db_tx, &consumed, block_num).unwrap();
+
+    let expected = network_notes
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| i % 3 != 0)
+        .map(|(_, note)| note.clone())
+        .collect::<Vec<_>>();
+    let result =
+        sql::unconsumed_network_notes(&db_tx, 0, NonZeroUsize::new(N as usize * 10).unwrap())
+            .unwrap();
+    assert_eq!(result, expected);
 }
 
 #[test]

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -393,17 +393,18 @@ impl State {
 
                 let merkle_path = note_tree.get_note_path(note_index);
 
-                Ok(NoteRecord {
+                let note_record = NoteRecord {
                     block_num,
                     note_index,
                     note_id: note.id().into(),
                     metadata: *note.metadata(),
                     details,
                     merkle_path,
-                    nullifier,
-                })
+                };
+
+                Ok((note_record, nullifier))
             })
-            .collect::<Result<Vec<NoteRecord>, InvalidBlockError>>()?;
+            .collect::<Result<Vec<_>, InvalidBlockError>>()?;
 
         // Signals the transaction is ready to be committed, and the write lock can be acquired
         let (allow_acquire, acquired_allowed) = oneshot::channel::<()>();

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -381,9 +381,9 @@ impl State {
         let notes = block
             .notes()
             .map(|(note_index, note)| {
-                let details = match note {
-                    OutputNote::Full(note) => Some(note.to_bytes()),
-                    OutputNote::Header(_) => None,
+                let (details, nullifier) = match note {
+                    OutputNote::Full(note) => (Some(note.to_bytes()), Some(note.nullifier())),
+                    OutputNote::Header(_) => (None, None),
                     note @ OutputNote::Partial(_) => {
                         return Err(InvalidBlockError::InvalidOutputNoteType(Box::new(
                             note.clone(),
@@ -400,6 +400,7 @@ impl State {
                     metadata: *note.metadata(),
                     details,
                     merkle_path,
+                    nullifier,
                 })
             })
             .collect::<Result<Vec<NoteRecord>, InvalidBlockError>>()?;


### PR DESCRIPTION
Adds `execution_mode` and `consumed` columns to the `notes` table.

Both are written when notes are inserted; however the `consumed` column is currently never set to `true` as we don't have that information available when applying a block (yet).

I've also added a pagination method to iterate over unconsumed network notes. This is intended to initialize the network transaction builder, probably via a streaming gRPC method. The implementation is copied from another note selection query so it should be correct.

Closes #696 