### PR TITLE
feat(store): Add index for non-fungible asset updates query

### DIFF
--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -294,6 +294,9 @@ pub fn select_account_delta(
 
     let mut select_non_fungible_asset_updates_stmt = conn.prepare_cached(
         "
+        CREATE INDEX IF NOT EXISTS idx_non_fungible_updates
+        ON account_non_fungible_asset_updates(account_id, block_num);
+
         SELECT
             block_num, vault_key, is_remove
         FROM


### PR DESCRIPTION
Add a composite index on account_id and block_num columns to optimize the performance of non-fungible asset updates query. This change improves query execution time by avoiding full table scans when retrieving ordered updates for specific accounts and block ranges.