### PR TITLE
Pin cargo machete to a specific version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,8 +94,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: machete
-        uses: bnjbvr/cargo-machete@main
+      - name: Install cargo-machete
+        uses: clechasseur/rs-cargo@v2
+        with:
+          command: install
+          args: cargo-machete@0.7.0
+      - name: Machete
+        uses: clechasseur/rs-cargo@v2
+        with:
+          command: machete
 
   proto:
     name: proto check


### PR DESCRIPTION
Pin cargo machete to a specific version since the latest one requires Edition 2024 which causes the action to fail (see current next).

Related: https://github.com/0xPolygonMiden/miden-base/pull/1181