### PR TITLE
chore: bump Rust 2024 edition

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,15 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: Install cargo-machete
-        uses: clechasseur/rs-cargo@v2
-        with:
-          command: install
-          args: cargo-machete@0.7.0
-      - name: Machete
-        uses: clechasseur/rs-cargo@v2
-        with:
-          command: machete
+      - name: machete
+        uses: bnjbvr/cargo-machete@main
 
   proto:
     name: proto check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [BREAKING] Update `GetBlockInputs` RPC (#709).
 - [BREAKING] `CheckNullifiersByPrefix` now takes a starting block number (#707).
 - [BREAKING] Removed nullifiers from `SyncState` endpoint (#708).
+- [BREAKING] Updated Rust Edition 2024 (#727).
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - [BREAKING] Update `GetBlockInputs` RPC (#709).
 - [BREAKING] `CheckNullifiersByPrefix` now takes a starting block number (#707).
 - [BREAKING] Removed nullifiers from `SyncState` endpoint (#708).
-- [BREAKING] Updated Rust Edition 2024 (#727).
+- [BREAKING] Updated to Rust Edition 2024 (#727).
+- [BREAKING] MSRV bumped to 1.85 (#727).
 
 ### Enhancements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ resolver = "2"
 
 [workspace.package]
 authors      = ["Miden contributors"]
-edition      = "2021"
+edition      = "2024"
 exclude      = [".github/"]
 homepage     = "https://polygon.technology/polygon-miden"
 license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xPolygonMiden/miden-node"
-rust-version = "1.84"
+rust-version = "1.85"
 version      = "0.8.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/miden-node/blob/main/LICENSE)
 [![test](https://github.com/0xPolygonMiden/miden-node/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-node/actions/workflows/test.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.84+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.85+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-node)](https://crates.io/crates/miden-node)
 
 This repository holds the Miden node; that is, the software which processes transactions and creates blocks for the
@@ -48,7 +48,7 @@ source.
 ### Debian package
 
 Debian packages are available and are the fastest way to install the node on a Debian-based system. Both `amd64` and
-`arm64` packages are available. 
+`arm64` packages are available.
 
 These packages can be found under our [releases](https://github.com/0xPolygonMiden/miden-node/releases) page along with
 a checksum.
@@ -73,7 +73,7 @@ sudo dpkg -i $package_name.deb
 
 ### Install using `cargo`
 
-Install Rust version **1.84** or greater using the official Rust installation
+Install Rust version **1.85** or greater using the official Rust installation
 [instructions](https://www.rust-lang.org/tools/install).
 
 Depending on the platform, you may need to install additional libraries. For example, on Ubuntu 22.04 the following

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -9,6 +9,7 @@ use miden_node_proto::generated::{
     rpc::api_client::ApiClient,
 };
 use miden_objects::{
+    Felt,
     account::{Account, AccountFile, AccountId, AuthSecretKey},
     asset::FungibleAsset,
     block::{BlockHeader, BlockNumber},
@@ -20,17 +21,16 @@ use miden_objects::{
     transaction::{ChainMmr, ExecutedTransaction, TransactionArgs, TransactionScript},
     utils::Deserializable,
     vm::AdviceMap,
-    Felt,
 };
 use miden_tx::{
-    auth::BasicAuthenticator, utils::Serializable, LocalTransactionProver, ProvingOptions,
-    TransactionExecutor, TransactionProver,
+    LocalTransactionProver, ProvingOptions, TransactionExecutor, TransactionProver,
+    auth::BasicAuthenticator, utils::Serializable,
 };
 use rand::{random, rngs::StdRng};
 use tonic::transport::Channel;
 use tracing::info;
 
-use crate::{config::FaucetConfig, errors::ClientError, store::FaucetDataStore, COMPONENT};
+use crate::{COMPONENT, config::FaucetConfig, errors::ClientError, store::FaucetDataStore};
 
 pub const DISTRIBUTE_FUNGIBLE_ASSET_SCRIPT: &str =
     include_str!("transaction_scripts/distribute_fungible_asset.masm");

--- a/bin/faucet/src/errors.rs
+++ b/bin/faucet/src/errors.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use axum::{
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 use miden_objects::AccountIdError;

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -1,9 +1,9 @@
 use anyhow::Context;
 use axum::{
+    Json,
     extract::State,
     http::{Response, StatusCode},
     response::IntoResponse,
-    Json,
 };
 use http::header;
 use http_body_util::Full;
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use tonic::body;
 use tracing::info;
 
-use crate::{errors::HandlerError, state::FaucetState, COMPONENT};
+use crate::{COMPONENT, errors::HandlerError, state::FaucetState};
 
 #[derive(Deserialize)]
 pub struct FaucetRequest {

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -170,7 +170,7 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
             let secret = SecretKey::with_rng(&mut get_rpo_random_coin(&mut rng));
 
             let (account, account_seed) = create_basic_fungible_faucet(
-                rng.gen(),
+                rng.r#gen(),
                 (&root_block_header).try_into().context("failed to create anchor block")?,
                 TokenSymbol::try_from(token_symbol.as_str())
                     .context("failed to parse token symbol")?,

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -12,22 +12,22 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use axum::{
-    routing::{get, post},
     Router,
+    routing::{get, post},
 };
 use clap::{Parser, Subcommand};
 use client::initialize_faucet_client;
 use handlers::{get_background, get_favicon, get_index_css, get_index_html, get_index_js};
 use http::HeaderValue;
-use miden_lib::{account::faucets::create_basic_fungible_faucet, AuthScheme};
+use miden_lib::{AuthScheme, account::faucets::create_basic_fungible_faucet};
 use miden_node_utils::{
     config::load_config, crypto::get_rpo_random_coin, logging::OpenTelemetry, version::LongVersion,
 };
 use miden_objects::{
+    Felt,
     account::{AccountFile, AccountStorageMode, AuthSecretKey},
     asset::TokenSymbol,
     crypto::dsa::rpo_falcon512::SecretKey,
-    Felt,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -38,7 +38,7 @@ use tower_http::{cors::CorsLayer, set_header::SetResponseHeaderLayer, trace::Tra
 use tracing::info;
 
 use crate::{
-    config::{FaucetConfig, DEFAULT_FAUCET_ACCOUNT_PATH},
+    config::{DEFAULT_FAUCET_ACCOUNT_PATH, FaucetConfig},
     handlers::{get_metadata, get_tokens},
 };
 
@@ -249,10 +249,10 @@ mod test {
     };
 
     use fantoccini::ClientBuilder;
-    use serde_json::{json, Map};
+    use serde_json::{Map, json};
     use url::Url;
 
-    use crate::{config::FaucetConfig, run_faucet_command, stub_rpc_api::serve_stub, Cli};
+    use crate::{Cli, config::FaucetConfig, run_faucet_command, stub_rpc_api::serve_stub};
 
     /// This test starts a stub node, a faucet connected to the stub node, and a chromedriver
     /// to test the faucet website. It then loads the website and checks that all the requests

--- a/bin/faucet/src/state.rs
+++ b/bin/faucet/src/state.rs
@@ -5,7 +5,7 @@ use static_files::Resource;
 use tokio::sync::Mutex;
 use tracing::info;
 
-use crate::{client::FaucetClient, config::FaucetConfig, static_resources, COMPONENT};
+use crate::{COMPONENT, client::FaucetClient, config::FaucetConfig, static_resources};
 
 // FAUCET STATE
 // ================================================================================================

--- a/bin/faucet/src/store.rs
+++ b/bin/faucet/src/store.rs
@@ -1,11 +1,11 @@
 use std::sync::Mutex;
 
 use miden_objects::{
+    Word,
     account::{Account, AccountId},
     block::{BlockHeader, BlockNumber},
     note::NoteId,
     transaction::{ChainMmr, InputNotes, TransactionInputs},
-    Word,
 };
 use miden_tx::{DataStore, DataStoreError};
 

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -118,7 +118,7 @@ fn create_accounts(
 
                 let storage_mode = inputs.storage_mode.as_str().try_into()?;
                 let (account, account_seed) = create_basic_fungible_faucet(
-                    rng.gen(),
+                    rng.r#gen(),
                     AccountIdAnchor::PRE_GENESIS,
                     TokenSymbol::try_from(inputs.token_symbol.as_str())?,
                     inputs.decimals,

--- a/bin/node/src/commands/genesis/mod.rs
+++ b/bin/node/src/commands/genesis/mod.rs
@@ -3,16 +3,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 pub use inputs::{AccountInput, AuthSchemeInput, GenesisInput};
-use miden_lib::{account::faucets::create_basic_fungible_faucet, AuthScheme};
+use miden_lib::{AuthScheme, account::faucets::create_basic_fungible_faucet};
 use miden_node_store::genesis::GenesisState;
 use miden_node_utils::{config::load_config, crypto::get_rpo_random_coin};
 use miden_objects::{
+    Felt, ONE,
     account::{Account, AccountFile, AccountIdAnchor, AuthSecretKey},
     asset::TokenSymbol,
     crypto::{dsa::rpo_falcon512::SecretKey, utils::Serializable},
-    Felt, ONE,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -45,7 +45,10 @@ pub fn make_genesis(inputs_path: &PathBuf, output_path: &PathBuf, force: bool) -
     if !force {
         if let Ok(file_exists) = output_path.try_exists() {
             if file_exists {
-                return Err(anyhow!("Failed to generate new genesis file {} because it already exists. Use the --force flag to overwrite.", output_path.display()));
+                return Err(anyhow!(
+                    "Failed to generate new genesis file {} because it already exists. Use the --force flag to overwrite.",
+                    output_path.display()
+                ));
             }
         } else {
             return Err(anyhow!("Failed to open {} file.", output_path.display()));
@@ -142,7 +145,10 @@ fn create_accounts(
         let path = accounts_path.as_ref().join(format!("{name}.mac"));
 
         if !force && matches!(path.try_exists(), Ok(true)) {
-            bail!("Failed to generate account file {} because it already exists. Use the --force flag to overwrite.", path.display());
+            bail!(
+                "Failed to generate account file {} because it already exists. Use the --force flag to overwrite.",
+                path.display()
+            );
         }
 
         account_data.account.set_nonce(ONE)?;

--- a/bin/node/src/commands/init.rs
+++ b/bin/node/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Write, path::Path};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::{commands::genesis::GenesisInput, config::NodeConfig};
 

--- a/bin/node/src/config.rs
+++ b/bin/node/src/config.rs
@@ -79,8 +79,8 @@ mod tests {
 
     use super::NodeConfig;
     use crate::{
-        config::{NormalizedBlockProducerConfig, NormalizedRpcConfig},
         NODE_CONFIG_FILE_PATH,
+        config::{NormalizedBlockProducerConfig, NormalizedRpcConfig},
     };
 
     #[test]

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use clap::{Parser, Subcommand};
 use commands::{init::init_config_files, start::start_node};
 use miden_node_block_producer::server::BlockProducer;

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -3,17 +3,17 @@ use std::{num::NonZeroUsize, ops::Range, time::Duration};
 use miden_node_proto::domain::batch::BatchInputs;
 use miden_node_utils::formatting::format_array;
 use miden_objects::{
-    batch::{BatchId, ProposedBatch, ProvenBatch},
     MIN_PROOF_SECURITY_LEVEL,
+    batch::{BatchId, ProposedBatch, ProvenBatch},
 };
 use miden_tx_batch_prover::LocalBatchProver;
 use rand::Rng;
 use tokio::{task::JoinSet, time};
-use tracing::{debug, info, instrument, Span};
+use tracing::{Span, debug, info, instrument};
 
 use crate::{
-    domain::transaction::AuthenticatedTransaction, errors::BuildBatchError, mempool::SharedMempool,
-    store::StoreClient, COMPONENT, SERVER_BUILD_BATCH_FREQUENCY,
+    COMPONENT, SERVER_BUILD_BATCH_FREQUENCY, domain::transaction::AuthenticatedTransaction,
+    errors::BuildBatchError, mempool::SharedMempool, store::StoreClient,
 };
 
 // BATCH BUILDER

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -212,7 +212,7 @@ impl WorkerPool {
                 // Randomly fail batches at the configured rate.
                 //
                 // Note: Rng::gen rolls between [0, 1.0) for f32, so this works as expected.
-                let failed = rand::thread_rng().gen::<f32>() < self.failure_rate;
+                let failed = rand::thread_rng().r#gen::<f32>() < self.failure_rate;
                 let store = self.store.clone();
 
                 async move {

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -234,7 +234,7 @@ impl BlockBuilder {
 
     #[instrument(target = COMPONENT, name = "block_builder.inject_failure", skip_all, err)]
     fn inject_failure<T>(&self, value: T) -> Result<T, BuildBlockError> {
-        let roll = rand::thread_rng().gen::<f64>();
+        let roll = rand::thread_rng().r#gen::<f64>();
 
         Span::current().set_attribute("failure_rate", self.failure_rate);
         Span::current().set_attribute("dice_roll", roll);

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -4,18 +4,18 @@ use futures::FutureExt;
 use miden_block_prover::LocalBlockProver;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_objects::{
+    MIN_PROOF_SECURITY_LEVEL,
     batch::ProvenBatch,
     block::{BlockInputs, BlockNumber, ProposedBlock, ProvenBlock},
     note::NoteHeader,
-    MIN_PROOF_SECURITY_LEVEL,
 };
 use rand::Rng;
 use tokio::time::Duration;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::{
-    errors::BuildBlockError, mempool::SharedMempool, store::StoreClient, COMPONENT,
-    SERVER_BLOCK_FREQUENCY,
+    COMPONENT, SERVER_BLOCK_FREQUENCY, errors::BuildBlockError, mempool::SharedMempool,
+    store::StoreClient,
 };
 
 // BLOCK BUILDER

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -1,11 +1,11 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use miden_objects::{
+    Digest,
     account::AccountId,
     block::BlockNumber,
     note::{NoteId, Nullifier},
     transaction::{ProvenTransaction, TransactionId, TxAccountUpdate},
-    Digest,
 };
 
 use crate::{errors::VerifyTxError, store::TransactionInputs};

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -2,10 +2,10 @@ use miden_block_prover::ProvenBlockError;
 use miden_node_proto::errors::ConversionError;
 use miden_node_utils::formatting::format_opt;
 use miden_objects::{
+    Digest, ProposedBatchError, ProposedBlockError,
     block::BlockNumber,
     note::{NoteId, Nullifier},
     transaction::TransactionId,
-    Digest, ProposedBatchError, ProposedBlockError,
 };
 use miden_tx_batch_prover::errors::ProvenBatchError;
 use thiserror::Error;
@@ -80,7 +80,9 @@ pub enum AddTransactionError {
     #[error("transaction verification failed")]
     VerificationFailed(#[from] VerifyTxError),
 
-    #[error("transaction input data from block {input_block} is rejected as stale because it is older than the limit of {stale_limit}")]
+    #[error(
+        "transaction input data from block {input_block} is rejected as stale because it is older than the limit of {stale_limit}"
+    )]
     StaleInputs {
         input_block: BlockNumber,
         stale_limit: BlockNumber,

--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -7,8 +7,8 @@ use miden_objects::{
 };
 
 use super::{
-    graph::{DependencyGraph, GraphError},
     BlockBudget, BudgetStatus,
+    graph::{DependencyGraph, GraphError},
 };
 
 // BATCH GRAPH

--- a/crates/block-producer/src/mempool/inflight_state/account_state.rs
+++ b/crates/block-producer/src/mempool/inflight_state/account_state.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use miden_objects::{transaction::TransactionId, Digest};
+use miden_objects::{Digest, transaction::TransactionId};
 
 // IN-FLIGHT ACCOUNT STATE
 // ================================================================================================
@@ -55,7 +55,8 @@ impl InflightAccountState {
     pub fn revert(&mut self, n: usize) -> AccountStatus {
         let uncommitted = self.uncommitted_count();
         assert!(
-            uncommitted >= n, "Attempted to revert {n} transactions which is more than the {uncommitted} which are uncommitted.",
+            uncommitted >= n,
+            "Attempted to revert {n} transactions which is more than the {uncommitted} which are uncommitted.",
         );
 
         self.states.drain(self.states.len() - n..);
@@ -71,7 +72,8 @@ impl InflightAccountState {
     pub fn commit(&mut self, n: usize) {
         let uncommitted = self.uncommitted_count();
         assert!(
-            uncommitted >= n, "Attempted to revert {n} transactions which is more than the {uncommitted} which are uncommitted."
+            uncommitted >= n,
+            "Attempted to revert {n} transactions which is more than the {uncommitted} which are uncommitted."
         );
 
         self.committed += n;

--- a/crates/block-producer/src/mempool/inflight_state/mod.rs
+++ b/crates/block-producer/src/mempool/inflight_state/mod.rs
@@ -353,11 +353,7 @@ impl OutputNoteState {
 
     /// Returns the source transaction ID if the output note is not yet committed.
     fn transaction(&self) -> Option<&TransactionId> {
-        if let Self::Inflight(tx) = self {
-            Some(tx)
-        } else {
-            None
-        }
+        if let Self::Inflight(tx) = self { Some(tx) } else { None }
     }
 }
 
@@ -371,9 +367,8 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        mock_account_id,
+        MockProvenTxBuilder, mock_account_id,
         note::{mock_note, mock_output_note},
-        MockProvenTxBuilder,
     };
 
     #[test]

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -4,10 +4,10 @@ use batch_graph::BatchGraph;
 use graph::GraphError;
 use inflight_state::InflightState;
 use miden_objects::{
+    MAX_ACCOUNTS_PER_BATCH, MAX_INPUT_NOTES_PER_BATCH, MAX_OUTPUT_NOTES_PER_BATCH,
     batch::{BatchId, ProvenBatch},
     block::BlockNumber,
     transaction::TransactionId,
-    MAX_ACCOUNTS_PER_BATCH, MAX_INPUT_NOTES_PER_BATCH, MAX_OUTPUT_NOTES_PER_BATCH,
 };
 use tokio::sync::{Mutex, MutexGuard};
 use tracing::instrument;
@@ -15,8 +15,8 @@ use transaction_expiration::TransactionExpirations;
 use transaction_graph::TransactionGraph;
 
 use crate::{
-    domain::transaction::AuthenticatedTransaction, errors::AddTransactionError, COMPONENT,
-    SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
+    COMPONENT, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
+    domain::transaction::AuthenticatedTransaction, errors::AddTransactionError,
 };
 
 mod batch_graph;

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -2,7 +2,7 @@ use miden_objects::block::BlockNumber;
 use pretty_assertions::assert_eq;
 
 use super::*;
-use crate::test_utils::{batch::TransactionBatchConstructor, MockProvenTxBuilder};
+use crate::test_utils::{MockProvenTxBuilder, batch::TransactionBatchConstructor};
 
 impl Mempool {
     fn for_tests() -> Self {

--- a/crates/block-producer/src/mempool/transaction_expiration.rs
+++ b/crates/block-producer/src/mempool/transaction_expiration.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
 use miden_objects::{block::BlockNumber, transaction::TransactionId};
 

--- a/crates/block-producer/src/mempool/transaction_graph.rs
+++ b/crates/block-producer/src/mempool/transaction_graph.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeSet;
 use miden_objects::transaction::TransactionId;
 
 use super::{
-    graph::{DependencyGraph, GraphError},
     BatchBudget, BudgetStatus,
+    graph::{DependencyGraph, GraphError},
 };
 use crate::domain::transaction::AuthenticatedTransaction;
 

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -7,7 +7,7 @@ use miden_node_proto::generated::{
 use miden_node_utils::{
     errors::ApiError,
     formatting::{format_input_notes, format_output_notes},
-    tracing::grpc::{block_producer_trace_fn, OtelInterceptor},
+    tracing::grpc::{OtelInterceptor, block_producer_trace_fn},
 };
 use miden_objects::{
     block::BlockNumber, transaction::ProvenTransaction, utils::serde::Deserializable,
@@ -19,6 +19,7 @@ use tower_http::trace::TraceLayer;
 use tracing::{debug, info, instrument};
 
 use crate::{
+    COMPONENT, SERVER_MEMPOOL_EXPIRATION_SLACK, SERVER_MEMPOOL_STATE_RETENTION,
     batch_builder::BatchBuilder,
     block_builder::BlockBuilder,
     config::BlockProducerConfig,
@@ -26,7 +27,6 @@ use crate::{
     errors::{AddTransactionError, BlockProducerError, VerifyTxError},
     mempool::{BatchBudget, BlockBudget, Mempool, SharedMempool},
     store::StoreClient,
-    COMPONENT, SERVER_MEMPOOL_EXPIRATION_SLACK, SERVER_MEMPOOL_STATE_RETENTION,
 };
 
 /// Represents an initialized block-producer component where the RPC connection is open,

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use itertools::Itertools;
 use miden_node_proto::{
+    AccountState,
     domain::batch::BatchInputs,
     errors::{ConversionError, MissingFieldHelper},
     generated::{
@@ -17,22 +18,21 @@ use miden_node_proto::{
         responses::{GetTransactionInputsResponse, NullifierTransactionInputRecord},
         store::api_client as store_client,
     },
-    AccountState,
 };
 use miden_node_utils::{formatting::format_opt, tracing::grpc::OtelInterceptor};
 use miden_objects::{
+    Digest,
     account::AccountId,
     block::{BlockHeader, BlockInputs, BlockNumber, ProvenBlock},
     note::{NoteId, Nullifier},
     transaction::ProvenTransaction,
     utils::Serializable,
-    Digest,
 };
 use miden_processor::crypto::RpoDigest;
 use tonic::{service::interceptor::InterceptedService, transport::Channel};
 use tracing::{debug, info, instrument};
 
-use crate::{errors::StoreError, COMPONENT};
+use crate::{COMPONENT, errors::StoreError};
 
 // TRANSACTION INPUTS
 // ================================================================================================

--- a/crates/block-producer/src/test_utils/account.rs
+++ b/crates/block-producer/src/test_utils/account.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, ops::Not, sync::LazyLock};
 
 use miden_objects::{
-    account::{AccountIdAnchor, AccountIdVersion, AccountStorageMode, AccountType},
     Hasher,
+    account::{AccountIdAnchor, AccountIdVersion, AccountStorageMode, AccountType},
 };
 
 use super::*;

--- a/crates/block-producer/src/test_utils/batch.rs
+++ b/crates/block-producer/src/test_utils/batch.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
 use miden_objects::{
+    Digest,
     batch::{BatchAccountUpdate, BatchId, ProvenBatch},
     block::BlockNumber,
     transaction::{InputNotes, ProvenTransaction},
-    Digest,
 };
 
 use crate::test_utils::MockProvenTxBuilder;
@@ -19,7 +19,7 @@ pub trait TransactionBatchConstructor {
     /// [`ProposedBatch`](miden_objects::batch::ProposedBatch) first and convert (without proving)
     /// or prove it into a [`ProvenBatch`].
     fn mocked_from_transactions<'tx>(txs: impl IntoIterator<Item = &'tx ProvenTransaction>)
-        -> Self;
+    -> Self;
 
     /// Returns a `TransactionBatch` with `notes_per_tx.len()` transactions, where the i'th
     /// transaction has `notes_per_tx[i]` notes created

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -1,4 +1,5 @@
 use miden_objects::{
+    ACCOUNT_TREE_DEPTH, Digest,
     batch::ProvenBatch,
     block::{
         BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree, OutputNoteBatch,
@@ -7,7 +8,6 @@ use miden_objects::{
     crypto::merkle::{Mmr, SimpleSmt},
     note::Nullifier,
     transaction::OutputNote,
-    Digest, ACCOUNT_TREE_DEPTH,
 };
 
 use super::MockStoreSuccess;

--- a/crates/block-producer/src/test_utils/mod.rs
+++ b/crates/block-producer/src/test_utils/mod.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
 use miden_objects::{
+    Digest,
     account::AccountId,
     crypto::rand::{FeltRng, RpoRandomCoin},
     testing::account_id::AccountIdBuilder,
     transaction::TransactionId,
-    Digest,
 };
 
 mod proven_tx;
 
-pub use proven_tx::{mock_proven_tx, MockProvenTxBuilder};
+pub use proven_tx::{MockProvenTxBuilder, mock_proven_tx};
 
 mod store;
 
@@ -18,7 +18,7 @@ pub use store::{MockStoreSuccess, MockStoreSuccessBuilder};
 
 mod account;
 
-pub use account::{mock_account_id, MockPrivateAccount};
+pub use account::{MockPrivateAccount, mock_account_id};
 
 pub mod block;
 

--- a/crates/block-producer/src/test_utils/note.rs
+++ b/crates/block-producer/src/test_utils/note.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     testing::note::NoteBuilder,
     transaction::{InputNote, InputNoteCommitment, OutputNote},
 };
-use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
 use crate::test_utils::account::mock_account_id;
 

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -36,7 +36,7 @@ impl MockProvenTxBuilder {
     /// Generates 3 random, sequential transactions acting on the same account.
     pub fn sequential() -> [AuthenticatedTransaction; 3] {
         let mut rng = rand::thread_rng();
-        let mock_account: MockPrivateAccount<4> = rng.gen::<u32>().into();
+        let mock_account: MockPrivateAccount<4> = rng.r#gen::<u32>().into();
 
         (0..3)
             .map(|i| {

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -3,12 +3,12 @@ use std::ops::Range;
 use itertools::Itertools;
 use miden_air::HashFunction;
 use miden_objects::{
+    Digest, Felt, Hasher, ONE,
     account::AccountId,
     block::BlockNumber,
     note::{Note, NoteExecutionHint, NoteHeader, NoteMetadata, NoteType, Nullifier},
     transaction::{InputNote, OutputNote, ProvenTransaction, ProvenTransactionBuilder},
     vm::ExecutionProof,
-    Digest, Felt, Hasher, ONE,
 };
 use rand::Rng;
 use winterfell::Proof;

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use miden_objects::{
+    ACCOUNT_TREE_DEPTH, EMPTY_WORD, ZERO,
     batch::ProvenBatch,
     block::{BlockHeader, BlockNumber, OutputNoteBatch, ProvenBlock},
     crypto::merkle::{Mmr, SimpleSmt, Smt},
     note::{NoteId, NoteInclusionProof},
     transaction::ProvenTransaction,
-    ACCOUNT_TREE_DEPTH, EMPTY_WORD, ZERO,
 };
 use tokio::sync::RwLock;
 

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -2,11 +2,11 @@ use std::fmt::{Debug, Display, Formatter};
 
 use miden_node_utils::formatting::format_opt;
 use miden_objects::{
+    Digest,
     account::{Account, AccountHeader, AccountId},
     block::BlockNumber,
     crypto::{hash::rpo::RpoDigest, merkle::MerklePath},
     utils::{Deserializable, Serializable},
-    Digest,
 };
 
 use super::try_convert;

--- a/crates/proto/src/domain/block.rs
+++ b/crates/proto/src/domain/block.rs
@@ -8,11 +8,11 @@ use miden_objects::{
 };
 
 use crate::{
+    AccountWitnessRecord, NullifierWitnessRecord,
     errors::{ConversionError, MissingFieldHelper},
     generated::{
         block as proto, note::NoteInclusionInBlockProof, responses::GetBlockInputsResponse,
     },
-    AccountWitnessRecord, NullifierWitnessRecord,
 };
 
 // BLOCK HEADER

--- a/crates/proto/src/domain/digest.rs
+++ b/crates/proto/src/domain/digest.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use hex::{FromHex, ToHex};
-use miden_objects::{note::NoteId, Digest, Felt, StarkField};
+use miden_objects::{Digest, Felt, StarkField, note::NoteId};
 
 use crate::{errors::ConversionError, generated::digest as proto};
 

--- a/crates/proto/src/domain/merkle.rs
+++ b/crates/proto/src/domain/merkle.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
-    crypto::merkle::{LeafIndex, MerklePath, MmrDelta, SmtLeaf, SmtProof},
     Digest, Word,
+    crypto::merkle::{LeafIndex, MerklePath, MmrDelta, SmtLeaf, SmtProof},
 };
 
 use super::{convert, try_convert};

--- a/crates/proto/src/domain/note.rs
+++ b/crates/proto/src/domain/note.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
-    note::{NoteExecutionHint, NoteId, NoteInclusionProof, NoteMetadata, NoteTag, NoteType},
     Digest, Felt,
+    note::{NoteExecutionHint, NoteId, NoteInclusionProof, NoteMetadata, NoteTag, NoteType},
 };
 
 use crate::{

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -20,18 +20,18 @@ use miden_node_proto::{
 };
 use miden_node_utils::tracing::grpc::OtelInterceptor;
 use miden_objects::{
-    account::AccountId, crypto::hash::rpo::RpoDigest, transaction::ProvenTransaction,
-    utils::serde::Deserializable, Digest, MAX_NUM_FOREIGN_ACCOUNTS, MIN_PROOF_SECURITY_LEVEL,
+    Digest, MAX_NUM_FOREIGN_ACCOUNTS, MIN_PROOF_SECURITY_LEVEL, account::AccountId,
+    crypto::hash::rpo::RpoDigest, transaction::ProvenTransaction, utils::serde::Deserializable,
 };
 use miden_tx::TransactionVerifier;
 use tonic::{
+    Request, Response, Status,
     service::interceptor::InterceptedService,
     transport::{Channel, Error},
-    Request, Response, Status,
 };
 use tracing::{debug, info, instrument};
 
-use crate::{config::RpcConfig, COMPONENT};
+use crate::{COMPONENT, config::RpcConfig};
 
 // RPC API
 // ================================================================================================

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -5,7 +5,7 @@ use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tracing::info;
 
-use crate::{config::RpcConfig, COMPONENT};
+use crate::{COMPONENT, config::RpcConfig};
 
 mod api;
 

--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -1,14 +1,14 @@
 use std::sync::LazyLock;
 
-use miden_objects::crypto::hash::blake::{Blake3Digest, Blake3_160};
+use miden_objects::crypto::hash::blake::{Blake3_160, Blake3Digest};
 use rusqlite::Connection;
-use rusqlite_migration::{Migrations, SchemaVersion, M};
+use rusqlite_migration::{M, Migrations, SchemaVersion};
 use tracing::{debug, error, info, instrument};
 
 use crate::{
+    COMPONENT,
     db::{settings::Settings, sql::utils::schema_version},
     errors::DatabaseError,
-    COMPONENT,
 };
 
 type Hash = Blake3Digest<20>;

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -23,12 +23,12 @@ use tokio::sync::oneshot;
 use tracing::{info, info_span, instrument};
 
 use crate::{
+    COMPONENT, SQL_STATEMENT_CACHE_CAPACITY,
     blocks::BlockStore,
     config::StoreConfig,
     db::migrations::apply_migrations,
     errors::{DatabaseError, DatabaseSetupError, GenesisError, NoteSyncError, StateSyncError},
     genesis::GenesisState,
-    COMPONENT, SQL_STATEMENT_CACHE_CAPACITY,
 };
 
 mod migrations;

--- a/crates/store/src/db/settings.rs
+++ b/crates/store/src/db/settings.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, types::FromSql, Connection, OptionalExtension, Result, ToSql};
+use rusqlite::{Connection, OptionalExtension, Result, ToSql, params, types::FromSql};
 
 use crate::db::sql::utils::table_exists;
 

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -5,17 +5,18 @@ pub(crate) mod utils;
 
 use std::{
     borrow::Cow,
-    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
     num::NonZeroUsize,
     rc::Rc,
 };
 
 use miden_node_proto::domain::account::{AccountInfo, AccountSummary};
 use miden_objects::{
+    Digest, Word,
     account::{
-        delta::AccountUpdateDetails, AccountDelta, AccountId, AccountStorageDelta,
-        AccountVaultDelta, FungibleAssetDelta, NonFungibleAssetDelta, NonFungibleDeltaAction,
-        StorageMapDelta,
+        AccountDelta, AccountId, AccountStorageDelta, AccountVaultDelta, FungibleAssetDelta,
+        NonFungibleAssetDelta, NonFungibleDeltaAction, StorageMapDelta,
+        delta::AccountUpdateDetails,
     },
     asset::NonFungibleAsset,
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNumber},
@@ -23,9 +24,8 @@ use miden_objects::{
     note::{NoteExecutionMode, NoteId, NoteInclusionProof, NoteMetadata, NoteType, Nullifier},
     transaction::TransactionId,
     utils::serde::{Deserializable, Serializable},
-    Digest, Word,
 };
-use rusqlite::{params, types::Value, Connection, Transaction};
+use rusqlite::{Connection, Transaction, params, types::Value};
 use utils::{read_block_number, read_from_blob_column};
 
 use super::{
@@ -383,7 +383,7 @@ pub fn select_account_delta(
             _ => {
                 return Err(DatabaseError::DataCorrupted(format!(
                     "Invalid non-fungible asset delta action: {action}"
-                )))
+                )));
             },
         }
     }

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -38,7 +38,7 @@ pub fn schema_version(conn: &Connection) -> rusqlite::Result<usize> {
 
 /// Auxiliary macro which substitutes `$src` token by `$dst` expression.
 macro_rules! subst {
-    ($src:tt, $dst:expr) => {
+    ($src:tt, $dst:expr_2021) => {
         $dst
     };
 }

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -7,9 +7,8 @@ use miden_objects::{
     utils::Deserializable,
 };
 use rusqlite::{
-    params,
+    Connection, OptionalExtension, params,
     types::{Value, ValueRef},
-    Connection, OptionalExtension,
 };
 
 use crate::errors::DatabaseError;

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -6,10 +6,11 @@ use std::num::NonZeroUsize;
 use miden_lib::transaction::TransactionKernel;
 use miden_node_proto::domain::account::AccountSummary;
 use miden_objects::{
+    Felt, FieldElement, Word, ZERO,
     account::{
-        delta::AccountUpdateDetails, Account, AccountBuilder, AccountComponent, AccountDelta,
-        AccountId, AccountIdVersion, AccountStorageDelta, AccountStorageMode, AccountType,
-        AccountVaultDelta, StorageSlot,
+        Account, AccountBuilder, AccountComponent, AccountDelta, AccountId, AccountIdVersion,
+        AccountStorageDelta, AccountStorageMode, AccountType, AccountVaultDelta, StorageSlot,
+        delta::AccountUpdateDetails,
     },
     asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree, BlockNumber},
@@ -22,12 +23,11 @@ use miden_objects::{
         ACCOUNT_ID_OFF_CHAIN_SENDER, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
         ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_ON_CHAIN,
     },
-    Felt, FieldElement, Word, ZERO,
 };
-use rusqlite::{vtab::array, Connection};
+use rusqlite::{Connection, vtab::array};
 
-use super::{sql, AccountInfo, NoteRecord, NullifierInfo};
-use crate::db::{migrations::apply_migrations, sql::PaginationToken, TransactionSummary};
+use super::{AccountInfo, NoteRecord, NullifierInfo, sql};
+use crate::db::{TransactionSummary, migrations::apply_migrations, sql::PaginationToken};
 
 fn create_db() -> Connection {
     let mut conn = Connection::open_in_memory().unwrap();

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use deadpool_sqlite::{InteractError, PoolError};
 use miden_objects::{
+    AccountDeltaError, AccountError, NoteError,
     account::AccountId,
     block::{BlockHeader, BlockNumber},
     crypto::{
@@ -11,7 +12,6 @@ use miden_objects::{
     },
     note::Nullifier,
     transaction::OutputNote,
-    AccountDeltaError, AccountError, NoteError,
 };
 use rusqlite::types::FromSqlError;
 use thiserror::Error;
@@ -150,7 +150,9 @@ pub enum GenesisError {
         genesis_filepath: String,
         source: io::Error,
     },
-    #[error("block header in store doesn't match block header in genesis file. Expected {expected_genesis_header:?}, but store contained {block_header_in_store:?}")]
+    #[error(
+        "block header in store doesn't match block header in genesis file. Expected {expected_genesis_header:?}, but store contained {block_header_in_store:?}"
+    )]
     GenesisBlockHeaderMismatch {
         expected_genesis_header: Box<BlockHeader>,
         block_header_in_store: Box<BlockHeader>,
@@ -230,7 +232,9 @@ pub enum GetBlockInputsError {
     SelectNoteInclusionProofError(#[source] DatabaseError),
     #[error("failed to select block headers")]
     SelectBlockHeaderError(#[source] DatabaseError),
-    #[error("highest block number {highest_block_number} referenced by a batch is newer than the latest block {latest_block_number}")]
+    #[error(
+        "highest block number {highest_block_number} referenced by a batch is newer than the latest block {latest_block_number}"
+    )]
     UnknownBatchBlockReference {
         highest_block_number: BlockNumber,
         latest_block_number: BlockNumber,
@@ -265,7 +269,9 @@ pub enum GetBatchInputsError {
     SelectBlockHeaderError(#[source] DatabaseError),
     #[error("set of blocks refernced by transactions is empty")]
     TransactionBlockReferencesEmpty,
-    #[error("highest block number {highest_block_num} referenced by a transaction is newer than the latest block {latest_block_num}")]
+    #[error(
+        "highest block number {highest_block_num} referenced by a transaction is newer than the latest block {latest_block_num}"
+    )]
     UnknownTransactionBlockReference {
         highest_block_num: BlockNumber,
         latest_block_num: BlockNumber,

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -1,11 +1,11 @@
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    account::{delta::AccountUpdateDetails, Account},
+    ACCOUNT_TREE_DEPTH, Digest,
+    account::{Account, delta::AccountUpdateDetails},
     block::{BlockAccountUpdate, BlockHeader, BlockNoteTree, BlockNumber, ProvenBlock},
     crypto::merkle::{MmrPeaks, SimpleSmt, Smt},
     note::Nullifier,
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    Digest, ACCOUNT_TREE_DEPTH,
 };
 
 use crate::errors::GenesisError;

--- a/crates/store/src/nullifier_tree.rs
+++ b/crates/store/src/nullifier_tree.rs
@@ -1,11 +1,11 @@
 use miden_objects::{
+    Felt, FieldElement, Word,
     block::BlockNumber,
     crypto::{
         hash::rpo::RpoDigest,
-        merkle::{MutationSet, Smt, SmtProof, SMT_DEPTH},
+        merkle::{MutationSet, SMT_DEPTH, Smt, SmtProof},
     },
     note::Nullifier,
-    Felt, FieldElement, Word,
 };
 
 use crate::errors::NullifierTreeError;

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -37,7 +37,7 @@ use miden_objects::{
 use tonic::{Request, Response, Status};
 use tracing::{debug, info, instrument};
 
-use crate::{state::State, COMPONENT};
+use crate::{COMPONENT, state::State};
 
 // STORE API
 // ================================================================================================
@@ -487,7 +487,7 @@ impl api_server::Api for StoreApi {
 
         Ok(Response::new(GetAccountProofsResponse {
             block_num: block_num.as_u32(),
-            account_proofs: infos.into_iter().map(Into::into).collect(),
+            account_proofs: infos,
         }))
     }
 

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -7,7 +7,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-use crate::{blocks::BlockStore, config::StoreConfig, db::Db, state::State, COMPONENT};
+use crate::{COMPONENT, blocks::BlockStore, config::StoreConfig, db::Db, state::State};
 
 mod api;
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -18,6 +18,7 @@ use miden_node_proto::{
 };
 use miden_node_utils::formatting::format_array;
 use miden_objects::{
+    ACCOUNT_TREE_DEPTH, AccountError,
     account::{AccountDelta, AccountHeader, AccountId, StorageSlot},
     block::{AccountWitness, BlockHeader, BlockInputs, BlockNumber, NullifierWitness, ProvenBlock},
     crypto::{
@@ -30,15 +31,15 @@ use miden_objects::{
     note::{NoteId, Nullifier},
     transaction::{ChainMmr, OutputNote},
     utils::Serializable,
-    AccountError, ACCOUNT_TREE_DEPTH,
 };
 use tokio::{
-    sync::{oneshot, Mutex, RwLock},
+    sync::{Mutex, RwLock, oneshot},
     time::Instant,
 };
 use tracing::{info, info_span, instrument};
 
 use crate::{
+    COMPONENT,
     blocks::BlockStore,
     db::{Db, NoteRecord, NoteSyncUpdate, NullifierInfo, StateSyncUpdate},
     errors::{
@@ -47,7 +48,6 @@ use crate::{
         StateSyncError,
     },
     nullifier_tree::NullifierTree,
-    COMPONENT,
 };
 // STRUCTURES
 // ================================================================================================
@@ -962,10 +962,7 @@ impl State {
         from_block: BlockNumber,
         to_block: BlockNumber,
     ) -> Result<Option<AccountDelta>, DatabaseError> {
-        self.db
-            .select_account_state_delta(account_id, from_block, to_block)
-            .await
-            .map_err(Into::into)
+        self.db.select_account_state_delta(account_id, from_block, to_block).await
     }
 
     /// Loads a block from the block store. Return `Ok(None)` if the block is not found.

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::ToTokens;
-use syn::{parse_macro_input, parse_quote, Block, ItemFn};
+use syn::{Block, ItemFn, parse_macro_input, parse_quote};
 
 #[proc_macro_attribute]
 pub fn enable_logging(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use figment::{
-    providers::{Format, Toml},
     Figment,
+    providers::{Format, Toml},
 };
 use serde::Deserialize;
 

--- a/crates/utils/src/crypto.rs
+++ b/crates/utils/src/crypto.rs
@@ -6,7 +6,7 @@ use rand::{Rng, RngCore};
 
 /// Creates a new RPO Random Coin with random seed
 pub fn get_rpo_random_coin<T: RngCore>(rng: &mut T) -> RpoRandomCoin {
-    let auth_seed: [u64; 4] = rng.gen();
+    let auth_seed: [u64; 4] = rng.r#gen();
     let rng_seed = RpoDigest::from(auth_seed.map(Felt::new));
 
     RpoRandomCoin::new(rng_seed.into())

--- a/crates/utils/src/crypto.rs
+++ b/crates/utils/src/crypto.rs
@@ -1,6 +1,6 @@
 use miden_objects::{
-    crypto::{hash::rpo::RpoDigest, rand::RpoRandomCoin},
     Felt,
+    crypto::{hash::rpo::RpoDigest, rand::RpoRandomCoin},
 };
 use rand::{Rng, RngCore};
 

--- a/crates/utils/src/formatting.rs
+++ b/crates/utils/src/formatting.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use itertools::Itertools;
 use miden_objects::{
     crypto::{
-        hash::{blake::Blake3Digest, Digest},
+        hash::{Digest, blake::Blake3Digest},
         utils::bytes_to_hex_string,
     },
     transaction::{InputNoteCommitment, InputNotes, OutputNotes},

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -7,8 +7,8 @@ use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SpanExporter
 use tracing::subscriber::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
-    layer::{Filter, SubscriberExt},
     Layer, Registry,
+    layer::{Filter, SubscriberExt},
 };
 
 /// Configures [`setup_tracing`] to enable or disable the open-telemetry exporter.
@@ -108,8 +108,8 @@ where
 fn env_or_default_filter<S>() -> Box<dyn Filter<S> + Send + Sync + 'static> {
     use tracing::level_filters::LevelFilter;
     use tracing_subscriber::{
-        filter::{FilterExt, Targets},
         EnvFilter,
+        filter::{FilterExt, Targets},
     };
 
     // `tracing` does not allow differentiating between invalid and missing env var so we manually

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -1,6 +1,6 @@
 /// Creates a [`tracing::Span`] based on RPC service and method name.
 macro_rules! rpc_span {
-    ($service:expr, $method:expr) => {
+    ($service:expr_2021, $method:expr_2021) => {
         tracing::info_span!(
             concat!($service, "/", $method),
             rpc.service = $service,

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -1,6 +1,6 @@
 /// Creates a [`tracing::Span`] based on RPC service and method name.
 macro_rules! rpc_span {
-    ($service:expr_2021, $method:expr_2021) => {
+    ($service:literal, $method:literal) => {
         tracing::info_span!(
             concat!($service, "/", $method),
             rpc.service = $service,

--- a/crates/utils/src/tracing/span_ext.rs
+++ b/crates/utils/src/tracing/span_ext.rs
@@ -1,8 +1,8 @@
 use core::time::Duration;
 use std::net::IpAddr;
 
-use miden_objects::{block::BlockNumber, Digest};
-use opentelemetry::{trace::Status, Key, Value};
+use miden_objects::{Digest, block::BlockNumber};
+use opentelemetry::{Key, Value, trace::Status};
 
 /// Utility functions for converting types into [`opentelemetry::Value`].
 pub trait ToValue {

--- a/crates/utils/src/version/mod.rs
+++ b/crates/utils/src/version/mod.rs
@@ -26,7 +26,7 @@ pub struct LongVersion {
 
 impl std::fmt::Display for LongVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
+        let &Self {
             version,
             mut sha,
             mut branch,
@@ -39,7 +39,7 @@ impl std::fmt::Display for LongVersion {
             debug,
         } = self;
 
-        let dirty = match *dirty {
+        let dirty = match dirty {
             "true" => "-dirty",
             _ => "",
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.84"
+channel    = "1.85"
 components = ["clippy", "rust-src", "rustfmt"]
 profile    = "minimal"


### PR DESCRIPTION
Closes https://github.com/0xPolygonMiden/miden-node/issues/674.

- Updates Rust edition to 2024.
- Reverts the machete version pin.
