### PR TITLE
Implemented SQL query plan explainer, added necessary indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +634,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1939,6 +1972,7 @@ name = "miden-node-store"
 version = "0.8.0"
 dependencies = [
  "assert_matches",
+ "comfy-table",
  "deadpool-sqlite",
  "hex",
  "miden-lib",
@@ -3887,6 +3921,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.12.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+checksum = "28d3c3845002cd8dec1e045bc3fc076d1e467a123794cf56326d804489df1896"
 dependencies = [
  "deadpool-runtime",
  "num_cpus",
@@ -693,17 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
-]
-
-[[package]]
-name = "deadpool-sqlite"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656f14fc1ab819c65f332045ea7cb38841bbe551f3b2bc7e3abefb559af4155c"
-dependencies = [
- "deadpool",
- "deadpool-sync",
- "rusqlite",
 ]
 
 [[package]]
@@ -1939,7 +1928,8 @@ name = "miden-node-store"
 version = "0.8.0"
 dependencies = [
  "assert_matches",
- "deadpool-sqlite",
+ "deadpool",
+ "deadpool-sync",
  "hex",
  "miden-lib",
  "miden-node-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,17 +569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "comfy-table"
-version = "7.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
-dependencies = [
- "crossterm",
- "unicode-segmentation",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,28 +623,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "parking_lot",
- "rustix",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crunchy"
@@ -1972,7 +1939,6 @@ name = "miden-node-store"
 version = "0.8.0"
 dependencies = [
  "assert_matches",
- "comfy-table",
  "deadpool-sqlite",
  "hex",
  "miden-lib",
@@ -1982,6 +1948,7 @@ dependencies = [
  "rusqlite",
  "rusqlite_migration",
  "serde",
+ "termtree",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
@@ -3401,6 +3368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,12 +3894,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "miden-node-proto",
  "miden-node-utils",
  "miden-objects",
+ "regex",
  "rusqlite",
  "rusqlite_migration",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7747ac3a66a06f4ee6718686c8ea976d2d05fb30ada93ebd76b3f9aef97257c"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +813,21 @@ name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+
+[[package]]
+name = "dtor"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf39a0bfd1f94d62ffdb2802a7e6244c0f34f6ebacf5d4c26547d08cd1d67a5"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "either"
@@ -1928,6 +1959,7 @@ name = "miden-node-store"
 version = "0.8.0"
 dependencies = [
  "assert_matches",
+ "ctor",
  "deadpool",
  "deadpool-sync",
  "hex",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace      = true
 workspace = true
 
 [features]
+explain-query-plans = ["miden-node-store/explain-query-plans"]
 tracing-forest = ["miden-node-block-producer/tracing-forest"]
 
 [dependencies]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -18,13 +18,14 @@ workspace = true
 explain-query-plans = ["termtree"]
 
 [dependencies]
-deadpool-sqlite    = { version = "0.9.0", features = ["rt_tokio_1"] }
+deadpool           = { version = "0.12", features = ["managed", "rt_tokio_1"], default-features = false }
+deadpool-sync      = { version = "0.1" }
 hex                = { version = "0.4" }
 miden-lib          = { workspace = true }
 miden-node-proto   = { workspace = true }
 miden-node-utils   = { workspace = true }
 miden-objects      = { workspace = true }
-rusqlite           = { version = "0.32.1", features = ["array", "buildtime_bindgen", "bundled"] }
+rusqlite           = { version = "0.32", features = ["array", "buildtime_bindgen", "bundled"] }
 rusqlite_migration = { version = "1.3" }
 serde              = { version = "1.0", features = ["derive"] }
 termtree           = { version = "0.5", optional = true }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -38,6 +38,7 @@ url                = { workspace = true }
 
 [dev-dependencies]
 assert_matches   = { workspace = true }
+ctor             = { version = "0.4" }
 miden-lib        = { workspace = true, features = ["testing"] }
 miden-node-utils = { workspace = true, features = ["tracing-forest"] }
 miden-objects    = { workspace = true, features = ["testing"] }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -15,10 +15,9 @@ version.workspace      = true
 workspace = true
 
 [features]
-explain-query-plans = ["comfy-table"]
+explain-query-plans = ["termtree"]
 
 [dependencies]
-comfy-table        = { version = "7.1", optional = true }
 deadpool-sqlite    = { version = "0.9.0", features = ["rt_tokio_1"] }
 hex                = { version = "0.4" }
 miden-lib          = { workspace = true }
@@ -28,6 +27,7 @@ miden-objects      = { workspace = true }
 rusqlite           = { version = "0.32.1", features = ["array", "buildtime_bindgen", "bundled"] }
 rusqlite_migration = { version = "1.3" }
 serde              = { version = "1.0", features = ["derive"] }
+termtree           = { version = "0.5", optional = true }
 thiserror          = { workspace = true }
 tokio              = { workspace = true, features = ["fs", "macros", "net", "rt-multi-thread"] }
 tokio-stream       = { workspace = true, features = ["net"] }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -41,3 +41,4 @@ assert_matches   = { workspace = true }
 miden-lib        = { workspace = true, features = ["testing"] }
 miden-node-utils = { workspace = true, features = ["tracing-forest"] }
 miden-objects    = { workspace = true, features = ["testing"] }
+regex            = { version = "1.11" }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -14,7 +14,11 @@ version.workspace      = true
 [lints]
 workspace = true
 
+[features]
+explain-query-plans = ["comfy-table"]
+
 [dependencies]
+comfy-table        = { version = "7.1", optional = true }
 deadpool-sqlite    = { version = "0.9.0", features = ["rt_tokio_1"] }
 hex                = { version = "0.4" }
 miden-lib          = { workspace = true }

--- a/crates/store/src/db/connection.rs
+++ b/crates/store/src/db/connection.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use rusqlite::vtab::array;
+
+use crate::db::transaction::Transaction;
+
+pub struct Connection {
+    inner: rusqlite::Connection,
+}
+
+impl Connection {
+    pub fn open(path: impl AsRef<Path>) -> rusqlite::Result<Self> {
+        rusqlite::Connection::open(path).and_then(Self::new)
+    }
+
+    #[cfg(test)]
+    pub fn open_in_memory() -> rusqlite::Result<Self> {
+        rusqlite::Connection::open_in_memory().and_then(Self::new)
+    }
+
+    fn new(inner: rusqlite::Connection) -> rusqlite::Result<Self> {
+        // Feature used to support `IN` and `NOT IN` queries. We need to load
+        // this module for every connection we create to the DB to support the
+        // queries we want to run
+        array::load_module(&inner)?;
+
+        Ok(Self { inner })
+    }
+
+    pub(crate) fn inner(&self) -> &rusqlite::Connection {
+        &self.inner
+    }
+
+    pub(crate) fn inner_mut(&mut self) -> &mut rusqlite::Connection {
+        &mut self.inner
+    }
+
+    #[inline]
+    pub fn transaction(&mut self) -> rusqlite::Result<Transaction<'_>> {
+        self.inner.transaction().map(Transaction::new)
+    }
+}
+
+#[cfg(not(feature = "explain-query-plans"))]
+impl Connection {
+    #[inline]
+    pub fn prepare_cached(&self, sql: &str) -> rusqlite::Result<rusqlite::CachedStatement<'_>> {
+        self.inner.prepare_cached(sql)
+    }
+
+    #[inline]
+    pub fn execute<P: rusqlite::Params>(&self, sql: &str, params: P) -> rusqlite::Result<usize> {
+        self.inner.execute(sql, params)
+    }
+
+    #[inline]
+    pub fn query_row<T, P, F>(&self, sql: &str, params: P, f: F) -> rusqlite::Result<T>
+    where
+        P: rusqlite::Params,
+        F: FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+    {
+        self.inner.query_row(sql, params, f)
+    }
+}

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -52,6 +52,9 @@ CREATE TABLE notes (
     CONSTRAINT notes_note_index_is_u32 CHECK (note_index BETWEEN 0 AND 0xFFFFFFFF)
 ) STRICT;
 
+CREATE INDEX idx_notes_note_id ON notes(note_id);
+CREATE INDEX idx_notes_sender ON notes(sender);
+CREATE INDEX idx_notes_nullifier ON notes(nullifier);
 CREATE INDEX idx_unconsumed_network_notes ON notes(execution_mode, consumed);
 
 CREATE TABLE account_deltas (
@@ -115,6 +118,9 @@ CREATE TABLE nullifiers (
     CONSTRAINT nullifiers_nullifier_is_digest CHECK (length(nullifier) = 32),
     CONSTRAINT nullifiers_nullifier_prefix_is_u16 CHECK (nullifier_prefix BETWEEN 0 AND 0xFFFF)
 ) STRICT, WITHOUT ROWID;
+
+CREATE INDEX idx_nullifiers_prefix ON nullifiers(nullifier_prefix);
+CREATE INDEX idx_nullifiers_block_num ON nullifiers(block_num);
 
 CREATE TABLE transactions (
     transaction_id BLOB    NOT NULL,

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -53,7 +53,8 @@ CREATE TABLE notes (
 ) STRICT;
 
 CREATE INDEX idx_notes_note_id ON notes(note_id);
-CREATE INDEX idx_notes_sender ON notes(sender);
+CREATE INDEX idx_notes_sender ON notes(sender, block_num);
+CREATE INDEX idx_notes_tag ON notes(tag, block_num);
 CREATE INDEX idx_notes_nullifier ON notes(nullifier);
 CREATE INDEX idx_unconsumed_network_notes ON notes(execution_mode, consumed);
 

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -1,8 +1,6 @@
 -- Table for storing different settings in run-time, which need to persist over runs.
 -- Note: we can store values of different types in the same `value` field.
-CREATE TABLE
-    settings
-(
+CREATE TABLE settings (
     name  TEXT NOT NULL,
     value ANY,
 
@@ -10,9 +8,7 @@ CREATE TABLE
     CONSTRAINT settings_name_is_not_empty CHECK (length(name) > 0)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    block_headers
-(
+CREATE TABLE block_headers (
     block_num    INTEGER NOT NULL,
     block_header BLOB    NOT NULL,
 
@@ -20,9 +16,17 @@ CREATE TABLE
     CONSTRAINT block_header_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF)
 ) STRICT;
 
-CREATE TABLE
-    notes
-(
+CREATE TABLE accounts (
+      account_id   BLOB    NOT NULL,
+      account_hash BLOB    NOT NULL,
+      block_num    INTEGER NOT NULL,
+      details      BLOB,
+
+      PRIMARY KEY (account_id),
+      FOREIGN KEY (block_num) REFERENCES block_headers(block_num)
+) STRICT, WITHOUT ROWID;
+
+CREATE TABLE notes (
     block_num      INTEGER NOT NULL,
     batch_index    INTEGER NOT NULL, -- Index of batch in block, starting from 0
     note_index     INTEGER NOT NULL, -- Index of note in batch, starting from 0
@@ -40,30 +44,17 @@ CREATE TABLE
 
     PRIMARY KEY (block_num, batch_index, note_index),
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
+    FOREIGN KEY (sender) REFERENCES accounts(account_id),
     CONSTRAINT notes_type_in_enum CHECK (note_type BETWEEN 1 AND 3),
     CONSTRAINT notes_execution_mode_in_enum CHECK (execution_mode BETWEEN 0 AND 1),
     CONSTRAINT notes_consumed_is_bool CHECK (execution_mode BETWEEN 0 AND 1),
-    CONSTRAINT notes_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF),
     CONSTRAINT notes_batch_index_is_u32 CHECK (batch_index BETWEEN 0 AND 0xFFFFFFFF),
     CONSTRAINT notes_note_index_is_u32 CHECK (note_index BETWEEN 0 AND 0xFFFFFFFF)
 ) STRICT;
 
-CREATE TABLE
-    accounts
-(
-    account_id   BLOB NOT NULL,
-    account_hash BLOB    NOT NULL,
-    block_num    INTEGER NOT NULL,
-    details      BLOB,
+CREATE INDEX idx_unconsumed_network_notes ON notes(execution_mode, consumed);
 
-    PRIMARY KEY (account_id),
-    FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
-    CONSTRAINT accounts_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF)
-) STRICT;
-
-CREATE TABLE
-    account_deltas
-(
+CREATE TABLE account_deltas (
     account_id  BLOB NOT NULL,
     block_num   INTEGER NOT NULL,
     nonce       INTEGER NOT NULL,
@@ -73,9 +64,7 @@ CREATE TABLE
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    account_storage_slot_updates
-(
+CREATE TABLE account_storage_slot_updates (
     account_id  BLOB NOT NULL,
     block_num   INTEGER NOT NULL,
     slot        INTEGER NOT NULL,
@@ -85,9 +74,7 @@ CREATE TABLE
     FOREIGN KEY (account_id, block_num) REFERENCES account_deltas (account_id, block_num)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    account_storage_map_updates
-(
+CREATE TABLE account_storage_map_updates (
     account_id  BLOB NOT NULL,
     block_num   INTEGER NOT NULL,
     slot        INTEGER NOT NULL,
@@ -98,9 +85,7 @@ CREATE TABLE
     FOREIGN KEY (account_id, block_num) REFERENCES account_deltas (account_id, block_num)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    account_fungible_asset_deltas
-(
+CREATE TABLE account_fungible_asset_deltas (
     account_id  BLOB NOT NULL,
     block_num   INTEGER NOT NULL,
     faucet_id   BLOB NOT NULL,
@@ -110,9 +95,7 @@ CREATE TABLE
     FOREIGN KEY (account_id, block_num) REFERENCES account_deltas (account_id, block_num)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    account_non_fungible_asset_updates
-(
+CREATE TABLE account_non_fungible_asset_updates (
     account_id  BLOB NOT NULL,
     block_num   INTEGER NOT NULL,
     vault_key   BLOB NOT NULL,
@@ -122,9 +105,7 @@ CREATE TABLE
     FOREIGN KEY (account_id, block_num) REFERENCES account_deltas (account_id, block_num)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    nullifiers
-(
+CREATE TABLE nullifiers (
     nullifier        BLOB    NOT NULL,
     nullifier_prefix INTEGER NOT NULL,
     block_num        INTEGER NOT NULL,
@@ -132,22 +113,18 @@ CREATE TABLE
     PRIMARY KEY (nullifier),
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
     CONSTRAINT nullifiers_nullifier_is_digest CHECK (length(nullifier) = 32),
-    CONSTRAINT nullifiers_nullifier_prefix_is_u16 CHECK (nullifier_prefix BETWEEN 0 AND 0xFFFF),
-    CONSTRAINT nullifiers_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF)
+    CONSTRAINT nullifiers_nullifier_prefix_is_u16 CHECK (nullifier_prefix BETWEEN 0 AND 0xFFFF)
 ) STRICT, WITHOUT ROWID;
 
-CREATE TABLE
-    transactions
-(
+CREATE TABLE transactions (
     transaction_id BLOB    NOT NULL,
     account_id     BLOB    NOT NULL,
     block_num      INTEGER NOT NULL,
 
     PRIMARY KEY (transaction_id),
-    FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
-    CONSTRAINT transactions_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF)
+    FOREIGN KEY (account_id) REFERENCES accounts(account_id),
+    FOREIGN KEY (block_num) REFERENCES block_headers(block_num)
 ) STRICT, WITHOUT ROWID;
 
 CREATE INDEX idx_transactions_account_id ON transactions(account_id);
 CREATE INDEX idx_transactions_block_num ON transactions(block_num);
-CREATE INDEX unconsumed_network_notes ON notes(execution_mode, consumed);

--- a/crates/store/src/db/pool_manager.rs
+++ b/crates/store/src/db/pool_manager.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use deadpool::Runtime;
+
+use crate::errors::DatabaseError;
+
+deadpool::managed_reexports!(
+    "miden-node-store",
+    SqlitePoolManager,
+    deadpool::managed::Object<SqlitePoolManager>,
+    rusqlite::Error,
+    DatabaseError
+);
+
+use crate::SQL_STATEMENT_CACHE_CAPACITY;
+
+const RUNTIME: Runtime = Runtime::Tokio1;
+
+pub struct SqlitePoolManager {
+    database_path: PathBuf,
+}
+
+impl SqlitePoolManager {
+    pub fn new(database_path: PathBuf) -> Self {
+        Self { database_path }
+    }
+
+    pub fn new_connection(&self) -> rusqlite::Result<Connection> {
+        let conn = Connection::open(&self.database_path)?;
+        let inner = conn.inner();
+
+        // Increase the statement cache size.
+        inner.set_prepared_statement_cache_capacity(SQL_STATEMENT_CACHE_CAPACITY);
+
+        // Enable the WAL mode. This allows concurrent reads while the
+        // transaction is being written, this is required for proper
+        // synchronization of the servers in-memory and on-disk representations
+        // (see [State::apply_block])
+        inner.execute("PRAGMA journal_mode = WAL;", ())?;
+
+        // Enable foreign key checks.
+        inner.execute("PRAGMA foreign_keys = ON;", ())?;
+
+        Ok(conn)
+    }
+}
+
+use deadpool::managed::{Manager, Metrics, RecycleResult};
+
+use crate::db::connection::Connection;
+
+impl Manager for SqlitePoolManager {
+    type Type = deadpool_sync::SyncWrapper<Connection>;
+    type Error = rusqlite::Error;
+
+    async fn create(&self) -> Result<Self::Type, Self::Error> {
+        let conn = self.new_connection();
+        deadpool_sync::SyncWrapper::new(RUNTIME, move || conn).await
+    }
+
+    async fn recycle(&self, _: &mut Self::Type, _: &Metrics) -> RecycleResult<Self::Error> {
+        Ok(())
+    }
+}

--- a/crates/store/src/db/settings.rs
+++ b/crates/store/src/db/settings.rs
@@ -1,6 +1,6 @@
-use rusqlite::{params, types::FromSql, Connection, OptionalExtension, Result, ToSql};
+use rusqlite::{params, types::FromSql, OptionalExtension, Result, ToSql};
 
-use crate::db::sql::utils::table_exists;
+use crate::db::{connection::Connection, sql::utils::table_exists};
 
 pub struct Settings;
 

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 pub(crate) mod utils;
+mod plan_explainer;
 
 use std::{
     borrow::Cow,
@@ -33,9 +34,12 @@ use super::{
     TransactionSummary,
 };
 use crate::{
-    db::sql::utils::{
-        account_info_from_row, account_summary_from_row, apply_delta, column_value_as_u64,
-        get_nullifier_prefix, u64_to_value,
+    db::sql::{
+        plan_explainer::ConnectionHelper,
+        utils::{
+            account_info_from_row, account_summary_from_row, apply_delta, column_value_as_u64,
+            get_nullifier_prefix, u64_to_value,
+        },
     },
     errors::{DatabaseError, NoteSyncError, StateSyncError},
 };
@@ -49,7 +53,7 @@ use crate::{
 /// A vector with accounts, or an error.
 #[cfg(test)]
 pub fn select_all_accounts(conn: &mut Connection) -> Result<Vec<AccountInfo>> {
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             account_id,
@@ -77,8 +81,9 @@ pub fn select_all_accounts(conn: &mut Connection) -> Result<Vec<AccountInfo>> {
 ///
 /// The vector with the account id and corresponding hash, or an error.
 pub fn select_all_account_hashes(conn: &mut Connection) -> Result<Vec<(AccountId, RpoDigest)>> {
-    let mut stmt = conn
-        .prepare_cached("SELECT account_id, account_hash FROM accounts ORDER BY block_num ASC;")?;
+    let mut stmt = conn.prepare_cached_opt_explain(
+        "SELECT account_id, account_hash FROM accounts ORDER BY block_num ASC;",
+    )?;
     let mut rows = stmt.query([])?;
 
     let mut result = Vec::new();
@@ -105,7 +110,7 @@ pub fn select_accounts_by_block_range(
     block_end: BlockNumber,
     account_ids: &[AccountId],
 ) -> Result<Vec<AccountSummary>> {
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             account_id,
@@ -144,7 +149,7 @@ pub fn select_accounts_by_block_range(
 ///
 /// The latest account details, or an error.
 pub fn select_account(conn: &mut Connection, account_id: AccountId) -> Result<AccountInfo> {
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             account_id,
@@ -173,7 +178,7 @@ pub fn select_accounts_by_ids(
     conn: &mut Connection,
     account_ids: &[AccountId],
 ) -> Result<Vec<AccountInfo>> {
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             account_id,
@@ -219,7 +224,7 @@ pub fn select_account_delta(
     block_start: BlockNumber,
     block_end: BlockNumber,
 ) -> Result<Option<AccountDelta>> {
-    let mut select_nonce_stmt = conn.prepare_cached(
+    let mut select_nonce_stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             nonce
@@ -233,7 +238,7 @@ pub fn select_account_delta(
     ",
     )?;
 
-    let mut select_slot_updates_stmt = conn.prepare_cached(
+    let mut select_slot_updates_stmt = conn.prepare_cached_opt_explain(
         "
             SELECT
                 slot, value
@@ -255,7 +260,7 @@ pub fn select_account_delta(
         ",
     )?;
 
-    let mut select_storage_map_updates_stmt = conn.prepare_cached(
+    let mut select_storage_map_updates_stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             slot, key, value
@@ -278,7 +283,7 @@ pub fn select_account_delta(
         ",
     )?;
 
-    let mut select_fungible_asset_deltas_stmt = conn.prepare_cached(
+    let mut select_fungible_asset_deltas_stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             faucet_id, SUM(delta)
@@ -293,7 +298,7 @@ pub fn select_account_delta(
         ",
     )?;
 
-    let mut select_non_fungible_asset_updates_stmt = conn.prepare_cached(
+    let mut select_non_fungible_asset_updates_stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             block_num, vault_key, is_remove
@@ -409,11 +414,11 @@ pub fn upsert_accounts(
     accounts: &[BlockAccountUpdate],
     block_num: BlockNumber,
 ) -> Result<usize> {
-    let mut upsert_stmt = transaction.prepare_cached(
+    let mut upsert_stmt = transaction.prepare_cached_opt_explain(
         "INSERT OR REPLACE INTO accounts (account_id, account_hash, block_num, details) VALUES (?1, ?2, ?3, ?4);",
     )?;
-    let mut select_details_stmt =
-        transaction.prepare_cached("SELECT details FROM accounts WHERE account_id = ?1;")?;
+    let mut select_details_stmt = transaction
+        .prepare_cached_opt_explain("SELECT details FROM accounts WHERE account_id = ?1;")?;
 
     let mut count = 0;
     for update in accounts {
@@ -477,11 +482,11 @@ fn insert_account_delta(
     block_number: BlockNumber,
     delta: &AccountDelta,
 ) -> Result<()> {
-    let mut insert_acc_delta_stmt =
-        transaction.prepare_cached(insert_sql!(account_deltas { account_id, block_num, nonce }))?;
+    let mut insert_acc_delta_stmt = transaction
+        .prepare_cached_opt_explain(insert_sql!(account_deltas { account_id, block_num, nonce }))?;
 
     let mut insert_slot_update_stmt =
-        transaction.prepare_cached(insert_sql!(account_storage_slot_updates {
+        transaction.prepare_cached_opt_explain(insert_sql!(account_storage_slot_updates {
             account_id,
             block_num,
             slot,
@@ -489,7 +494,7 @@ fn insert_account_delta(
         }))?;
 
     let mut insert_storage_map_update_stmt =
-        transaction.prepare_cached(insert_sql!(account_storage_map_updates {
+        transaction.prepare_cached_opt_explain(insert_sql!(account_storage_map_updates {
             account_id,
             block_num,
             slot,
@@ -498,20 +503,21 @@ fn insert_account_delta(
         }))?;
 
     let mut insert_fungible_asset_delta_stmt =
-        transaction.prepare_cached(insert_sql!(account_fungible_asset_deltas {
+        transaction.prepare_cached_opt_explain(insert_sql!(account_fungible_asset_deltas {
             account_id,
             block_num,
             faucet_id,
             delta,
         }))?;
 
-    let mut insert_non_fungible_asset_update_stmt =
-        transaction.prepare_cached(insert_sql!(account_non_fungible_asset_updates {
+    let mut insert_non_fungible_asset_update_stmt = transaction.prepare_cached_opt_explain(
+        insert_sql!(account_non_fungible_asset_updates {
             account_id,
             block_num,
             vault_key,
             is_remove,
-        }))?;
+        }),
+    )?;
 
     insert_acc_delta_stmt.execute(params![
         account_id.to_bytes(),
@@ -588,11 +594,12 @@ pub fn insert_nullifiers_for_block(
         nullifiers.iter().map(Nullifier::to_bytes).map(Into::into).collect();
     let serialized_nullifiers = Rc::new(serialized_nullifiers);
 
-    let mut stmt = transaction
-        .prepare_cached("UPDATE notes SET consumed = TRUE WHERE nullifier IN rarray(?1)")?;
+    let mut stmt = transaction.prepare_cached_opt_explain(
+        "UPDATE notes SET consumed = TRUE WHERE nullifier IN rarray(?1)",
+    )?;
     let mut count = stmt.execute(params![serialized_nullifiers])?;
 
-    let mut stmt = transaction.prepare_cached(
+    let mut stmt = transaction.prepare_cached_opt_explain(
         "INSERT INTO nullifiers (nullifier, nullifier_prefix, block_num) VALUES (?1, ?2, ?3);",
     )?;
 
@@ -609,8 +616,9 @@ pub fn insert_nullifiers_for_block(
 ///
 /// A vector with nullifiers and the block height at which they were created, or an error.
 pub fn select_all_nullifiers(conn: &mut Connection) -> Result<Vec<(Nullifier, BlockNumber)>> {
-    let mut stmt =
-        conn.prepare_cached("SELECT nullifier, block_num FROM nullifiers ORDER BY block_num ASC;")?;
+    let mut stmt = conn.prepare_cached_opt_explain(
+        "SELECT nullifier, block_num FROM nullifiers ORDER BY block_num ASC;",
+    )?;
     let mut rows = stmt.query([])?;
 
     let mut result = vec![];
@@ -644,7 +652,7 @@ pub fn select_nullifiers_by_prefix(
     let nullifier_prefixes: Vec<Value> =
         nullifier_prefixes.iter().copied().map(Into::into).collect();
 
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             nullifier,
@@ -681,7 +689,7 @@ pub fn select_nullifiers_by_prefix(
 /// A vector with notes, or an error.
 #[cfg(test)]
 pub fn select_all_notes(conn: &mut Connection) -> Result<Vec<NoteRecord>> {
-    let mut stmt = conn.prepare_cached(&format!(
+    let mut stmt = conn.prepare_cached_opt_explain(&format!(
         "SELECT {} FROM notes ORDER BY block_num ASC",
         NoteRecord::SELECT_COLUMNS,
     ))?;
@@ -708,7 +716,7 @@ pub fn insert_notes(
     transaction: &Transaction,
     notes: &[(NoteRecord, Option<Nullifier>)],
 ) -> Result<usize> {
-    let mut stmt = transaction.prepare_cached(insert_sql!(notes {
+    let mut stmt = transaction.prepare_cached_opt_explain(insert_sql!(notes {
         block_num,
         batch_index,
         note_index,
@@ -769,8 +777,9 @@ pub fn select_notes_since_block_by_tag_and_sender(
     account_ids: &[AccountId],
     block_num: BlockNumber,
 ) -> Result<Vec<NoteSyncRecord>> {
-    let mut stmt = conn
-        .prepare_cached(include_str!("queries/select_notes_since_block_by_tag_and_sender.sql"))?;
+    let mut stmt = conn.prepare_cached_opt_explain(include_str!(
+        "queries/select_notes_since_block_by_tag_and_sender.sql"
+    ))?;
 
     let tags: Vec<Value> = tags.iter().copied().map(Into::into).collect();
     let account_ids: Vec<Value> = account_ids
@@ -827,7 +836,7 @@ pub fn select_notes_since_block_by_tag_and_sender(
 pub fn select_notes_by_id(conn: &mut Connection, note_ids: &[NoteId]) -> Result<Vec<NoteRecord>> {
     let note_ids: Vec<Value> = note_ids.iter().map(|id| id.to_bytes().into()).collect();
 
-    let mut stmt = conn.prepare_cached(&format!(
+    let mut stmt = conn.prepare_cached_opt_explain(&format!(
         "SELECT {} FROM notes WHERE note_id IN rarray(?1)",
         NoteRecord::SELECT_COLUMNS
     ))?;
@@ -853,7 +862,7 @@ pub fn select_note_inclusion_proofs(
 ) -> Result<BTreeMap<NoteId, NoteInclusionProof>> {
     let note_ids: Vec<Value> = note_ids.into_iter().map(|id| id.to_bytes().into()).collect();
 
-    let mut select_notes_stmt = conn.prepare_cached(
+    let mut select_notes_stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             block_num,
@@ -919,7 +928,7 @@ pub fn unconsumed_network_notes(
     //
     // rowid column _must_ come after the note fields so that we don't mess up the
     // `NoteRecord::from_row` call.
-    let mut stmt = transaction.prepare_cached(&format!(
+    let mut stmt = transaction.prepare_cached_opt_explain(&format!(
         "
         SELECT {}, rowid FROM notes
         WHERE
@@ -960,8 +969,9 @@ pub struct PaginationToken(i64);
 /// The [Transaction] object is not consumed. It's up to the caller to commit or rollback the
 /// transaction.
 pub fn insert_block_header(transaction: &Transaction, block_header: &BlockHeader) -> Result<usize> {
-    let mut stmt = transaction
-        .prepare_cached("INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);")?;
+    let mut stmt = transaction.prepare_cached_opt_explain(
+        "INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);",
+    )?;
     Ok(stmt.execute(params![block_header.block_num().as_u32(), block_header.to_bytes()])?)
 }
 
@@ -977,11 +987,12 @@ pub fn select_block_header_by_block_num(
 ) -> Result<Option<BlockHeader>> {
     let mut stmt;
     let mut rows = if let Some(block_number) = block_number {
-        stmt =
-            conn.prepare_cached("SELECT block_header FROM block_headers WHERE block_num = ?1")?;
+        stmt = conn.prepare_cached_opt_explain(
+            "SELECT block_header FROM block_headers WHERE block_num = ?1",
+        )?;
         stmt.query([block_number.as_u32()])?
     } else {
-        stmt = conn.prepare_cached(
+        stmt = conn.prepare_cached_opt_explain(
             "SELECT block_header FROM block_headers ORDER BY block_num DESC LIMIT 1",
         )?;
         stmt.query([])?
@@ -1012,8 +1023,9 @@ pub fn select_block_headers(
     let blocks: Vec<Value> = blocks.map(|b| b.as_u32().into()).collect();
 
     let mut headers = Vec::with_capacity(blocks.len());
-    let mut stmt = conn
-        .prepare_cached("SELECT block_header FROM block_headers WHERE block_num IN rarray(?1);")?;
+    let mut stmt = conn.prepare_cached_opt_explain(
+        "SELECT block_header FROM block_headers WHERE block_num IN rarray(?1);",
+    )?;
     let mut rows = stmt.query(params![Rc::new(blocks)])?;
 
     while let Some(row) = rows.next()? {
@@ -1031,8 +1043,9 @@ pub fn select_block_headers(
 ///
 /// A vector of [`BlockHeader`] or an error.
 pub fn select_all_block_headers(conn: &mut Connection) -> Result<Vec<BlockHeader>> {
-    let mut stmt =
-        conn.prepare_cached("SELECT block_header FROM block_headers ORDER BY block_num ASC;")?;
+    let mut stmt = conn.prepare_cached_opt_explain(
+        "SELECT block_header FROM block_headers ORDER BY block_num ASC;",
+    )?;
     let mut rows = stmt.query([])?;
     let mut result = vec![];
     while let Some(row) = rows.next()? {
@@ -1062,7 +1075,7 @@ pub fn insert_transactions(
     block_num: BlockNumber,
     accounts: &[BlockAccountUpdate],
 ) -> Result<usize> {
-    let mut stmt = transaction.prepare_cached(
+    let mut stmt = transaction.prepare_cached_opt_explain(
         "INSERT INTO transactions (transaction_id, account_id, block_num) VALUES (?1, ?2, ?3);",
     )?;
     let mut count = 0;
@@ -1097,7 +1110,7 @@ pub fn select_transactions_by_accounts_and_block_range(
         .map(|account_id| account_id.to_bytes().into())
         .collect();
 
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached_opt_explain(
         "
         SELECT
             account_id,

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -740,7 +740,7 @@ pub fn insert_notes(
             u64_to_value(note.metadata.aux().into()),
             u64_to_value(note.metadata.execution_hint().into()),
             note.merkle_path.to_bytes(),
-            // New notes are always uncomsumed.
+            // New notes are always unconsumed.
             false,
             details,
             // Beware: `Option<T>` also implements `to_bytes`, but this is not what you want.

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -106,10 +106,7 @@ impl CachedStatementWithQueryPlan<'_> {
         };
 
         let mut rows = explain_stmt.query(params)?;
-
-        if let Some(sql) = rows.as_ref().and_then(Statement::expanded_sql) {
-            println!("\n>> {sql}");
-        }
+        let expanded_sql = rows.as_ref().and_then(Statement::expanded_sql).unwrap_or_default();
 
         // Build tree from the returned table
         let mut path = OpenedPath {
@@ -129,7 +126,7 @@ impl CachedStatementWithQueryPlan<'_> {
         }
         path.fold_up_to(0);
 
-        println!("{}", path.pop());
+        println!("\n>> {expanded_sql}\n{}", path.pop());
 
         Ok(())
     }

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -1,5 +1,6 @@
 use rusqlite::{CachedStatement, Params, Row, Rows, Statement};
 use termtree::Tree;
+use tracing::info;
 
 use crate::db::{connection::Connection, transaction::Transaction};
 
@@ -128,7 +129,7 @@ impl CachedStatementWithQueryPlan<'_> {
 
         let query_plan = path.pop().to_string();
 
-        println!("\n>> {expanded_sql}\n\n{query_plan}");
+        info!("\n>> {expanded_sql}\n\n{query_plan}");
 
         #[cfg(test)]
         Self::fail_if_has_problems(&explain_sql, &query_plan);

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -19,8 +19,6 @@ mod internals {
 mod internals {
     use rusqlite::{CachedStatement, Connection, Params, Row, Rows, Statement};
 
-    use crate::db::sql::utils::print_to_stdout;
-
     pub trait ConnectionHelper {
         fn prepare_cached_opt_explain(
             &self,
@@ -66,6 +64,8 @@ mod internals {
         }
 
         fn explain<P: Params>(&mut self, params: P) -> rusqlite::Result<()> {
+            use super::super::utils::pretty_print_query_results;
+
             let mut explain_stmt =
                 self.conn.prepare(&format!("EXPLAIN QUERY PLAN {}", self.sql))?;
 
@@ -75,7 +75,7 @@ mod internals {
                 println!("\n>> {sql}");
             }
 
-            print_to_stdout(rows)?;
+            println!("{}", pretty_print_query_results(rows)?);
 
             Ok(())
         }

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -18,6 +18,7 @@ mod internals {
 #[cfg(feature = "explain-query-plans")]
 mod internals {
     use rusqlite::{CachedStatement, Connection, Params, Row, Rows, Statement};
+    use termtree::Tree;
 
     pub trait ConnectionHelper {
         fn prepare_cached_opt_explain(
@@ -64,18 +65,59 @@ mod internals {
         }
 
         fn explain<P: Params>(&mut self, params: P) -> rusqlite::Result<()> {
-            use super::super::utils::pretty_print_query_results;
+            /// Path needed for storing opened nodes from the root.
+            struct OpenedPath {
+                path: Vec<(u64, Tree<String>)>,
+            }
+
+            impl OpenedPath {
+                fn push(&mut self, id: u64, element: Tree<String>) {
+                    self.path.push((id, element));
+                }
+
+                fn pop(&mut self) -> Tree<String> {
+                    self.path.pop().expect("Stack must contain at least root node").1
+                }
+
+                fn fold_up_to(&mut self, id: u64) {
+                    while self.path.last().expect("Stack must contain at least root node").0 > id {
+                        let top = self.pop();
+                        self.path
+                            .last_mut()
+                            .map(|(_, last)| last.push(top))
+                            .expect("Stack must contain at least root node");
+                    }
+                }
+            }
 
             let mut explain_stmt =
                 self.conn.prepare(&format!("EXPLAIN QUERY PLAN {}", self.sql))?;
 
-            let rows = explain_stmt.query(params)?;
+            let mut rows = explain_stmt.query(params)?;
 
             if let Some(sql) = rows.as_ref().and_then(Statement::expanded_sql) {
                 println!("\n>> {sql}");
             }
 
-            println!("{}", pretty_print_query_results(rows)?);
+            // Build tree from the returned table
+            let mut path = OpenedPath {
+                path: vec![(0_u64, Tree::new("QUERY PLAN".to_string()))],
+            };
+            while let Some(row) = rows.next()? {
+                let id: u64 = row.get(0)?;
+                let parent_id: u64 = row.get(1)?;
+                let not_used: bool = row.get(2)?;
+                let mut label: String = row.get(3)?;
+                if not_used {
+                    label = format!("(not used) {label}");
+                }
+
+                path.fold_up_to(parent_id);
+                path.push(id, label.into());
+            }
+            path.fold_up_to(0);
+
+            println!("{}", path.pop());
 
             Ok(())
         }

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -126,7 +126,7 @@ impl CachedStatementWithQueryPlan<'_> {
         }
         path.fold_up_to(0);
 
-        println!("\n>> {expanded_sql}\n{}", path.pop());
+        println!("\n>> {expanded_sql}\n\n{}", path.pop());
 
         Ok(())
     }

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -1,125 +1,136 @@
-pub(crate) use internals::ConnectionHelper;
+use rusqlite::{CachedStatement, Params, Row, Rows, Statement};
+use termtree::Tree;
 
-#[cfg(not(feature = "explain-query-plans"))]
-mod internals {
-    use rusqlite::{CachedStatement, Connection};
+use crate::db::{connection::Connection, transaction::Transaction};
 
-    pub trait ConnectionHelper {
-        fn prepare_cached_opt_explain(&self, sql: &str) -> rusqlite::Result<CachedStatement<'_>>;
+impl Connection {
+    #[inline]
+    pub fn prepare_cached(&self, sql: &str) -> rusqlite::Result<CachedStatementWithQueryPlan<'_>> {
+        let statement = self.inner().prepare_cached(sql)?;
+
+        Ok(CachedStatementWithQueryPlan {
+            executor: Executor::Connection(self.inner()),
+            sql: sql.into(),
+            statement,
+        })
     }
 
-    impl ConnectionHelper for Connection {
-        fn prepare_cached_opt_explain(&self, sql: &str) -> rusqlite::Result<CachedStatement<'_>> {
-            self.prepare_cached(sql)
-        }
+    #[inline]
+    pub fn execute<P: Params + Clone>(&self, sql: &str, params: P) -> rusqlite::Result<usize> {
+        self.prepare_cached(sql)?.execute(params)
+    }
+
+    #[inline]
+    pub fn query_row<T, P, F>(&self, sql: &str, params: P, f: F) -> rusqlite::Result<T>
+    where
+        P: Params + Clone,
+        F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
+    {
+        self.prepare_cached(sql)?.query_row(params, f)
     }
 }
 
-#[cfg(feature = "explain-query-plans")]
-mod internals {
-    use rusqlite::{CachedStatement, Connection, Params, Row, Rows, Statement};
-    use termtree::Tree;
+impl Transaction<'_> {
+    pub fn prepare_cached(&self, sql: &str) -> rusqlite::Result<CachedStatementWithQueryPlan> {
+        let statement = self.inner().prepare_cached(sql)?;
 
-    pub trait ConnectionHelper {
-        fn prepare_cached_opt_explain(
-            &self,
-            sql: &str,
-        ) -> rusqlite::Result<CachedStatementWithQueryPlan<'_>>;
+        Ok(CachedStatementWithQueryPlan {
+            executor: Executor::Transaction(self.inner()),
+            sql: sql.into(),
+            statement,
+        })
+    }
+}
+
+enum Executor<'conn> {
+    Connection(&'conn rusqlite::Connection),
+    Transaction(&'conn rusqlite::Transaction<'conn>),
+}
+
+pub struct CachedStatementWithQueryPlan<'conn> {
+    executor: Executor<'conn>,
+    sql: Box<str>,
+    statement: CachedStatement<'conn>,
+}
+
+impl CachedStatementWithQueryPlan<'_> {
+    pub fn query<P: Params + Clone>(&mut self, params: P) -> rusqlite::Result<Rows<'_>> {
+        self.explain(params.clone())?;
+        self.statement.query(params)
     }
 
-    impl ConnectionHelper for Connection {
-        fn prepare_cached_opt_explain(
-            &self,
-            sql: &str,
-        ) -> rusqlite::Result<CachedStatementWithQueryPlan<'_>> {
-            let statement = self.prepare_cached(sql)?;
-
-            Ok(CachedStatementWithQueryPlan { conn: self, sql: sql.into(), statement })
-        }
+    pub fn query_row<T, P, F>(&mut self, params: P, f: F) -> rusqlite::Result<T>
+    where
+        P: Params + Clone,
+        F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
+    {
+        self.explain(params.clone())?;
+        self.statement.query_row(params, f)
     }
 
-    pub struct CachedStatementWithQueryPlan<'conn> {
-        conn: &'conn Connection,
-        sql: Box<str>,
-        statement: CachedStatement<'conn>,
+    pub fn execute<P: Params + Clone>(&mut self, params: P) -> rusqlite::Result<usize> {
+        self.explain(params.clone())?;
+        self.statement.execute(params)
     }
 
-    impl CachedStatementWithQueryPlan<'_> {
-        pub fn query<P: Params + Clone>(&mut self, params: P) -> rusqlite::Result<Rows<'_>> {
-            self.explain(params.clone())?;
-            self.statement.query(params)
+    fn explain<P: Params>(&mut self, params: P) -> rusqlite::Result<()> {
+        /// Path needed for storing opened nodes from the root.
+        struct OpenedPath {
+            path: Vec<(u64, Tree<String>)>,
         }
 
-        pub fn query_row<T, P, F>(&mut self, params: P, f: F) -> rusqlite::Result<T>
-        where
-            P: Params + Clone,
-            F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
-        {
-            self.explain(params.clone())?;
-            self.statement.query_row(params, f)
+        impl OpenedPath {
+            fn push(&mut self, id: u64, element: Tree<String>) {
+                self.path.push((id, element));
+            }
+
+            fn pop(&mut self) -> Tree<String> {
+                self.path.pop().expect("Stack must contain at least root node").1
+            }
+
+            fn fold_up_to(&mut self, id: u64) {
+                while self.path.last().expect("Stack must contain at least root node").0 > id {
+                    let top = self.pop();
+                    self.path
+                        .last_mut()
+                        .map(|(_, last)| last.push(top))
+                        .expect("Stack must contain at least root node");
+                }
+            }
         }
 
-        pub fn execute<P: Params + Clone>(&mut self, params: P) -> rusqlite::Result<usize> {
-            self.explain(params.clone())?;
-            self.statement.execute(params)
+        let explain_sql = format!("EXPLAIN QUERY PLAN {}", self.sql);
+        let mut explain_stmt = match self.executor {
+            Executor::Connection(conn) => conn.prepare(&explain_sql)?,
+            Executor::Transaction(transaction) => transaction.prepare(&explain_sql)?,
+        };
+
+        let mut rows = explain_stmt.query(params)?;
+
+        if let Some(sql) = rows.as_ref().and_then(Statement::expanded_sql) {
+            println!("\n>> {sql}");
         }
 
-        fn explain<P: Params>(&mut self, params: P) -> rusqlite::Result<()> {
-            /// Path needed for storing opened nodes from the root.
-            struct OpenedPath {
-                path: Vec<(u64, Tree<String>)>,
+        // Build tree from the returned table
+        let mut path = OpenedPath {
+            path: vec![(0_u64, Tree::new("QUERY PLAN".to_string()))],
+        };
+        while let Some(row) = rows.next()? {
+            let id: u64 = row.get(0)?;
+            let parent_id: u64 = row.get(1)?;
+            let not_used: bool = row.get(2)?;
+            let mut label: String = row.get(3)?;
+            if not_used {
+                label = format!("(not used) {label}");
             }
 
-            impl OpenedPath {
-                fn push(&mut self, id: u64, element: Tree<String>) {
-                    self.path.push((id, element));
-                }
-
-                fn pop(&mut self) -> Tree<String> {
-                    self.path.pop().expect("Stack must contain at least root node").1
-                }
-
-                fn fold_up_to(&mut self, id: u64) {
-                    while self.path.last().expect("Stack must contain at least root node").0 > id {
-                        let top = self.pop();
-                        self.path
-                            .last_mut()
-                            .map(|(_, last)| last.push(top))
-                            .expect("Stack must contain at least root node");
-                    }
-                }
-            }
-
-            let mut explain_stmt =
-                self.conn.prepare(&format!("EXPLAIN QUERY PLAN {}", self.sql))?;
-
-            let mut rows = explain_stmt.query(params)?;
-
-            if let Some(sql) = rows.as_ref().and_then(Statement::expanded_sql) {
-                println!("\n>> {sql}");
-            }
-
-            // Build tree from the returned table
-            let mut path = OpenedPath {
-                path: vec![(0_u64, Tree::new("QUERY PLAN".to_string()))],
-            };
-            while let Some(row) = rows.next()? {
-                let id: u64 = row.get(0)?;
-                let parent_id: u64 = row.get(1)?;
-                let not_used: bool = row.get(2)?;
-                let mut label: String = row.get(3)?;
-                if not_used {
-                    label = format!("(not used) {label}");
-                }
-
-                path.fold_up_to(parent_id);
-                path.push(id, label.into());
-            }
-            path.fold_up_to(0);
-
-            println!("{}", path.pop());
-
-            Ok(())
+            path.fold_up_to(parent_id);
+            path.push(id, label.into());
         }
+        path.fold_up_to(0);
+
+        println!("{}", path.pop());
+
+        Ok(())
     }
 }

--- a/crates/store/src/db/sql/plan_explainer.rs
+++ b/crates/store/src/db/sql/plan_explainer.rs
@@ -1,0 +1,79 @@
+pub(crate) use internals::ConnectionHelper;
+
+#[cfg(not(feature = "explain-query-plans"))]
+mod internals {
+    use rusqlite::{CachedStatement, Connection};
+
+    pub trait ConnectionHelper {
+        fn prepare_cached_opt_explain(&self, sql: &str) -> rusqlite::Result<CachedStatement<'_>>;
+    }
+
+    impl ConnectionHelper for Connection {
+        fn prepare_cached_opt_explain(&self, sql: &str) -> rusqlite::Result<CachedStatement<'_>> {
+            self.prepare_cached(sql)
+        }
+    }
+}
+
+#[cfg(feature = "explain-query-plans")]
+mod internals {
+    use rusqlite::{CachedStatement, Connection, Params, Row, Rows};
+
+    use crate::db::sql::utils::query_to_stdout;
+
+    pub trait ConnectionHelper {
+        fn prepare_cached_opt_explain(
+            &self,
+            sql: &str,
+        ) -> rusqlite::Result<CachedStatementWithQueryPlan<'_>>;
+    }
+
+    impl ConnectionHelper for Connection {
+        fn prepare_cached_opt_explain(
+            &self,
+            sql: &str,
+        ) -> rusqlite::Result<CachedStatementWithQueryPlan<'_>> {
+            let statement = self.prepare_cached(sql)?;
+
+            Ok(CachedStatementWithQueryPlan { conn: self, sql: sql.into(), statement })
+        }
+    }
+
+    pub struct CachedStatementWithQueryPlan<'conn> {
+        conn: &'conn Connection,
+        sql: Box<str>,
+        statement: CachedStatement<'conn>,
+    }
+
+    impl CachedStatementWithQueryPlan<'_> {
+        pub fn query<P: Params + Clone>(&mut self, params: P) -> rusqlite::Result<Rows<'_>> {
+            self.explain(params.clone())?;
+            self.statement.query(params)
+        }
+
+        pub fn query_row<T, P, F>(&mut self, params: P, f: F) -> rusqlite::Result<T>
+        where
+            P: Params + Clone,
+            F: FnOnce(&Row<'_>) -> rusqlite::Result<T>,
+        {
+            self.explain(params.clone())?;
+            self.statement.query_row(params, f)
+        }
+
+        pub fn execute<P: Params + Clone>(&mut self, params: P) -> rusqlite::Result<usize> {
+            self.explain(params.clone())?;
+            self.statement.execute(params)
+        }
+
+        fn explain<P: Params>(&mut self, params: P) -> rusqlite::Result<()> {
+            println!(">> Explaining query plan for the query:\n\n{}\n", self.sql);
+
+            let mut explain_stmt =
+                self.conn.prepare(&format!("EXPLAIN QUERY PLAN {}", self.sql))?;
+
+            query_to_stdout(&mut explain_stmt, params)?;
+
+            Ok(())
+        }
+    }
+}

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -171,36 +171,3 @@ pub fn apply_delta(
 
     Ok(account)
 }
-
-/// Formats query results into `String`.
-#[cfg(feature = "explain-query-plans")]
-pub fn pretty_print_query_results(mut rows: rusqlite::Rows) -> rusqlite::Result<String> {
-    let stmt = rows.as_ref().expect("`Rows` state must be correct");
-
-    let num_columns = stmt.column_count();
-
-    let mut table = comfy_table::Table::new();
-    table.load_preset(comfy_table::presets::UTF8_FULL);
-
-    let column_headers =
-        (0..num_columns).map(|i| stmt.column_name(i)).collect::<Result<Vec<_>, _>>()?;
-    table.set_header(column_headers);
-
-    while let Some(row) = rows.next()? {
-        let values = (0..num_columns)
-            .map(|i| {
-                row.get_ref(i).map(|value| match value {
-                    ValueRef::Null => "<NULL>".to_string(),
-                    ValueRef::Integer(int) => int.to_string(),
-                    ValueRef::Real(float) => float.to_string(),
-                    ValueRef::Text(text) => String::from_utf8_lossy(text).into_owned(),
-                    ValueRef::Blob(blob) => format!("x'{}'", hex::encode(blob)),
-                })
-            })
-            .collect::<Result<Vec<String>, _>>()?;
-
-        table.add_row(values);
-    }
-
-    Ok(table.to_string())
-}

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -47,7 +47,7 @@ macro_rules! subst {
 ///
 /// # Usage:
 ///
-/// ```
+/// ```ignore
 /// insert_sql!(users { id, first_name, last_name, age });
 /// ```
 /// which generates:

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -172,12 +172,11 @@ pub fn apply_delta(
     Ok(account)
 }
 
-/// Runs query and prints results into STDOUT.
+/// Prints query results into STDOUT.
 #[cfg(feature = "explain-query-plans")]
-pub fn query_to_stdout<P: rusqlite::Params>(
-    stmt: &mut rusqlite::Statement,
-    params: P,
-) -> rusqlite::Result<()> {
+pub fn print_to_stdout(mut rows: rusqlite::Rows) -> rusqlite::Result<()> {
+    let stmt = rows.as_ref().expect("`Rows` state must be correct");
+
     let num_columns = stmt.column_count();
 
     let mut table = comfy_table::Table::new();
@@ -187,7 +186,6 @@ pub fn query_to_stdout<P: rusqlite::Params>(
         (0..num_columns).map(|i| stmt.column_name(i)).collect::<Result<Vec<_>, _>>()?;
     table.set_header(column_headers);
 
-    let mut rows = stmt.query(params)?;
     while let Some(row) = rows.next()? {
         let values = (0..num_columns)
             .map(|i| {

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -9,10 +9,10 @@ use miden_objects::{
 use rusqlite::{
     params,
     types::{Value, ValueRef},
-    Connection, OptionalExtension,
+    OptionalExtension,
 };
 
-use crate::errors::DatabaseError;
+use crate::{db::connection::Connection, errors::DatabaseError};
 
 /// Returns the high 16 bits of the provided nullifier.
 pub fn get_nullifier_prefix(nullifier: &Nullifier) -> u32 {

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -29,6 +29,12 @@ use crate::db::{
     connection::Connection, migrations::apply_migrations, sql::PaginationToken, TransactionSummary,
 };
 
+#[ctor::ctor]
+fn initialize() {
+    miden_node_utils::logging::setup_tracing(miden_node_utils::logging::OpenTelemetry::Disabled)
+        .expect("Failed to setup logging for tests");
+}
+
 fn create_db() -> Connection {
     let mut conn = Connection::open_in_memory().unwrap();
     apply_migrations(&mut conn).unwrap();

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -23,14 +23,14 @@ use miden_objects::{
     },
     Felt, FieldElement, Word, ZERO,
 };
-use rusqlite::{vtab::array, Connection};
 
 use super::{sql, AccountInfo, NoteRecord, NullifierInfo};
-use crate::db::{migrations::apply_migrations, sql::PaginationToken, TransactionSummary};
+use crate::db::{
+    connection::Connection, migrations::apply_migrations, sql::PaginationToken, TransactionSummary,
+};
 
 fn create_db() -> Connection {
     let mut conn = Connection::open_in_memory().unwrap();
-    array::load_module(&conn).unwrap();
     apply_migrations(&mut conn).unwrap();
     conn
 }
@@ -447,7 +447,7 @@ fn sql_select_accounts() {
             [i; 15],
             AccountIdVersion::Version0,
             AccountType::RegularAccountImmutableCode,
-            miden_objects::account::AccountStorageMode::Private,
+            AccountStorageMode::Private,
         );
         let account_hash = num_to_rpo_digest(u64::from(i));
         state.push(AccountInfo {

--- a/crates/store/src/db/transaction.rs
+++ b/crates/store/src/db/transaction.rs
@@ -1,0 +1,27 @@
+pub struct Transaction<'conn> {
+    inner: rusqlite::Transaction<'conn>,
+}
+
+impl<'conn> Transaction<'conn> {
+    pub(super) fn new(inner: rusqlite::Transaction<'conn>) -> Self {
+        Self { inner }
+    }
+
+    #[cfg(feature = "explain-query-plans")]
+    pub fn inner(&self) -> &rusqlite::Transaction<'conn> {
+        &self.inner
+    }
+
+    #[inline]
+    pub fn commit(self) -> rusqlite::Result<()> {
+        self.inner.commit()
+    }
+}
+
+#[cfg(not(feature = "explain-query-plans"))]
+impl Transaction<'_> {
+    #[inline]
+    pub fn prepare_cached(&self, sql: &str) -> rusqlite::Result<rusqlite::CachedStatement<'_>> {
+        self.inner.prepare_cached(sql)
+    }
+}

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -1,6 +1,7 @@
 use std::io;
 
-use deadpool_sqlite::{InteractError, PoolError};
+use deadpool::managed::PoolError;
+use deadpool_sync::InteractError;
 use miden_objects::{
     account::AccountId,
     block::{BlockHeader, BlockNumber},
@@ -54,7 +55,7 @@ pub enum DatabaseError {
     #[error("migration failed")]
     MigrationError(#[from] rusqlite_migration::Error),
     #[error("missing database connection")]
-    MissingDbConnection(#[from] PoolError),
+    MissingDbConnection(#[from] PoolError<rusqlite::Error>),
     #[error("note error")]
     NoteError(#[from] NoteError),
     #[error("SQLite error")]
@@ -120,7 +121,7 @@ pub enum DatabaseSetupError {
     #[error("genesis block error")]
     GenesisBlockError(#[from] GenesisError),
     #[error("pool build error")]
-    PoolBuildError(#[from] deadpool_sqlite::BuildError),
+    PoolBuildError(#[from] deadpool::managed::BuildError),
     #[error("SQLite migration error")]
     SqliteMigrationError(#[from] rusqlite_migration::Error),
 }

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -487,7 +487,7 @@ impl api_server::Api for StoreApi {
 
         Ok(Response::new(GetAccountProofsResponse {
             block_num: block_num.as_u32(),
-            account_proofs: infos.into_iter().map(Into::into).collect(),
+            account_proofs: infos.into_iter().collect(),
         }))
     }
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -962,10 +962,7 @@ impl State {
         from_block: BlockNumber,
         to_block: BlockNumber,
     ) -> Result<Option<AccountDelta>, DatabaseError> {
-        self.db
-            .select_account_state_delta(account_id, from_block, to_block)
-            .await
-            .map_err(Into::into)
+        self.db.select_account_state_delta(account_id, from_block, to_block).await
     }
 
     /// Loads a block from the block store. Return `Ok(None)` if the block is not found.


### PR DESCRIPTION
Resolves https://github.com/0xPolygonMiden/miden-node/issues/712 and https://github.com/0xPolygonMiden/miden-node/issues/57

In this PR we implemented SQL query plan explainer which writes to log something like a query plan below for each running query:

```
>> EXPLAIN QUERY PLAN -- Selects new notes matching the tags and account IDs search criteria.
SELECT
    block_num,
    batch_index,
    note_index,
    note_id,
    note_type,
    sender,
    tag,
    aux,
    execution_hint,
    merkle_path
FROM
    notes
WHERE
    -- find the next block which contains at least one note with a matching tag or sender
    block_num = (
        SELECT
            block_num
        FROM
            notes
        WHERE
            (tag IN rarray(NULL) OR sender IN rarray(NULL)) AND
            block_num > 0
        ORDER BY
            block_num ASC
    LIMIT 1) AND
    -- filter the block's notes and return only the ones matching the requested tags or senders
    (tag IN rarray(NULL) OR sender IN rarray(NULL))


QUERY PLAN
├── SEARCH notes USING INDEX sqlite_autoindex_notes_1 (block_num=?)
├── SCALAR SUBQUERY 3
│   ├── MULTI-INDEX OR
│   │   ├── INDEX 1
│   │   │   ├── LIST SUBQUERY 1
│   │   │   │   └── SCAN rarray VIRTUAL TABLE INDEX 1:
│   │   │   └── SEARCH notes USING INDEX idx_notes_tag (tag=? AND block_num>?)
│   │   └── INDEX 2
│   │       ├── LIST SUBQUERY 2
│   │       │   └── SCAN rarray VIRTUAL TABLE INDEX 1:
│   │       └── SEARCH notes USING INDEX idx_notes_sender (sender=? AND block_num>?)
│   └── USE TEMP B-TREE FOR ORDER BY
├── LIST SUBQUERY 4
│   └── SCAN rarray VIRTUAL TABLE INDEX 1:
└── LIST SUBQUERY 5
    └── SCAN rarray VIRTUAL TABLE INDEX 1:
```

This works for both tests and running node, if feature `explain-query-plans` is enabled.

In order to achieve this, we implemented our own SQLite connection pool which constructs special wrapper for each connection, returning special wrapper for each cached prepared statement. The latter is able to explain a query once it is being run. The same was done for transactions as well. This solution also helped us to get rid of deadpool-sqlite (all necessary functionality from it we have now). And configuring of connection now done in SQLite connection pool instead of hooking connection creation, it looks more elegant to me.

Also implemented some simple checking for problems in query plans during test run (test will fail, if any problem found in any query plan for queries run in tests).