### PR TITLE
feat: add `get_network_notes` endpoint to the store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arrayref"
@@ -200,7 +200,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -232,7 +232,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.0",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -248,7 +248,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -311,9 +311,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -479,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,15 +542,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake3"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -583,9 +589,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -595,9 +601,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -619,23 +625,23 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -669,16 +675,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -694,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -704,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1015,15 +1021,15 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ena"
@@ -1228,9 +1234,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1472,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1792,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -1923,10 +1929,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2027,7 +2039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671c1e48a91d4652c5bd3e6a5f6147e34b5b93484421bd7d5ded8fbe22fee7ec"
 dependencies = [
  "miden-core",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "winter-air",
  "winter-prover",
 ]
@@ -2045,7 +2057,7 @@ dependencies = [
  "miden-miette",
  "rustc_version 0.4.1",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -2053,12 +2065,12 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f2d50bfa4a83841875570d1301adccbe164ea111"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#c2ed75f843ada1579e9469ca8831123ec19f643a"
 dependencies = [
  "miden-crypto",
  "miden-lib",
  "miden-objects",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2076,7 +2088,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parking_lot",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "winter-math",
  "winter-utils",
 ]
@@ -2095,7 +2107,7 @@ dependencies = [
  "rand",
  "rand_core",
  "sha3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "winter-crypto",
  "winter-math",
  "winter-utils",
@@ -2122,7 +2134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static-files",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "toml",
@@ -2146,13 +2158,13 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f2d50bfa4a83841875570d1301adccbe164ea111"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#c2ed75f843ada1579e9469ca8831123ec19f643a"
 dependencies = [
  "miden-assembly",
  "miden-objects",
  "miden-stdlib",
  "regex",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "walkdir",
 ]
 
@@ -2182,7 +2194,7 @@ dependencies = [
  "syn",
  "terminal_size",
  "textwrap",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "trybuild",
  "unicode-width 0.1.14",
 ]
@@ -2242,7 +2254,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2264,7 +2276,7 @@ dependencies = [
  "prost",
  "prost-build",
  "protox",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tonic",
  "tonic-build",
 ]
@@ -2300,7 +2312,7 @@ dependencies = [
  "rusqlite",
  "rusqlite_migration",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2331,7 +2343,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tonic",
  "tracing",
  "tracing-forest",
@@ -2344,8 +2356,9 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f2d50bfa4a83841875570d1301adccbe164ea111"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#c2ed75f843ada1579e9469ca8831123ec19f643a"
 dependencies = [
+ "bech32",
  "getrandom 0.2.15",
  "miden-assembly",
  "miden-core",
@@ -2354,9 +2367,9 @@ dependencies = [
  "miden-verifier",
  "rand",
  "rand_xoshiro",
- "semver 1.0.25",
+ "semver 1.0.26",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "toml",
  "winter-rand-utils",
 ]
@@ -2369,7 +2382,7 @@ checksum = "4fbc6f1d5cad60b17da51ee00c8f16e047b3deca50cc42dd18e13cc0c73ca23c"
 dependencies = [
  "miden-air",
  "miden-core",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "winter-prover",
 ]
@@ -2403,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f2d50bfa4a83841875570d1301adccbe164ea111"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#c2ed75f843ada1579e9469ca8831123ec19f643a"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2413,21 +2426,21 @@ dependencies = [
  "miden-verifier",
  "rand",
  "rand_chacha",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "winter-maybe-async",
 ]
 
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f2d50bfa4a83841875570d1301adccbe164ea111"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#c2ed75f843ada1579e9469ca8831123ec19f643a"
 dependencies = [
  "miden-core",
  "miden-crypto",
  "miden-objects",
  "miden-processor",
  "miden-tx",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2438,7 +2451,7 @@ checksum = "76105a8bc8fb948d02b114ea0540de771b34f446191a08a3393d705aafc70191"
 dependencies = [
  "miden-air",
  "miden-core",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "winter-verifier",
 ]
@@ -2516,9 +2529,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -2736,7 +2749,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2753,7 +2766,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tonic",
 ]
@@ -2786,7 +2799,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2908,18 +2921,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2951,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
@@ -2965,7 +2978,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3003,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3013,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -3098,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b318f733603136dcc61aa9e77c928d67f87d2436c34ec052ba3f1b5ca219de"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
 dependencies = [
  "logos",
  "miette",
@@ -3153,9 +3166,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -3230,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -3294,9 +3307,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3357,7 +3370,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
@@ -3369,7 +3382,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -3428,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty-fork"
@@ -3446,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3527,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -3562,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3574,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -3753,9 +3779,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3787,15 +3813,15 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3825,19 +3851,19 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3851,11 +3877,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3871,9 +3897,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3892,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -3909,15 +3935,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3981,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -4309,9 +4335,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4352,9 +4378,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4735,6 +4761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5097,18 +5129,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bin/faucet/src/store.rs
+++ b/bin/faucet/src/store.rs
@@ -61,7 +61,7 @@ impl DataStore for FaucetDataStore {
         TransactionInputs::new(
             account.clone(),
             account.is_new().then_some(self.init_seed).flatten(),
-            self.block_header,
+            self.block_header.clone(),
             self.chain_mmr.clone(),
             InputNotes::default(),
         )

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -18,14 +18,15 @@ pub async fn build_expected_block_header(
     store: &MockStoreSuccess,
     batches: &[ProvenBatch],
 ) -> BlockHeader {
-    let last_block_header = *store
+    let last_block_header = store
         .block_headers
         .read()
         .await
         .iter()
         .max_by_key(|(block_num, _)| *block_num)
         .unwrap()
-        .1;
+        .1
+        .clone();
 
     // Compute new account root
     let updated_accounts: Vec<_> =
@@ -84,14 +85,15 @@ impl MockBlockBuilder {
         Self {
             store_accounts: store.accounts.read().await.clone(),
             store_chain_mmr: store.chain_mmr.read().await.clone(),
-            last_block_header: *store
+            last_block_header: store
                 .block_headers
                 .read()
                 .await
                 .iter()
                 .max_by_key(|(block_num, _)| *block_num)
                 .unwrap()
-                .1,
+                .1
+                .clone(),
 
             updated_accounts: None,
             created_notes: None,

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -237,7 +237,7 @@ impl MockStoreSuccess {
         }
 
         // append the block header
-        self.block_headers.write().await.insert(header.block_num(), header);
+        self.block_headers.write().await.insert(header.block_num(), header.clone());
 
         // update num_apply_block_called
         *self.num_apply_block_called.write().await += 1;

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -214,5 +214,13 @@ pub mod get_account_proofs_request {
         pub map_keys: ::prost::alloc::vec::Vec<super::super::digest::Digest>,
     }
 }
+/// Returns a list of unconsumed network notes using pagination.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct GetUnconsumedNetworkNotesRequest {}
+pub struct GetUnconsumedNetworkNotesRequest {
+    /// Page number to retrieve.
+    #[prost(uint64, tag = "1")]
+    pub page: u64,
+    /// Number of notes to retrieve per page.
+    #[prost(uint64, tag = "2")]
+    pub limit: u64,
+}

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -214,3 +214,5 @@ pub mod get_account_proofs_request {
         pub map_keys: ::prost::alloc::vec::Vec<super::super::digest::Digest>,
     }
 }
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct GetUnconsumedNetworkNotesRequest {}

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -270,3 +270,8 @@ pub struct StorageSlotMapProof {
     #[prost(bytes = "vec", tag = "2")]
     pub smt_proof: ::prost::alloc::vec::Vec<u8>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetUnconsumedNetworkNotesResponse {
+    #[prost(message, optional, tag = "1")]
+    pub note: ::core::option::Option<super::note::Note>,
+}

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -270,8 +270,13 @@ pub struct StorageSlotMapProof {
     #[prost(bytes = "vec", tag = "2")]
     pub smt_proof: ::prost::alloc::vec::Vec<u8>,
 }
+/// Represents the result of getting the unconsumed network notes.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetUnconsumedNetworkNotesResponse {
-    #[prost(message, optional, tag = "1")]
-    pub note: ::core::option::Option<super::note::Note>,
+    /// The next page number.
+    #[prost(uint64, tag = "1")]
+    pub next_page: u64,
+    /// The list of unconsumed network notes.
+    #[prost(message, repeated, tag = "2")]
+    pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
 }

--- a/crates/proto/src/generated/store.rs
+++ b/crates/proto/src/generated/store.rs
@@ -467,6 +467,38 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("store.Api", "SyncState"));
             self.inner.unary(req, path, codec).await
         }
+        /// Returns a stream with the unconsumed network notes.
+        /// TODO: check if a request is needed.
+        pub async fn get_unconsumed_network_notes(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::requests::GetUnconsumedNetworkNotesRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<
+                    super::super::responses::GetUnconsumedNetworkNotesResponse,
+                >,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/store.Api/GetUnconsumedNetworkNotes",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("store.Api", "GetUnconsumedNetworkNotes"));
+            self.inner.server_streaming(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -622,6 +654,26 @@ pub mod api_server {
             request: tonic::Request<super::super::requests::SyncStateRequest>,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::SyncStateResponse>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the GetUnconsumedNetworkNotes method.
+        type GetUnconsumedNetworkNotesStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    super::super::responses::GetUnconsumedNetworkNotesResponse,
+                    tonic::Status,
+                >,
+            >
+            + std::marker::Send
+            + 'static;
+        /// Returns a stream with the unconsumed network notes.
+        /// TODO: check if a request is needed.
+        async fn get_unconsumed_network_notes(
+            &self,
+            request: tonic::Request<
+                super::super::requests::GetUnconsumedNetworkNotesRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetUnconsumedNetworkNotesStream>,
             tonic::Status,
         >;
     }
@@ -1371,6 +1423,56 @@ pub mod api_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/store.Api/GetUnconsumedNetworkNotes" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetUnconsumedNetworkNotesSvc<T: Api>(pub Arc<T>);
+                    impl<
+                        T: Api,
+                    > tonic::server::ServerStreamingService<
+                        super::super::requests::GetUnconsumedNetworkNotesRequest,
+                    > for GetUnconsumedNetworkNotesSvc<T> {
+                        type Response = super::super::responses::GetUnconsumedNetworkNotesResponse;
+                        type ResponseStream = T::GetUnconsumedNetworkNotesStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::requests::GetUnconsumedNetworkNotesRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::get_unconsumed_network_notes(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetUnconsumedNetworkNotesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/crates/proto/src/generated/store.rs
+++ b/crates/proto/src/generated/store.rs
@@ -468,18 +468,13 @@ pub mod api_client {
             self.inner.unary(req, path, codec).await
         }
         /// Returns a stream with the unconsumed network notes.
-        /// TODO: check if a request is needed.
         pub async fn get_unconsumed_network_notes(
             &mut self,
             request: impl tonic::IntoRequest<
                 super::super::requests::GetUnconsumedNetworkNotesRequest,
             >,
         ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<
-                    super::super::responses::GetUnconsumedNetworkNotesResponse,
-                >,
-            >,
+            tonic::Response<super::super::responses::GetUnconsumedNetworkNotesResponse>,
             tonic::Status,
         > {
             self.inner
@@ -497,7 +492,7 @@ pub mod api_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("store.Api", "GetUnconsumedNetworkNotes"));
-            self.inner.server_streaming(req, path, codec).await
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -656,24 +651,14 @@ pub mod api_server {
             tonic::Response<super::super::responses::SyncStateResponse>,
             tonic::Status,
         >;
-        /// Server streaming response type for the GetUnconsumedNetworkNotes method.
-        type GetUnconsumedNetworkNotesStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<
-                    super::super::responses::GetUnconsumedNetworkNotesResponse,
-                    tonic::Status,
-                >,
-            >
-            + std::marker::Send
-            + 'static;
         /// Returns a stream with the unconsumed network notes.
-        /// TODO: check if a request is needed.
         async fn get_unconsumed_network_notes(
             &self,
             request: tonic::Request<
                 super::super::requests::GetUnconsumedNetworkNotesRequest,
             >,
         ) -> std::result::Result<
-            tonic::Response<Self::GetUnconsumedNetworkNotesStream>,
+            tonic::Response<super::super::responses::GetUnconsumedNetworkNotesResponse>,
             tonic::Status,
         >;
     }
@@ -1432,13 +1417,12 @@ pub mod api_server {
                     struct GetUnconsumedNetworkNotesSvc<T: Api>(pub Arc<T>);
                     impl<
                         T: Api,
-                    > tonic::server::ServerStreamingService<
+                    > tonic::server::UnaryService<
                         super::super::requests::GetUnconsumedNetworkNotesRequest,
                     > for GetUnconsumedNetworkNotesSvc<T> {
                         type Response = super::super::responses::GetUnconsumedNetworkNotesResponse;
-                        type ResponseStream = T::GetUnconsumedNetworkNotesStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1472,7 +1456,7 @@ pub mod api_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -189,4 +189,11 @@ message GetAccountProofsRequest {
     repeated digest.Digest code_commitments = 3;
 }
 
-message GetUnconsumedNetworkNotesRequest {}
+// Returns a list of unconsumed network notes using pagination.
+message GetUnconsumedNetworkNotesRequest {
+    // Page number to retrieve.
+    uint64 page = 1;
+
+    // Number of notes to retrieve per page.
+    uint64 limit = 2;
+}

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -188,3 +188,5 @@ message GetAccountProofsRequest {
     // all requested accounts.
     repeated digest.Digest code_commitments = 3;
 }
+
+message GetUnconsumedNetworkNotesRequest {}

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -253,6 +253,11 @@ message StorageSlotMapProof {
     bytes smt_proof = 2;
 }
 
+// Represents the result of getting the unconsumed network notes.
 message GetUnconsumedNetworkNotesResponse {
-    note.Note note = 1;
+    // The next page number.
+    uint64 next_page = 1;
+
+    // The list of unconsumed network notes.
+    repeated note.Note notes = 2;
 }

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -252,3 +252,7 @@ message StorageSlotMapProof {
     // Merkle proof of the map value
     bytes smt_proof = 2;
 }
+
+message GetUnconsumedNetworkNotesResponse {
+    note.Note note = 1;
+}

--- a/crates/rpc-proto/proto/store.proto
+++ b/crates/rpc-proto/proto/store.proto
@@ -77,6 +77,5 @@ service Api {
     rpc SyncState(requests.SyncStateRequest) returns (responses.SyncStateResponse) {}
 
     // Returns a stream with the unconsumed network notes.
-    // TODO: check if a request is needed.
-    rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (stream responses.GetUnconsumedNetworkNotesResponse) {}
+    rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (responses.GetUnconsumedNetworkNotesResponse) {}
 }

--- a/crates/rpc-proto/proto/store.proto
+++ b/crates/rpc-proto/proto/store.proto
@@ -75,4 +75,8 @@ service Api {
     // part of hashes. Thus, returned data contains excessive notes and nullifiers, client can make
     // additional filtering of that data on its side.
     rpc SyncState(requests.SyncStateRequest) returns (responses.SyncStateResponse) {}
+
+    // Returns a stream with the unconsumed network notes.
+    // TODO: check if a request is needed.
+    rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (stream responses.GetUnconsumedNetworkNotesResponse) {}
 }

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -474,7 +474,7 @@ impl Db {
                 let transaction = conn.transaction()?;
                 sql::apply_block(
                     &transaction,
-                    &block.header(),
+                    &block.header().clone(),
                     &notes,
                     block.created_nullifiers(),
                     block.updated_accounts(),
@@ -520,8 +520,8 @@ impl Db {
     pub(crate) async fn select_unconsumed_network_notes(
         &self,
         page: PaginationToken,
+        limit: NonZero<usize>,
     ) -> Result<(Vec<NoteRecord>, PaginationToken)> {
-        let limit = NonZero::new(100).unwrap(); // TODO: check if limit is harcoded or parameter
         self.pool
             .get()
             .await

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -936,14 +936,24 @@ pub fn unconsumed_network_notes(
         notes.push(NoteRecord::from_row(row)?);
         // Increment by 1 because we are using rowid >=, and otherwise we would include the last
         // element in the next page as well.
-        token.0 = row.get::<_, i64>(11)? + 1;
+        token.0 = row.get::<_, u64>(11)? + 1;
     }
 
     Ok((notes, token))
 }
 
 #[derive(Default, Debug, Copy, Clone)]
-pub struct PaginationToken(i64);
+pub struct PaginationToken(u64);
+
+impl PaginationToken {
+    pub fn new(token: u64) -> Self {
+        Self(token)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
 
 // BLOCK CHAIN QUERIES
 // ================================================================================================

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -903,7 +903,6 @@ pub fn select_note_inclusion_proofs(
 ///
 /// A set of unconsumed network notes with maximum length of `limit` and a pagination token to get
 /// the next set.
-#[cfg_attr(not(test), expect(dead_code, reason = "gRPC method is not yet implemented"))]
 pub fn unconsumed_network_notes(
     transaction: &Transaction,
     mut token: PaginationToken,

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, convert::Infallible, sync::Arc};
+use std::{collections::BTreeSet, convert::Infallible, pin::Pin, sync::Arc};
 
 use miden_node_proto::{
     convert,
@@ -19,8 +19,8 @@ use miden_node_proto::{
             CheckNullifiersResponse, GetAccountDetailsResponse, GetAccountProofsResponse,
             GetAccountStateDeltaResponse, GetBatchInputsResponse, GetBlockByNumberResponse,
             GetBlockHeaderByNumberResponse, GetBlockInputsResponse, GetNotesByIdResponse,
-            GetTransactionInputsResponse, NullifierTransactionInputRecord, NullifierUpdate,
-            SyncNoteResponse, SyncStateResponse,
+            GetTransactionInputsResponse, GetUnconsumedNetworkNotesResponse,
+            NullifierTransactionInputRecord, NullifierUpdate, SyncNoteResponse, SyncStateResponse,
         },
         store::api_server,
         transaction::TransactionSummary,
@@ -34,10 +34,12 @@ use miden_objects::{
     note::{NoteId, Nullifier},
     utils::{Deserializable, Serializable},
 };
+use tokio::sync::mpsc;
+use tokio_stream::{Stream, wrappers::ReceiverStream};
 use tonic::{Request, Response, Status};
 use tracing::{debug, info, instrument};
 
-use crate::{COMPONENT, state::State};
+use crate::{COMPONENT, db::PaginationToken, state::State};
 
 // STORE API
 // ================================================================================================
@@ -46,8 +48,13 @@ pub struct StoreApi {
     pub(super) state: Arc<State>,
 }
 
+type ResponseStream =
+    Pin<Box<dyn Stream<Item = Result<GetUnconsumedNetworkNotesResponse, Status>> + Send>>;
+
 #[tonic::async_trait]
 impl api_server::Api for StoreApi {
+    type GetUnconsumedNetworkNotesStream = ResponseStream;
+
     // CLIENT ENDPOINTS
     // --------------------------------------------------------------------------------------------
 
@@ -518,6 +525,49 @@ impl api_server::Api for StoreApi {
             .map(|delta| delta.to_bytes());
 
         Ok(Response::new(GetAccountStateDeltaResponse { delta }))
+    }
+
+    #[instrument(
+        target = COMPONENT,
+        name = "store.server.get_unconsumed_network_notes",
+        skip_all,
+        err
+    )]
+    async fn get_unconsumed_network_notes(
+        &self,
+        _request: Request<generated::requests::GetUnconsumedNetworkNotesRequest>,
+    ) -> Result<Response<Self::GetUnconsumedNetworkNotesStream>, Status> {
+        // TODO: check if there is a way to remove the request struct, or if there is some needed parameter
+
+        let (sender, receiver) = mpsc::channel(128); // TODO: check bound of the channel
+
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            // Read all unconsumed network notes and send them through the stream
+            let mut page = PaginationToken::default();
+            loop {
+                let Ok((notes, next_page)) = state.get_unconsumed_network_notes(page).await else {
+                    let _ = sender.send(Err(internal_error("Failed to read network notes"))).await;
+                    break;
+                };
+
+                if notes.is_empty() {
+                    break;
+                }
+                page = next_page;
+
+                for note in notes.into_iter() {
+                    let response = GetUnconsumedNetworkNotesResponse { note: Some(note.into()) };
+                    let send_result = sender.send(Ok(response)).await;
+                    if let Err(e) = send_result {
+                        info!(target: COMPONENT, "Failed to send response: {e}");
+                        return;
+                    }
+                }
+            }
+        });
+        let output_stream = ReceiverStream::new(receiver);
+        Ok(Response::new(Box::pin(output_stream) as Self::GetUnconsumedNetworkNotesStream))
     }
 }
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    num::NonZero,
     ops::Not,
     sync::Arc,
 };
@@ -984,8 +985,9 @@ impl State {
     pub async fn get_unconsumed_network_notes(
         &self,
         page: PaginationToken,
+        limit: NonZero<usize>,
     ) -> Result<(Vec<NoteRecord>, PaginationToken), DatabaseError> {
-        self.db.select_unconsumed_network_notes(page).await
+        self.db.select_unconsumed_network_notes(page, limit).await
     }
 }
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -41,7 +41,7 @@ use tracing::{info, info_span, instrument};
 use crate::{
     COMPONENT,
     blocks::BlockStore,
-    db::{Db, NoteRecord, NoteSyncUpdate, NullifierInfo, StateSyncUpdate},
+    db::{Db, NoteRecord, NoteSyncUpdate, NullifierInfo, PaginationToken, StateSyncUpdate},
     errors::{
         ApplyBlockError, DatabaseError, GetBatchInputsError, GetBlockHeaderError,
         GetBlockInputsError, InvalidBlockError, NoteSyncError, StateInitializationError,
@@ -979,6 +979,13 @@ impl State {
     /// Returns the latest block number.
     pub async fn latest_block_num(&self) -> BlockNumber {
         self.inner.read().await.latest_block_num()
+    }
+
+    pub async fn get_unconsumed_network_notes(
+        &self,
+        page: PaginationToken,
+    ) -> Result<(Vec<NoteRecord>, PaginationToken), DatabaseError> {
+        self.db.select_unconsumed_network_notes(page).await
     }
 }
 

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -189,4 +189,11 @@ message GetAccountProofsRequest {
     repeated digest.Digest code_commitments = 3;
 }
 
-message GetUnconsumedNetworkNotesRequest {}
+// Returns a list of unconsumed network notes using pagination.
+message GetUnconsumedNetworkNotesRequest {
+    // Page number to retrieve.
+    uint64 page = 1;
+
+    // Number of notes to retrieve per page.
+    uint64 limit = 2;
+}

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -188,3 +188,5 @@ message GetAccountProofsRequest {
     // all requested accounts.
     repeated digest.Digest code_commitments = 3;
 }
+
+message GetUnconsumedNetworkNotesRequest {}

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -253,6 +253,11 @@ message StorageSlotMapProof {
     bytes smt_proof = 2;
 }
 
+// Represents the result of getting the unconsumed network notes.
 message GetUnconsumedNetworkNotesResponse {
-    note.Note note = 1;
+    // The next page number.
+    uint64 next_page = 1;
+
+    // The list of unconsumed network notes.
+    repeated note.Note notes = 2;
 }

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -252,3 +252,7 @@ message StorageSlotMapProof {
     // Merkle proof of the map value
     bytes smt_proof = 2;
 }
+
+message GetUnconsumedNetworkNotesResponse {
+    note.Note note = 1;
+}

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -77,6 +77,5 @@ service Api {
     rpc SyncState(requests.SyncStateRequest) returns (responses.SyncStateResponse) {}
 
     // Returns a stream with the unconsumed network notes.
-    // TODO: check if a request is needed.
-    rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (stream responses.GetUnconsumedNetworkNotesResponse) {}
+    rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (responses.GetUnconsumedNetworkNotesResponse) {}
 }

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -75,4 +75,8 @@ service Api {
     // part of hashes. Thus, returned data contains excessive notes and nullifiers, client can make
     // additional filtering of that data on its side.
     rpc SyncState(requests.SyncStateRequest) returns (responses.SyncStateResponse) {}
+
+    // Returns a stream with the unconsumed network notes.
+    // TODO: check if a request is needed.
+    rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (stream responses.GetUnconsumedNetworkNotesResponse) {}
 }


### PR DESCRIPTION
This is an auxiliary PR.

Since the query to get the unconsumed notes from the store is paginated, decided that it's best to delegate the pagination also at the endpoint level, instead of streaming the response.