### PR TITLE
feat: improve `insert_sql!` macro

### DIFF
--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 
 mod migrations;
+#[macro_use]
 mod sql;
 
 mod settings;

--- a/crates/store/src/db/settings.rs
+++ b/crates/store/src/db/settings.rs
@@ -18,7 +18,7 @@ impl Settings {
 
     pub fn set_value<T: ToSql>(conn: &Connection, name: &str, value: &T) -> Result<()> {
         let count =
-            conn.execute(insert_sql!(settings { name, value } | replace), params![name, value])?;
+            conn.execute(insert_sql!(settings { name, value } | REPLACE), params![name, value])?;
 
         debug_assert_eq!(count, 1);
 

--- a/crates/store/src/db/settings.rs
+++ b/crates/store/src/db/settings.rs
@@ -17,10 +17,8 @@ impl Settings {
     }
 
     pub fn set_value<T: ToSql>(conn: &Connection, name: &str, value: &T) -> Result<()> {
-        let count = conn.execute(
-            "INSERT OR REPLACE INTO settings (name, value) VALUES (?, ?)",
-            params![name, value],
-        )?;
+        let count =
+            conn.execute(insert_sql!(settings { name, value } | replace), params![name, value])?;
 
         debug_assert_eq!(count, 1);
 

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -409,9 +409,14 @@ pub fn upsert_accounts(
     accounts: &[BlockAccountUpdate],
     block_num: BlockNumber,
 ) -> Result<usize> {
-    let mut upsert_stmt = transaction.prepare_cached(
-        "INSERT OR REPLACE INTO accounts (account_id, account_hash, block_num, details) VALUES (?1, ?2, ?3, ?4);",
-    )?;
+    let mut upsert_stmt = transaction.prepare_cached(insert_sql!(
+        accounts {
+            account_id,
+            account_hash,
+            block_num,
+            details
+        } | replace
+    ))?;
     let mut select_details_stmt =
         transaction.prepare_cached("SELECT details FROM accounts WHERE account_id = ?1;")?;
 
@@ -592,9 +597,11 @@ pub fn insert_nullifiers_for_block(
         .prepare_cached("UPDATE notes SET consumed = TRUE WHERE nullifier IN rarray(?1)")?;
     let mut count = stmt.execute(params![serialized_nullifiers])?;
 
-    let mut stmt = transaction.prepare_cached(
-        "INSERT INTO nullifiers (nullifier, nullifier_prefix, block_num) VALUES (?1, ?2, ?3);",
-    )?;
+    let mut stmt = transaction.prepare_cached(insert_sql!(nullifiers {
+        nullifier,
+        nullifier_prefix,
+        block_num
+    }))?;
 
     for (nullifier, bytes) in nullifiers.iter().zip(serialized_nullifiers.iter()) {
         count +=
@@ -960,8 +967,8 @@ pub struct PaginationToken(i64);
 /// The [Transaction] object is not consumed. It's up to the caller to commit or rollback the
 /// transaction.
 pub fn insert_block_header(transaction: &Transaction, block_header: &BlockHeader) -> Result<usize> {
-    let mut stmt = transaction
-        .prepare_cached("INSERT INTO block_headers (block_num, block_header) VALUES (?1, ?2);")?;
+    let mut stmt =
+        transaction.prepare_cached(insert_sql!(block_headers { block_num, block_header }))?;
     Ok(stmt.execute(params![block_header.block_num().as_u32(), block_header.to_bytes()])?)
 }
 
@@ -1062,9 +1069,11 @@ pub fn insert_transactions(
     block_num: BlockNumber,
     accounts: &[BlockAccountUpdate],
 ) -> Result<usize> {
-    let mut stmt = transaction.prepare_cached(
-        "INSERT INTO transactions (transaction_id, account_id, block_num) VALUES (?1, ?2, ?3);",
-    )?;
+    let mut stmt = transaction.prepare_cached(insert_sql!(transactions {
+        transaction_id,
+        account_id,
+        block_num
+    }))?;
     let mut count = 0;
     for update in accounts {
         let account_id = update.account_id();

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -415,7 +415,7 @@ pub fn upsert_accounts(
             account_hash,
             block_num,
             details
-        } | replace
+        } | REPLACE
     ))?;
     let mut select_details_stmt =
         transaction.prepare_cached("SELECT details FROM accounts WHERE account_id = ?1;")?;

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -51,7 +51,7 @@ macro_rules! subst {
 /// `insert_sql!(users { id, first_name, last_name, age } | REPLACE);`
 ///
 /// which generates:
-/// "INSERT OR REPLACE INTO users (id, `first_name`, `last_name`, age) VALUES (?, ?, ?, ?)"
+/// "INSERT OR REPLACE INTO users (`id`, `first_name`, `last_name`, `age`) VALUES (?, ?, ?, ?)"
 macro_rules! insert_sql {
     ($table:ident { $first_field:ident $(, $($field:ident),+)? $(,)? } $(| $on_conflict:expr)?) => {
         concat!(

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -48,18 +48,24 @@ macro_rules! subst {
 ///
 /// # Usage:
 ///
-/// `insert_sql!(users { id, first_name, last_name, age } | REPLACE);`
+/// ```ignore
+/// insert_sql!(users { id, first_name, last_name, age } | REPLACE);
+/// ```
 ///
 /// which generates:
-/// "INSERT OR REPLACE INTO users (`id`, `first_name`, `last_name`, `age`) VALUES (?, ?, ?, ?)"
+/// ```sql
+/// INSERT OR REPLACE INTO `users` (`id`, `first_name`, `last_name`, `age`) VALUES (?, ?, ?, ?)
+/// ```
 macro_rules! insert_sql {
     ($table:ident { $first_field:ident $(, $($field:ident),+)? $(,)? } $(| $on_conflict:expr)?) => {
         concat!(
-            stringify!(INSERT $(OR $on_conflict)? INTO $table),
-            " (",
+            stringify!(INSERT $(OR $on_conflict)? INTO ),
+            "`",
+            stringify!($table),
+            "` (`",
             stringify!($first_field),
-            $($(concat!(", ", stringify!($field))),+ ,)?
-            ") VALUES (",
+            $($(concat!("`, `", stringify!($field))),+ ,)?
+            "`) VALUES (",
             subst!($first_field, "?"),
             $($(subst!($field, ", ?")),+ ,)?
             ")"

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -43,17 +43,17 @@ macro_rules! subst {
 }
 
 /// Generates a simple insert SQL statement with parameters for the provided table name and fields.
-/// Supports optional conflict resolution (adding "| replace" or "| ignore" at the end will generate
+/// Supports optional conflict resolution (adding "| REPLACE" or "| IGNORE" at the end will generate
 /// "OR REPLACE" and "OR IGNORE", correspondingly).
 ///
 /// # Usage:
 ///
-/// `insert_sql!(users { id, first_name, last_name, age } | replace);`
+/// `insert_sql!(users { id, first_name, last_name, age } | REPLACE);`
 ///
 /// which generates:
 /// "INSERT OR REPLACE INTO users (id, `first_name`, `last_name`, age) VALUES (?, ?, ?, ?)"
 macro_rules! insert_sql {
-    ($table:ident { $first_field:ident $(, $($field:ident),+)? $(,)? } $(, $on_conflict:expr)?) => {
+    ($table:ident { $first_field:ident $(, $($field:ident),+)? $(,)? } $(| $on_conflict:expr)?) => {
         concat!(
             stringify!(INSERT $(OR $on_conflict)? INTO $table),
             " (",
@@ -64,14 +64,6 @@ macro_rules! insert_sql {
             $($(subst!($field, ", ?")),+ ,)?
             ")"
         )
-    };
-
-    ($table:ident { $first_field:ident $(, $($field:ident),+)? $(,)? } | replace) => {
-        insert_sql!($table { $first_field, $($($field),+)? }, REPLACE)
-    };
-
-    ($table:ident { $first_field:ident $(, $($field:ident),+)? $(,)? } | ignore) => {
-        insert_sql!($table { $first_field, $($($field),+)? }, IGNORE)
     };
 }
 


### PR DESCRIPTION
Improved `insert_sql!` macro (added support for `OR REPLACE` and `OR IGNORE` conflicts resolution).
This feature was extracted from the https://github.com/0xPolygonMiden/miden-node/pull/563 PR.