### PR TITLE
docs: fix book deployment

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,39 +1,74 @@
-# Performs checks, builds and deploys the mdbook
+# Performs checks, builds and deploys the documentation mdbook.
+#
+# Flow is based on the official github and mdbook documentation:
+#
+#   https://github.com/actions/starter-workflows/blob/main/pages/mdbook.yml
+#   https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions
 
 name: book
 
-# Docs should reflect the latest development version.
-#
-# So we trigger on push to `next` AND only if the docs have changed.
+# Documentation should be built and tested on every pull-request, and additionally deployed on push onto next.
 on:
   workflow_dispatch:
+  pull_request:
+    path: ['docs/**']
   push:
     branches: [next]
     path: ['docs/**']
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy mdbook
+  # Always build and test the mdbook documentation whenever the docs folder is changed.
+  #
+  # The documentation is uploaded as a github artifact IFF it is required for deployment i.e. on push into next.
+  build:
+    name: Build documentaion
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install mdbook plugins
+      - name: Install mdbook and plugins
         run: |
           rustup update --no-self-update stable
-          cargo +stable install mdbook-linkcheck mdbook-alerts
+          cargo +stable install mdbook mdbook-linkcheck mdbook-alerts
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: "latest"
-
-      - name: Build miden book
+      - name: Build book
         run: mdbook build docs/
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      # Only Upload documentation if we want to deploy (i.e. push to next).
+      - name: Setup Pages
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload book artifact
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book
+          path: ./docs/book
+
+  # Deployment job only runs on push to next.
+  deploy:
+    name: Deploy documentation
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -37,12 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: Swatinem/rust-cache@v2
 
+      # Installation from source takes a fair while, so we install the binaries directly instead.
       - name: Install mdbook and plugins
-        run: |
-          rustup update --no-self-update stable
-          cargo +stable install mdbook mdbook-linkcheck mdbook-alerts
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook, mdbook-linkcheck, mdbook-alerts
 
       - name: Build book
         run: mdbook build docs/

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -33,7 +33,7 @@ jobs:
   #
   # The documentation is uploaded as a github artifact IFF it is required for deployment i.e. on push into next.
   build:
-    name: Build documentaion
+    name: Build documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -42,7 +42,7 @@ jobs:
       - name: Install mdbook and plugins
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook, mdbook-linkcheck, mdbook-alerts
+          tool: mdbook, mdbook-linkcheck, mdbook-alerts mdbook-katex
 
       - name: Build book
         run: mdbook build docs/

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - uses: Swatinem/rust-cache@v2
+
       - name: Install mdbook plugins
         run: |
           rustup update --no-self-update stable
@@ -34,4 +36,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book/html
+          publish_dir: ./docs/book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install mdbook and plugins
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook, mdbook-linkcheck, mdbook-alerts mdbook-katex
+          tool: mdbook, mdbook-linkcheck, mdbook-alerts, mdbook-katex
 
       - name: Build book
         run: mdbook build docs/


### PR DESCRIPTION
I'm unsure what the difference is to `miden-vm` setup, but the fix here was simply deploying the proper build directory.

I've also added caching because some of the `mdbook` plugins take several minutes to build.

Closes #741.