### PR TITLE
fix(store): database connections fail due to pragma

### DIFF
--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -84,7 +84,7 @@ pub fn apply_migrations(conn: &mut Connection) -> super::Result<()> {
     // 2. After restarting of the node, on first connection established.
     //
     // More info: https://www.sqlite.org/pragma.html#pragma_optimize
-    conn.execute("PRAGMA optimize = 0x10002;", ())?;
+    conn.pragma_update(None, "optimize", "0x10002")?;
 
     info!(target: COMPONENT, "Finished database optimization");
 

--- a/crates/store/src/db/pool_manager.rs
+++ b/crates/store/src/db/pool_manager.rs
@@ -37,10 +37,10 @@ impl SqlitePoolManager {
         // transaction is being written, this is required for proper
         // synchronization of the servers in-memory and on-disk representations
         // (see [State::apply_block])
-        conn.execute("PRAGMA journal_mode = WAL;", ())?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
 
         // Enable foreign key checks.
-        conn.execute("PRAGMA foreign_keys = ON;", ())?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
 
         Ok(conn)
     }


### PR DESCRIPTION
For whatever reason the changes in the sqlite pool management introduced in #728 no longer works with manually updating the pragma values. This caused connection creation to fail.

This PR updates it to use a builtin method instead.

This PR _does not_ fix the bad errors messages, those are left for a separate issue.