### PR TITLE
feat: allow content-type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Initial developer and operator guides covering monitoring (#699).
 - Instrument the block-producer's batch building process (#738).
 - Optimized database by adding missing indexes (#728).
+- Added support for `Content-type` header in `get_tokens` endpoint of the faucet (#754).
 
 ### Changes
 

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -18,7 +18,7 @@ use axum::{
 use clap::{Parser, Subcommand};
 use client::initialize_faucet_client;
 use handlers::{get_background, get_favicon, get_index_css, get_index_html, get_index_js};
-use http::HeaderValue;
+use http::{header, HeaderValue};
 use miden_lib::{AuthScheme, account::faucets::create_basic_fungible_faucet};
 use miden_node_utils::{
     config::load_config, crypto::get_rpo_random_coin, logging::OpenTelemetry, version::LongVersion,
@@ -129,7 +129,8 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
                         .layer(
                             CorsLayer::new()
                                 .allow_origin(tower_http::cors::Any)
-                                .allow_methods(tower_http::cors::Any),
+                                .allow_methods(tower_http::cors::Any)
+                                .allow_headers([header::CONTENT_TYPE]),
                         ),
                 )
                 .with_state(faucet_state);

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -18,7 +18,7 @@ use axum::{
 use clap::{Parser, Subcommand};
 use client::initialize_faucet_client;
 use handlers::{get_background, get_favicon, get_index_css, get_index_html, get_index_js};
-use http::{header, HeaderValue};
+use http::{HeaderValue, header};
 use miden_lib::{AuthScheme, account::faucets::create_basic_fungible_faucet};
 use miden_node_utils::{
     config::load_config, crypto::get_rpo_random_coin, logging::OpenTelemetry, version::LongVersion,


### PR DESCRIPTION
closes #736 

This PR allows an user to do request like:

```bash
curl -X 'POST' -d '{"asset_amount": 100, "is_private_note": false, "account_id": "0xe1ed79e8ea294d000000e1a0de7be2"}' -H 'Content-Type: application/json' http://0.0.0.0:8080/get_tokens --output output.txt
```

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/36030f54-08d9-4206-860b-b9862d962439" />
