### PR TITLE
fix: note submission causes database to break

### DIFF
--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -1223,9 +1223,10 @@ pub fn apply_block(
     accounts: &[BlockAccountUpdate],
 ) -> Result<usize> {
     let mut count = 0;
+    // Note: ordering here is important as the relevant tables have FK dependencies.
     count += insert_block_header(transaction, block_header)?;
-    count += insert_notes(transaction, notes)?;
     count += upsert_accounts(transaction, accounts, block_header.block_num())?;
+    count += insert_notes(transaction, notes)?;
     count += insert_transactions(transaction, block_header.block_num(), accounts)?;
     count += insert_nullifiers_for_block(transaction, nullifiers, block_header.block_num())?;
     Ok(count)


### PR DESCRIPTION
#728 introduced a [correction](https://github.com/0xPolygonMiden/miden-node/commit/26dbee7d8e5302f3eb8e9b23df3121b78ce163b6#diff-80fe25b196f42f66acaa4e63c5a23552c239be2ea7d0ea6a9050226ab63169a3R47) to `notes` table where a note now has the associated account ID as a foreign key.

Block application however first inserts notes, before inserting new accounts. This PR simply flips the order to the correct one.

Fixes #753.

## Other issues found during investigation

### Errors

- Our store error messages are opaque with several `err.to_string()` which hides the actual errors.
- For the error in question, we also have no idea which sql query it is that is failing since we lump them all into the same boat.
- Since the `store` is essentially just a gRPC server, there is nowhere where the errors actually get logged properly. The only error logs are from tracing's instrumentation which _does not_ produce error reports.
- Additionally, it is unclear whether the store should really care about the errors either. We currently log an account state query as an error if the account does not exist. This is not a store error, but rather a user query so logging this as an error is bad.
- The block producer doesn't really get a relevant error back over the wire either.
- The store has many "unique" error enums and variants, but they're still not enough to actually cover the specifics.

We definitely need to rethink how we handle errors in the `store`, and probably just in general in the `node`. We rely on error variants but this is proving brittle and simply too little despite having a lot of them. We also don't actually do anything with the variants and they're effectively only used internally. I think part of the issue is that we treat our components as if they're libraries but really they're just an entry-point into a binary - and should probably be largely using `anyhow` for almost all errors. Exceptions would be errors we want to match on and actually do something with.

### Memory explosion

Without the fix, the node's memory explodes and I haven't determined why yet. This should be investigated further as it likely means there is a bug elsewhere e.g. mempool or block-builder maybe.

I'll do that separately to unblock `next` at least.

### Testing

We clearly don't have enough tests around the store. Inserting a basic block into the database should _probably_ be present.

Between this and the (lack of) error reporting, this would be impossible to debug remotely.

Additionally, we have far too many logs/prints that don't help. I'll have to think about this a bit more, but likely having `open` and `close` events for every span is a bit overkill for `info` level.

### New account flow

How are new accounts created? Are they only populated on first use? I was sort of expecting the faucet to create its account with a transaction the moment it launches, however it seems accounts are only created once their state changes the first time?

As in, the faucet account is only created when the first note is submitted. I find this.. weird. The client wallet appears to behave similarly?