### PR TITLE
fix: renames after cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,25 +2023,13 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-air"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c1e48a91d4652c5bd3e6a5f6147e34b5b93484421bd7d5ded8fbe22fee7ec"
-dependencies = [
- "miden-core 0.12.0",
- "thiserror 2.0.12",
- "winter-air 0.11.1",
- "winter-prover 0.11.0",
-]
-
-[[package]]
-name = "miden-air"
 version = "0.13.0"
 source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#8f49c38f6207fe2761e03da6d486faa5344bf64c"
 dependencies = [
- "miden-core 0.13.0",
+ "miden-core",
  "thiserror 2.0.12",
- "winter-air 0.12.1",
- "winter-prover 0.12.2",
+ "winter-air",
+ "winter-prover",
 ]
 
 [[package]]
@@ -2052,7 +2040,7 @@ dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
- "miden-core 0.13.0",
+ "miden-core",
  "miden-miette",
  "rustc_version 0.4.1",
  "smallvec",
@@ -2066,29 +2054,10 @@ name = "miden-block-prover"
 version = "0.8.0"
 source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#6bf1ee5d89b872f788b800a1a269f1bba42946aa"
 dependencies = [
- "miden-crypto 0.14.0",
+ "miden-crypto",
  "miden-lib",
  "miden-objects",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "miden-core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9326385003c062affde18cb336a3475033df0a871fb122ecaa9b48561109e40"
-dependencies = [
- "lock_api",
- "loom",
- "memchr",
- "miden-crypto 0.13.3",
- "miden-formatting",
- "num-derive",
- "num-traits",
- "parking_lot",
- "thiserror 2.0.12",
- "winter-math 0.11.0",
- "winter-utils 0.11.0",
 ]
 
 [[package]]
@@ -2099,35 +2068,15 @@ dependencies = [
  "lock_api",
  "loom",
  "memchr",
- "miden-crypto 0.14.0",
+ "miden-crypto",
  "miden-formatting",
  "miden-miette",
  "num-derive",
  "num-traits",
  "parking_lot",
  "thiserror 2.0.12",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
-]
-
-[[package]]
-name = "miden-crypto"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8f76b64bfbb75705403ec3e2faad6a045544871d9c441758becc55415cfe64"
-dependencies = [
- "blake3",
- "cc",
- "glob",
- "num",
- "num-complex",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "sha3",
- "thiserror 2.0.12",
- "winter-crypto 0.11.0",
- "winter-math 0.11.0",
- "winter-utils 0.11.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -2145,9 +2094,9 @@ dependencies = [
  "rand_core 0.9.3",
  "sha3",
  "thiserror 2.0.12",
- "winter-crypto 0.12.0",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
+ "winter-crypto",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -2277,14 +2226,14 @@ dependencies = [
  "async-trait",
  "futures",
  "itertools 0.14.0",
- "miden-air 0.12.0",
+ "miden-air",
  "miden-block-prover",
  "miden-lib",
  "miden-node-proto",
  "miden-node-test-macro",
  "miden-node-utils",
  "miden-objects",
- "miden-processor 0.12.0",
+ "miden-processor",
  "miden-proving-service-client",
  "miden-tx",
  "miden-tx-batch-prover",
@@ -2399,9 +2348,9 @@ dependencies = [
  "bech32",
  "getrandom 0.2.15",
  "miden-assembly",
- "miden-core 0.13.0",
- "miden-crypto 0.14.0",
- "miden-processor 0.13.0",
+ "miden-core",
+ "miden-crypto",
+ "miden-processor",
  "miden-verifier",
  "rand 0.9.0",
  "rand_xoshiro",
@@ -2414,27 +2363,14 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbc6f1d5cad60b17da51ee00c8f16e047b3deca50cc42dd18e13cc0c73ca23c"
-dependencies = [
- "miden-air 0.12.0",
- "miden-core 0.12.0",
- "thiserror 2.0.12",
- "tracing",
- "winter-prover 0.11.0",
-]
-
-[[package]]
-name = "miden-processor"
 version = "0.13.0"
 source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#8f49c38f6207fe2761e03da6d486faa5344bf64c"
 dependencies = [
- "miden-air 0.13.0",
- "miden-core 0.13.0",
+ "miden-air",
+ "miden-core",
  "thiserror 2.0.12",
  "tracing",
- "winter-prover 0.12.2",
+ "winter-prover",
 ]
 
 [[package]]
@@ -2442,11 +2378,11 @@ name = "miden-prover"
 version = "0.13.0"
 source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#8f49c38f6207fe2761e03da6d486faa5344bf64c"
 dependencies = [
- "miden-air 0.13.0",
- "miden-processor 0.13.0",
+ "miden-air",
+ "miden-processor",
  "tracing",
- "winter-maybe-async 0.12.0",
- "winter-prover 0.12.2",
+ "winter-maybe-async",
+ "winter-prover",
 ]
 
 [[package]]
@@ -2478,7 +2414,7 @@ version = "0.13.0"
 source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#8f49c38f6207fe2761e03da6d486faa5344bf64c"
 dependencies = [
  "miden-assembly",
- "miden-core 0.13.0",
+ "miden-core",
 ]
 
 [[package]]
@@ -2489,13 +2425,13 @@ dependencies = [
  "async-trait",
  "miden-lib",
  "miden-objects",
- "miden-processor 0.13.0",
+ "miden-processor",
  "miden-prover",
  "miden-verifier",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "thiserror 2.0.12",
- "winter-maybe-async 0.12.0",
+ "winter-maybe-async",
 ]
 
 [[package]]
@@ -2503,10 +2439,10 @@ name = "miden-tx-batch-prover"
 version = "0.8.0"
 source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#6bf1ee5d89b872f788b800a1a269f1bba42946aa"
 dependencies = [
- "miden-core 0.13.0",
- "miden-crypto 0.14.0",
+ "miden-core",
+ "miden-crypto",
  "miden-objects",
- "miden-processor 0.13.0",
+ "miden-processor",
  "miden-tx",
  "thiserror 2.0.12",
 ]
@@ -2516,11 +2452,11 @@ name = "miden-verifier"
 version = "0.13.0"
 source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#8f49c38f6207fe2761e03da6d486faa5344bf64c"
 dependencies = [
- "miden-air 0.13.0",
- "miden-core 0.13.0",
+ "miden-air",
+ "miden-core",
  "thiserror 2.0.12",
  "tracing",
- "winter-verifier 0.12.2",
+ "winter-verifier",
 ]
 
 [[package]]
@@ -5108,40 +5044,15 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827ef2aa5a5ab663936e0a6326286e0fc83321771df0d9ea20c46c72c8baa90d"
-dependencies = [
- "libm",
- "winter-crypto 0.11.0",
- "winter-fri 0.11.0",
- "winter-math 0.11.0",
- "winter-utils 0.11.0",
-]
-
-[[package]]
-name = "winter-air"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d7fbdcaa53d220b84811199790c1dda77c025533cdd27715cf1625af2b4027a"
 dependencies = [
  "libm",
- "winter-crypto 0.12.0",
- "winter-fri 0.12.2",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
-]
-
-[[package]]
-name = "winter-crypto"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c57748fd2da77742be601f03eda639ff6046879738fd1faae86e80018263cb"
-dependencies = [
- "blake3",
- "sha3",
- "winter-math 0.11.0",
- "winter-utils 0.11.0",
+ "winter-crypto",
+ "winter-fri",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -5152,19 +5063,8 @@ checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
 dependencies = [
  "blake3",
  "sha3",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
-]
-
-[[package]]
-name = "winter-fri"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9f999bc248c6254138b627035cb6d2c319580eb37dadcab6672298dbf00e41"
-dependencies = [
- "winter-crypto 0.11.0",
- "winter-math 0.11.0",
- "winter-utils 0.11.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -5173,18 +5073,9 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
 dependencies = [
- "winter-crypto 0.12.0",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
-]
-
-[[package]]
-name = "winter-math"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6020c17839fa107ce4a7cc178e407ebbc24adfac1980f4fa2111198e052700ab"
-dependencies = [
- "winter-utils 0.11.0",
+ "winter-crypto",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -5193,17 +5084,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
 dependencies = [
- "winter-utils 0.12.0",
-]
-
-[[package]]
-name = "winter-maybe-async"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ce144fde121b98523bb8a6c15a311773e1d534d33c1cb47f5580bba9cff8e7"
-dependencies = [
- "quote",
- "syn",
+ "winter-utils",
 ]
 
 [[package]]
@@ -5218,32 +5099,17 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2f3cf80955f084fd614c86883195331116b6c96dc88532d43d6836bd7adee"
-dependencies = [
- "tracing",
- "winter-air 0.11.1",
- "winter-crypto 0.11.0",
- "winter-fri 0.11.0",
- "winter-math 0.11.0",
- "winter-maybe-async 0.11.0",
- "winter-utils 0.11.0",
-]
-
-[[package]]
-name = "winter-prover"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "426be0767a25150af20a241a6ae46bad1bf2f7da86393d897e5ec9967124f760"
 dependencies = [
  "tracing",
- "winter-air 0.12.1",
- "winter-crypto 0.12.0",
- "winter-fri 0.12.2",
- "winter-math 0.12.0",
- "winter-maybe-async 0.12.0",
- "winter-utils 0.12.0",
+ "winter-air",
+ "winter-crypto",
+ "winter-fri",
+ "winter-math",
+ "winter-maybe-async",
+ "winter-utils",
 ]
 
 [[package]]
@@ -5253,14 +5119,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
 dependencies = [
  "rand 0.8.5",
- "winter-utils 0.12.0",
+ "winter-utils",
 ]
-
-[[package]]
-name = "winter-utils"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1507ef312ea5569d54c2c7446a18b82143eb2a2e21f5c3ec7cfbe8200c03bd7c"
 
 [[package]]
 name = "winter-utils"
@@ -5273,39 +5133,26 @@ dependencies = [
 
 [[package]]
 name = "winter-verifier"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d949eab6c26328733477ec56ca054fdc69c0c1b8267fa03d8b618ffe2193c4"
-dependencies = [
- "winter-air 0.11.1",
- "winter-crypto 0.11.0",
- "winter-fri 0.11.0",
- "winter-math 0.11.0",
- "winter-utils 0.11.0",
-]
-
-[[package]]
-name = "winter-verifier"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e340716f24960b7ff3713029149fe5e52f9c0dae152101528ec5847d92d73e4"
 dependencies = [
- "winter-air 0.12.1",
- "winter-crypto 0.12.0",
- "winter-fri 0.12.2",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
+ "winter-air",
+ "winter-crypto",
+ "winter-fri",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
 name = "winterfell"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6bdcd01333bbf4a349d8d13f269281524bd6d1a36ae3a853187f0665bf1cfd4"
+checksum = "3e0568d7d853c01210440d4cdacae6586678931fcb45a1bc26af6b4091aea864"
 dependencies = [
- "winter-air 0.11.1",
- "winter-prover 0.11.0",
- "winter-verifier 0.11.0",
+ "winter-air",
+ "winter-prover",
+ "winter-verifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ version      = "0.8.0"
 assert_matches            = { version = "1.5" }
 http                      = { version = "1.2" }
 itertools                 = { version = "0.14" }
-miden-air                 = { version = "0.12" }
+miden-air                 = { package = "miden-air", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.8" }
 miden-node-proto          = { path = "crates/proto", version = "0.8" }
@@ -37,7 +37,7 @@ miden-node-store          = { path = "crates/store", version = "0.8" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.8" }
 miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
-miden-processor           = { version = "0.12" }
+miden-processor           = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next", default-features = false }
 miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -71,7 +71,7 @@ impl FaucetClient {
             Ok(account) => {
                 info!(
                     target: COMPONENT,
-                    hash = %account.hash(),
+                    commitment = %account.commitment(),
                     nonce = %account.nonce(),
                     "Received faucet account state from the node",
                 );

--- a/bin/faucet/src/store.rs
+++ b/bin/faucet/src/store.rs
@@ -61,7 +61,7 @@ impl DataStore for FaucetDataStore {
         TransactionInputs::new(
             account.clone(),
             account.is_new().then_some(self.init_seed).flatten(),
-            self.block_header,
+            self.block_header.clone(),
             self.chain_mmr.clone(),
             InputNotes::default(),
         )

--- a/bin/faucet/src/stub_rpc_api.rs
+++ b/bin/faucet/src/stub_rpc_api.rs
@@ -48,9 +48,9 @@ impl api_server::Api for StubRpcApi {
         Ok(Response::new(GetBlockHeaderByNumberResponse {
             block_header: Some(BlockHeader {
                 version: 1,
-                prev_hash: Some(Digest { d0: 0, d1: 0, d2: 0, d3: 0 }),
+                prev_block_commitment: Some(Digest { d0: 0, d1: 0, d2: 0, d3: 0 }),
                 block_num: 0,
-                chain_root: Some(Digest {
+                chain_commitment: Some(Digest {
                     d0: 0x9729_9D39_2DA8_DC69,
                     d1: 0x674_44AF_6294_0719,
                     d2: 0x7B97_0BC7_07A0_F7D6,
@@ -74,14 +74,14 @@ impl api_server::Api for StubRpcApi {
                     d2: 0x8022_9E0E_1808_C860,
                     d3: 0x13F4_7934_7EB7_FD78,
                 }),
-                tx_hash: Some(Digest { d0: 0, d1: 0, d2: 0, d3: 0 }),
-                kernel_root: Some(Digest {
+                tx_commitment: Some(Digest { d0: 0, d1: 0, d2: 0, d3: 0 }),
+                tx_kernel_commitment: Some(Digest {
                     d0: 0x7B6F_43E5_2910_C8C3,
                     d1: 0x99B3_2868_577E_5779,
                     d2: 0xAF9E_6424_57CD_B8C1,
                     d3: 0xB1DD_E61B_F983_2DBD,
                 }),
-                proof_hash: Some(Digest { d0: 0, d1: 0, d2: 0, d3: 0 }),
+                proof_commitment: Some(Digest { d0: 0, d1: 0, d2: 0, d3: 0 }),
                 timestamp: 0x63B0_CD00,
             }),
             mmr_path: None,

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -52,4 +52,4 @@ miden-tx              = { workspace = true, features = ["testing"] }
 pretty_assertions     = "1.4"
 rand_chacha           = { version = "0.9", default-features = false }
 tokio                 = { workspace = true, features = ["test-util"] }
-winterfell            = { version = "0.11" }
+winterfell            = { version = "0.12" }

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -342,19 +342,19 @@ impl TelemetryInjectorExt for ProvenBlock {
         let span = Span::current();
         let header = self.header();
 
-        span.set_attribute("block.hash", header.hash());
-        span.set_attribute("block.sub_hash", header.sub_hash());
-        span.set_attribute("block.parent_hash", header.prev_hash());
+        span.set_attribute("block.commitment", header.commitment());
+        span.set_attribute("block.sub_commitment", header.sub_commitment());
+        span.set_attribute("block.prev_block_commitment", header.prev_block_commitment());
         span.set_attribute("block.timestamp", header.timestamp());
 
         span.set_attribute("block.protocol.version", i64::from(header.version()));
 
-        span.set_attribute("block.commitments.kernel", header.kernel_root());
+        span.set_attribute("block.commitments.kernel", header.tx_kernel_commitment());
         span.set_attribute("block.commitments.nullifier", header.nullifier_root());
         span.set_attribute("block.commitments.account", header.account_root());
-        span.set_attribute("block.commitments.chain", header.chain_root());
+        span.set_attribute("block.commitments.chain", header.chain_commitment());
         span.set_attribute("block.commitments.note", header.note_root());
-        span.set_attribute("block.commitments.transaction", header.tx_hash());
+        span.set_attribute("block.commitments.transaction", header.tx_commitment());
     }
 }
 

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -61,7 +61,7 @@ impl AuthenticatedTransaction {
             inner: Arc::new(tx),
             notes_authenticated_by_store: inputs.found_unauthenticated_notes,
             authentication_height: inputs.current_block_height,
-            store_account_state: inputs.account_hash,
+            store_account_state: inputs.account_commitment,
         })
     }
 
@@ -102,7 +102,7 @@ impl AuthenticatedTransaction {
     }
 
     pub fn reference_block(&self) -> (BlockNumber, Digest) {
-        (self.inner.block_num(), self.inner.block_ref())
+        (self.inner.ref_block_num(), self.inner.ref_block_commitment())
     }
 
     /// Notes which were unauthenticate in the transaction __and__ which were
@@ -136,13 +136,13 @@ impl AuthenticatedTransaction {
     /// Short-hand for `Self::new` where the input's are setup to match the transaction's initial
     /// account state. This covers the account's initial state and nullifiers being set to unspent.
     pub fn from_inner(inner: ProvenTransaction) -> Self {
-        let store_account_state = match inner.account_update().init_state_hash() {
+        let store_account_state = match inner.account_update().initial_state_commitment() {
             zero if zero == Digest::default() => None,
             non_zero => Some(non_zero),
         };
         let inputs = TransactionInputs {
             account_id: inner.account_id(),
-            account_hash: store_account_state,
+            account_commitment: store_account_state,
             nullifiers: inner.get_nullifiers().map(|nullifier| (nullifier, None)).collect(),
             found_unauthenticated_notes: BTreeSet::default(),
             current_block_height: 0.into(),

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -54,11 +54,11 @@ pub enum VerifyTxError {
     #[error("output note IDs already used: {0:?}")]
     OutputNotesAlreadyExist(Vec<NoteId>),
 
-    /// The account's initial hash did not match the current account's hash
-    #[error("incorrect account's initial hash ({tx_initial_account_hash}, current: {})", format_opt(.current_account_hash.as_ref()))]
-    IncorrectAccountInitialHash {
-        tx_initial_account_hash: Digest,
-        current_account_hash: Option<Digest>,
+    /// The account's initial commitment did not match the current account's commitment
+    #[error("incorrect account's initial commitment ({tx_initial_account_commitment}, current: {})", format_opt(.current_account_commitment.as_ref()))]
+    IncorrectAccountInitialCommitment {
+        tx_initial_account_commitment: Digest,
+        current_account_commitment: Option<Digest>,
     },
 
     /// Failed to retrieve transaction inputs from the store
@@ -108,7 +108,7 @@ impl From<AddTransactionError> for tonic::Status {
                 VerifyTxError::InputNotesAlreadyConsumed(_)
                 | VerifyTxError::UnauthenticatedNotesNotFound(_)
                 | VerifyTxError::OutputNotesAlreadyExist(_)
-                | VerifyTxError::IncorrectAccountInitialHash { .. }
+                | VerifyTxError::IncorrectAccountInitialCommitment { .. }
                 | VerifyTxError::InvalidTransactionProof(_),
             )
             | AddTransactionError::Expired { .. }

--- a/crates/block-producer/src/mempool/inflight_state/mod.rs
+++ b/crates/block-producer/src/mempool/inflight_state/mod.rs
@@ -162,13 +162,13 @@ impl InflightState {
             .and_then(|account_state| account_state.current_state())
             .copied()
             .or(tx.store_account_state());
-        let expected = tx.account_update().init_state_hash();
+        let expected = tx.account_update().initial_state_commitment();
 
         // SAFETY: a new accounts state is set to zero ie default.
         if expected != current.unwrap_or_default() {
-            return Err(VerifyTxError::IncorrectAccountInitialHash {
-                tx_initial_account_hash: expected,
-                current_account_hash: current,
+            return Err(VerifyTxError::IncorrectAccountInitialCommitment {
+                tx_initial_account_commitment: expected,
+                current_account_commitment: current,
             }
             .into());
         }
@@ -219,7 +219,7 @@ impl InflightState {
             .accounts
             .entry(tx.account_id())
             .or_default()
-            .insert(tx.account_update().final_state_hash(), tx.id());
+            .insert(tx.account_update().final_state_commitment(), tx.id());
 
         self.nullifiers.extend(tx.nullifiers());
         self.output_notes
@@ -483,9 +483,9 @@ mod tests {
 
         assert_matches!(
             err,
-            AddTransactionError::VerificationFailed(VerifyTxError::IncorrectAccountInitialHash {
-                tx_initial_account_hash: init_state,
-                current_account_hash: current_state,
+            AddTransactionError::VerificationFailed(VerifyTxError::IncorrectAccountInitialCommitment {
+                tx_initial_account_commitment: init_state,
+                current_account_commitment: current_state,
             }) if init_state == states[0] && current_state == states[2].into()
         );
     }

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -244,11 +244,11 @@ impl BlockProducerRpcServer {
             target: COMPONENT,
             tx_id = %tx_id.to_hex(),
             account_id = %tx.account_id().to_hex(),
-            initial_account_hash = %tx.account_update().init_state_hash(),
-            final_account_hash = %tx.account_update().final_state_hash(),
+            initial_state_commitment = %tx.account_update().initial_state_commitment(),
+            final_state_commitment = %tx.account_update().final_state_commitment(),
             input_notes = %format_input_notes(tx.input_notes()),
             output_notes = %format_output_notes(tx.output_notes()),
-            block_ref = %tx.block_ref(),
+            ref_block_commitment = %tx.ref_block_commitment(),
             "Deserialized transaction"
         );
         debug!(target: COMPONENT, proof = ?tx.proof());

--- a/crates/block-producer/src/state_view/mod.rs
+++ b/crates/block-producer/src/state_view/mod.rs
@@ -3,10 +3,10 @@ use std::{collections::BTreeSet, sync::Arc};
 use async_trait::async_trait;
 use miden_node_utils::formatting::format_array;
 use miden_objects::{
+    Digest, MIN_PROOF_SECURITY_LEVEL,
     block::Block,
     note::{NoteId, Nullifier},
     transaction::OutputNote,
-    Digest, MIN_PROOF_SECURITY_LEVEL,
 };
 use miden_tx::TransactionVerifier;
 use tokio::sync::RwLock;
@@ -14,10 +14,10 @@ use tracing::{debug, instrument};
 
 use self::account_state::InflightAccountStates;
 use crate::{
+    COMPONENT, ProvenTransaction,
     errors::VerifyTxError,
     store::{ApplyBlock, ApplyBlockError, Store, TransactionInputs},
     txqueue::TransactionValidator,
-    ProvenTransaction, COMPONENT,
 };
 
 mod account_state;

--- a/crates/block-producer/src/state_view/tests/verify_tx.rs
+++ b/crates/block-producer/src/state_view/tests/verify_tx.rs
@@ -1,7 +1,7 @@
 //! `verify_tx(tx)` requirements:
 //!
 //! Store-related requirements
-//! VT1: `tx.initial_account_hash` must match the account hash in store
+//! VT1: `tx.initial_account_commitment` must match the account commitment in store
 //! VT2: If store doesn't contain account, `verify_tx` should check that it is a new account ( TODO
 //! ) and succeed VT3: If `tx` consumes an already-consumed note in the store, `verify_tx` must fail
 //!
@@ -17,7 +17,7 @@ use miden_objects::note::Note;
 use tokio::task::JoinSet;
 
 use super::*;
-use crate::test_utils::{block::MockBlockBuilder, note::mock_note, MockStoreSuccessBuilder};
+use crate::test_utils::{MockStoreSuccessBuilder, block::MockBlockBuilder, note::mock_note};
 
 /// Tests the happy path where 3 transactions who modify different accounts and consume different
 /// notes all verify successfully
@@ -86,7 +86,7 @@ async fn verify_tx_vt1() {
         MockStoreSuccessBuilder::from_accounts(iter::once((account.id, account.states[0]))).build(),
     );
 
-    // The transaction's initial account hash uses `account.states[1]`, where the store expects
+    // The transaction's initial account commitment uses `account.states[1]`, where the store expects
     // `account.states[0]`
     let tx = MockProvenTxBuilder::with_account(account.id, account.states[1], account.states[2])
         .nullifiers_range(0..1)

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -42,8 +42,8 @@ use crate::{COMPONENT, errors::StoreError};
 pub struct TransactionInputs {
     /// Account ID
     pub account_id: AccountId,
-    /// The account hash in the store corresponding to tx's account ID
-    pub account_hash: Option<Digest>,
+    /// The account commitment in the store corresponding to tx's account ID
+    pub account_commitment: Option<Digest>,
     /// Maps each consumed notes' nullifier to block number, where the note is consumed.
     ///
     /// We use `NonZeroU32` as the wire format uses 0 to encode none.
@@ -71,9 +71,9 @@ impl Display for TransactionInputs {
         };
 
         f.write_fmt(format_args!(
-            "{{ account_id: {}, account_hash: {}, nullifiers: {} }}",
+            "{{ account_id: {}, account_commitment: {}, nullifiers: {} }}",
             self.account_id,
-            format_opt(self.account_hash.as_ref()),
+            format_opt(self.account_commitment.as_ref()),
             nullifiers
         ))
     }
@@ -83,7 +83,7 @@ impl TryFrom<GetTransactionInputsResponse> for TransactionInputs {
     type Error = ConversionError;
 
     fn try_from(response: GetTransactionInputsResponse) -> Result<Self, Self::Error> {
-        let AccountState { account_id, account_hash } = response
+        let AccountState { account_id, account_commitment } = response
             .account_state
             .ok_or(GetTransactionInputsResponse::missing_field(stringify!(account_state)))?
             .try_into()?;
@@ -110,7 +110,7 @@ impl TryFrom<GetTransactionInputsResponse> for TransactionInputs {
 
         Ok(Self {
             account_id,
-            account_hash,
+            account_commitment,
             nullifiers,
             found_unauthenticated_notes,
             current_block_height,

--- a/crates/block-producer/src/test_utils/note.rs
+++ b/crates/block-producer/src/test_utils/note.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     testing::note::NoteBuilder,
     transaction::{InputNote, InputNoteCommitment, OutputNote},
 };
-use rand_chacha::{ChaCha20Rng, rand_core::{SeedableRng}};
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
 use crate::test_utils::account::mock_account_id;
 

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -18,8 +18,8 @@ use crate::domain::transaction::AuthenticatedTransaction;
 
 pub struct MockProvenTxBuilder {
     account_id: AccountId,
-    initial_account_hash: Digest,
-    final_account_hash: Digest,
+    initial_account_commitment: Digest,
+    final_account_commitment: Digest,
     expiration_block_num: BlockNumber,
     output_notes: Option<Vec<OutputNote>>,
     input_notes: Option<Vec<InputNote>>,
@@ -54,13 +54,13 @@ impl MockProvenTxBuilder {
 
     pub fn with_account(
         account_id: AccountId,
-        initial_account_hash: Digest,
-        final_account_hash: Digest,
+        initial_account_commitment: Digest,
+        final_account_commitment: Digest,
     ) -> Self {
         Self {
             account_id,
-            initial_account_hash,
-            final_account_hash,
+            initial_account_commitment,
+            final_account_commitment,
             expiration_block_num: u32::MAX.into(),
             output_notes: None,
             input_notes: None,
@@ -133,8 +133,8 @@ impl MockProvenTxBuilder {
     pub fn build(self) -> ProvenTransaction {
         ProvenTransactionBuilder::new(
             self.account_id,
-            self.initial_account_hash,
-            self.final_account_hash,
+            self.initial_account_commitment,
+            self.final_account_commitment,
             BlockNumber::from(0),
             Digest::default(),
             self.expiration_block_num,

--- a/crates/proto/src/domain/block.rs
+++ b/crates/proto/src/domain/block.rs
@@ -22,15 +22,15 @@ impl From<&BlockHeader> for proto::BlockHeader {
     fn from(header: &BlockHeader) -> Self {
         Self {
             version: header.version(),
-            prev_hash: Some(header.prev_hash().into()),
+            prev_block_commitment: Some(header.prev_block_commitment().into()),
             block_num: header.block_num().as_u32(),
-            chain_root: Some(header.chain_root().into()),
+            chain_commitment: Some(header.chain_commitment().into()),
             account_root: Some(header.account_root().into()),
             nullifier_root: Some(header.nullifier_root().into()),
             note_root: Some(header.note_root().into()),
-            tx_hash: Some(header.tx_hash().into()),
-            kernel_root: Some(header.kernel_root().into()),
-            proof_hash: Some(header.proof_hash().into()),
+            tx_commitment: Some(header.tx_commitment().into()),
+            tx_kernel_commitment: Some(header.tx_kernel_commitment().into()),
+            proof_commitment: Some(header.proof_commitment().into()),
             timestamp: header.timestamp(),
         }
     }
@@ -57,13 +57,13 @@ impl TryFrom<proto::BlockHeader> for BlockHeader {
         Ok(BlockHeader::new(
             value.version,
             value
-                .prev_hash
-                .ok_or(proto::BlockHeader::missing_field(stringify!(prev_hash)))?
+                .prev_block_commitment
+                .ok_or(proto::BlockHeader::missing_field(stringify!(prev_block_commitment)))?
                 .try_into()?,
             value.block_num.into(),
             value
-                .chain_root
-                .ok_or(proto::BlockHeader::missing_field(stringify!(chain_root)))?
+                .chain_commitment
+                .ok_or(proto::BlockHeader::missing_field(stringify!(chain_commitment)))?
                 .try_into()?,
             value
                 .account_root
@@ -78,16 +78,16 @@ impl TryFrom<proto::BlockHeader> for BlockHeader {
                 .ok_or(proto::BlockHeader::missing_field(stringify!(note_root)))?
                 .try_into()?,
             value
-                .tx_hash
-                .ok_or(proto::BlockHeader::missing_field(stringify!(tx_hash)))?
+                .tx_commitment
+                .ok_or(proto::BlockHeader::missing_field(stringify!(tx_commitment)))?
                 .try_into()?,
             value
-                .kernel_root
-                .ok_or(proto::BlockHeader::missing_field(stringify!(kernel_root)))?
+                .tx_kernel_commitment
+                .ok_or(proto::BlockHeader::missing_field(stringify!(tx_kernel_commitment)))?
                 .try_into()?,
             value
-                .proof_hash
-                .ok_or(proto::BlockHeader::missing_field(stringify!(proof_hash)))?
+                .proof_commitment
+                .ok_or(proto::BlockHeader::missing_field(stringify!(proof_commitment)))?
                 .try_into()?,
             value.timestamp,
         ))

--- a/crates/proto/src/generated/account.rs
+++ b/crates/proto/src/generated/account.rs
@@ -17,9 +17,9 @@ pub struct AccountSummary {
     /// The account ID.
     #[prost(message, optional, tag = "1")]
     pub account_id: ::core::option::Option<AccountId>,
-    /// The current account hash or zero if the account does not exist.
+    /// The current account commitment or zero if the account does not exist.
     #[prost(message, optional, tag = "2")]
-    pub account_hash: ::core::option::Option<super::digest::Digest>,
+    pub account_commitment: ::core::option::Option<super::digest::Digest>,
     /// Block number at which the summary was made.
     #[prost(uint32, tag = "3")]
     pub block_num: u32,

--- a/crates/proto/src/generated/block.rs
+++ b/crates/proto/src/generated/block.rs
@@ -5,15 +5,15 @@ pub struct BlockHeader {
     /// Specifies the version of the protocol.
     #[prost(uint32, tag = "1")]
     pub version: u32,
-    /// The hash of the previous blocks header.
+    /// The commitment of the previous blocks header.
     #[prost(message, optional, tag = "2")]
-    pub prev_hash: ::core::option::Option<super::digest::Digest>,
+    pub prev_block_commitment: ::core::option::Option<super::digest::Digest>,
     /// A unique sequential number of the current block.
     #[prost(fixed32, tag = "3")]
     pub block_num: u32,
     /// A commitment to an MMR of the entire chain where each block is a leaf.
     #[prost(message, optional, tag = "4")]
-    pub chain_root: ::core::option::Option<super::digest::Digest>,
+    pub chain_commitment: ::core::option::Option<super::digest::Digest>,
     /// A commitment to account database.
     #[prost(message, optional, tag = "5")]
     pub account_root: ::core::option::Option<super::digest::Digest>,
@@ -25,13 +25,13 @@ pub struct BlockHeader {
     pub note_root: ::core::option::Option<super::digest::Digest>,
     /// A commitment to a set of IDs of transactions which affected accounts in this block.
     #[prost(message, optional, tag = "8")]
-    pub tx_hash: ::core::option::Option<super::digest::Digest>,
-    /// A hash of a STARK proof attesting to the correct state transition.
+    pub tx_commitment: ::core::option::Option<super::digest::Digest>,
+    /// A commitment to a STARK proof attesting to the correct state transition.
     #[prost(message, optional, tag = "9")]
-    pub proof_hash: ::core::option::Option<super::digest::Digest>,
+    pub proof_commitment: ::core::option::Option<super::digest::Digest>,
     /// A commitment to all transaction kernels supported by this block.
     #[prost(message, optional, tag = "10")]
-    pub kernel_root: ::core::option::Option<super::digest::Digest>,
+    pub tx_kernel_commitment: ::core::option::Option<super::digest::Digest>,
     /// The time when the block was created.
     #[prost(fixed32, tag = "11")]
     pub timestamp: u32,

--- a/crates/proto/src/generated/requests.rs
+++ b/crates/proto/src/generated/requests.rs
@@ -53,9 +53,9 @@ pub struct SyncStateRequest {
     /// if there are no notes.
     #[prost(fixed32, tag = "1")]
     pub block_num: u32,
-    /// Accounts' hash to include in the response.
+    /// Accounts' commitment to include in the response.
     ///
-    /// An account hash will be included if-and-only-if it is the latest update. Meaning it is
+    /// An account commitment will be included if-and-only-if it is the latest update. Meaning it is
     /// possible there was an update to the account for the given range, but if it is not the latest,
     /// it won't be included in the response.
     #[prost(message, repeated, tag = "2")]

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -51,7 +51,7 @@ pub struct SyncStateResponse {
     /// Data needed to update the partial MMR from `request.block_num + 1` to `response.block_header.block_num`.
     #[prost(message, optional, tag = "3")]
     pub mmr_delta: ::core::option::Option<super::mmr::MmrDelta>,
-    /// List of account hashes updated after `request.block_num + 1` but not after `response.block_header.block_num`.
+    /// List of account commitments updated after `request.block_num + 1` but not after `response.block_header.block_num`.
     #[prost(message, repeated, tag = "5")]
     pub accounts: ::prost::alloc::vec::Vec<super::account::AccountSummary>,
     /// List of transactions executed against requested accounts between `request.block_num + 1` and
@@ -150,9 +150,9 @@ pub struct AccountTransactionInputRecord {
     /// The account ID.
     #[prost(message, optional, tag = "1")]
     pub account_id: ::core::option::Option<super::account::AccountId>,
-    /// The latest account hash, zero hash if the account doesn't exist.
+    /// The latest account commitment, zero commitment if the account doesn't exist.
     #[prost(message, optional, tag = "2")]
-    pub account_hash: ::core::option::Option<super::digest::Digest>,
+    pub account_commitment: ::core::option::Option<super::digest::Digest>,
 }
 /// A nullifier returned as a response to the `GetTransactionInputs`.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -233,9 +233,9 @@ pub struct AccountProofsResponse {
     /// Account ID.
     #[prost(message, optional, tag = "1")]
     pub account_id: ::core::option::Option<super::account::AccountId>,
-    /// Account hash.
+    /// Account commitment.
     #[prost(message, optional, tag = "2")]
-    pub account_hash: ::core::option::Option<super::digest::Digest>,
+    pub account_commitment: ::core::option::Option<super::digest::Digest>,
     /// Authentication path from the `account_root` of the block header to the account.
     #[prost(message, optional, tag = "3")]
     pub account_proof: ::core::option::Option<super::merkle::MerklePath>,

--- a/crates/rpc-proto/proto/account.proto
+++ b/crates/rpc-proto/proto/account.proto
@@ -18,8 +18,8 @@ message AccountSummary {
     // The account ID.
     AccountId account_id = 1;
 
-    // The current account hash or zero if the account does not exist.
-    digest.Digest account_hash = 2;
+    // The current account commitment or zero if the account does not exist.
+    digest.Digest account_commitment = 2;
 
     // Block number at which the summary was made.
     uint32 block_num = 3;

--- a/crates/rpc-proto/proto/block.proto
+++ b/crates/rpc-proto/proto/block.proto
@@ -9,14 +9,14 @@ message BlockHeader {
     // Specifies the version of the protocol.
     uint32 version = 1;
 
-    // The hash of the previous blocks header.
-    digest.Digest prev_hash = 2;
+    // The commitment of the previous blocks header.
+    digest.Digest prev_block_commitment = 2;
 
     // A unique sequential number of the current block.
     fixed32 block_num = 3;
 
     // A commitment to an MMR of the entire chain where each block is a leaf.
-    digest.Digest chain_root = 4;
+    digest.Digest chain_commitment = 4;
 
     // A commitment to account database.
     digest.Digest account_root = 5;
@@ -28,13 +28,13 @@ message BlockHeader {
     digest.Digest note_root = 7;
 
     // A commitment to a set of IDs of transactions which affected accounts in this block.
-    digest.Digest tx_hash = 8;
+    digest.Digest tx_commitment = 8;
 
-    // A hash of a STARK proof attesting to the correct state transition.
-    digest.Digest proof_hash = 9;
+    // A commitment to a STARK proof attesting to the correct state transition.
+    digest.Digest proof_commitment = 9;
 
     // A commitment to all transaction kernels supported by this block.
-    digest.Digest kernel_root = 10;
+    digest.Digest tx_kernel_commitment = 10;
 
     // The time when the block was created.
     fixed32 timestamp = 11;

--- a/crates/rpc-proto/proto/requests.proto
+++ b/crates/rpc-proto/proto/requests.proto
@@ -50,9 +50,9 @@ message SyncStateRequest {
     // if there are no notes.
     fixed32 block_num = 1;
 
-    // Accounts' hash to include in the response.
+    // Accounts' commitment to include in the response.
     //
-    // An account hash will be included if-and-only-if it is the latest update. Meaning it is
+    // An account commitment will be included if-and-only-if it is the latest update. Meaning it is
     // possible there was an update to the account for the given range, but if it is not the latest,
     // it won't be included in the response.
     repeated account.AccountId account_ids = 2;

--- a/crates/rpc-proto/proto/responses.proto
+++ b/crates/rpc-proto/proto/responses.proto
@@ -57,7 +57,7 @@ message SyncStateResponse {
     // Data needed to update the partial MMR from `request.block_num + 1` to `response.block_header.block_num`.
     mmr.MmrDelta mmr_delta = 3;
 
-    // List of account hashes updated after `request.block_num + 1` but not after `response.block_header.block_num`.
+    // List of account commitments updated after `request.block_num + 1` but not after `response.block_header.block_num`.
     repeated account.AccountSummary accounts = 5;
 
     // List of transactions executed against requested accounts between `request.block_num + 1` and
@@ -148,8 +148,8 @@ message AccountTransactionInputRecord {
     // The account ID.
     account.AccountId account_id = 1;
 
-    // The latest account hash, zero hash if the account doesn't exist.
-    digest.Digest account_hash = 2;
+    // The latest account commitment, zero commitment if the account doesn't exist.
+    digest.Digest account_commitment = 2;
 }
 
 // A nullifier returned as a response to the `GetTransactionInputs`.
@@ -220,8 +220,8 @@ message GetAccountProofsResponse {
 message AccountProofsResponse {
     // Account ID.
     account.AccountId account_id = 1;
-    // Account hash.
-    digest.Digest account_hash = 2;
+    // Account commitment.
+    digest.Digest account_commitment = 2;
     // Authentication path from the `account_root` of the block header to the account.
     merkle.MerklePath account_proof = 3;
     // State header for public accounts. Filled only if `include_headers` flag is set to `true`.

--- a/crates/store/src/db/migrations/001-init.sql
+++ b/crates/store/src/db/migrations/001-init.sql
@@ -17,10 +17,10 @@ CREATE TABLE block_headers (
 ) STRICT;
 
 CREATE TABLE accounts (
-      account_id   BLOB    NOT NULL,
-      account_hash BLOB    NOT NULL,
-      block_num    INTEGER NOT NULL,
-      details      BLOB,
+      account_id            BLOB    NOT NULL,
+      account_commitment    BLOB    NOT NULL,
+      block_num             INTEGER NOT NULL,
+      details               BLOB,
 
       PRIMARY KEY (account_id),
       FOREIGN KEY (block_num) REFERENCES block_headers(block_num)

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -19,8 +19,8 @@ use miden_objects::{
         NoteExecutionHint, NoteExecutionMode, NoteId, NoteMetadata, NoteTag, NoteType, Nullifier,
     },
     testing::account_id::{
-        ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN,
-        ACCOUNT_ID_OFF_CHAIN_SENDER, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
+        ACCOUNT_ID_PRIVATE_SENDER, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
+        ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET, ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
     },
 };
 
@@ -120,7 +120,7 @@ fn sql_select_transactions() {
             &conn.transaction().unwrap(),
             0.into(),
             2.into(),
-            &[AccountId::try_from(ACCOUNT_ID_OFF_CHAIN_SENDER).unwrap()],
+            &[AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap()],
         )
         .unwrap()
     }
@@ -179,7 +179,7 @@ fn sql_select_notes() {
     let notes = sql::select_all_notes(&conn.transaction().unwrap()).unwrap();
     assert!(notes.is_empty());
 
-    let account_id = AccountId::try_from(ACCOUNT_ID_OFF_CHAIN_SENDER).unwrap();
+    let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
 
     let transaction = conn.transaction().unwrap();
 
@@ -229,7 +229,7 @@ fn sql_select_notes_different_execution_hints() {
     let notes = sql::select_all_notes(&conn.transaction().unwrap()).unwrap();
     assert!(notes.is_empty());
 
-    let sender = AccountId::try_from(ACCOUNT_ID_OFF_CHAIN_SENDER).unwrap();
+    let sender = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
 
     let transaction = conn.transaction().unwrap();
 
@@ -346,7 +346,7 @@ fn sql_unconsumed_network_notes() {
         &transaction,
         &[BlockAccountUpdate::new(
             account_id,
-            account.hash(),
+            account.commitment(),
             AccountUpdateDetails::New(account),
             vec![],
         )],
@@ -463,9 +463,13 @@ fn sql_select_accounts() {
             AccountType::RegularAccountImmutableCode,
             AccountStorageMode::Private,
         );
-        let account_hash = num_to_rpo_digest(u64::from(i));
+        let account_commitment = num_to_rpo_digest(u64::from(i));
         state.push(AccountInfo {
-            summary: AccountSummary { account_id, account_hash, block_num },
+            summary: AccountSummary {
+                account_id,
+                account_commitment,
+                block_num,
+            },
             details: None,
         });
 
@@ -474,7 +478,7 @@ fn sql_select_accounts() {
             &transaction,
             &[BlockAccountUpdate::new(
                 account_id,
-                account_hash,
+                account_commitment,
                 AccountUpdateDetails::Private,
                 vec![],
             )],
@@ -494,9 +498,9 @@ fn sql_public_account_details() {
 
     create_block(&mut conn, 1.into());
 
-    let fungible_faucet_id = AccountId::try_from(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+    let fungible_faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
     let non_fungible_faucet_id =
-        AccountId::try_from(ACCOUNT_ID_NON_FUNGIBLE_FAUCET_ON_CHAIN).unwrap();
+        AccountId::try_from(ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET).unwrap();
 
     let nft1 = Asset::NonFungible(
         NonFungibleAsset::new(
@@ -520,7 +524,7 @@ fn sql_public_account_details() {
         &transaction,
         &[BlockAccountUpdate::new(
             account.id(),
-            account.hash(),
+            account.commitment(),
             AccountUpdateDetails::New(account.clone()),
             vec![],
         )],
@@ -568,7 +572,7 @@ fn sql_public_account_details() {
         &transaction,
         &[BlockAccountUpdate::new(
             account.id(),
-            account.hash(),
+            account.commitment(),
             AccountUpdateDetails::Delta(delta2.clone()),
             vec![],
         )],
@@ -614,7 +618,7 @@ fn sql_public_account_details() {
         &transaction,
         &[BlockAccountUpdate::new(
             account.id(),
-            account.hash(),
+            account.commitment(),
             AccountUpdateDetails::Delta(delta3.clone()),
             vec![],
         )],
@@ -877,7 +881,7 @@ fn db_account() {
 
     // test empty table
     let account_ids: Vec<AccountId> =
-        [ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, 1, 2, 3, 4, 5]
+        [ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE, 1, 2, 3, 4, 5]
             .iter()
             .map(|acc_id| (*acc_id).try_into().unwrap())
             .collect();
@@ -891,15 +895,15 @@ fn db_account() {
     assert!(res.is_empty());
 
     // test insertion
-    let account_id = ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN;
-    let account_hash = num_to_rpo_digest(0);
+    let account_id = ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE;
+    let account_commitment = num_to_rpo_digest(0);
 
     let transaction = conn.transaction().unwrap();
     let row_count = sql::upsert_accounts(
         &transaction,
         &[BlockAccountUpdate::new(
             account_id.try_into().unwrap(),
-            account_hash,
+            account_commitment,
             AccountUpdateDetails::Private,
             vec![],
         )],
@@ -920,7 +924,7 @@ fn db_account() {
         res,
         vec![AccountSummary {
             account_id: account_id.try_into().unwrap(),
-            account_hash,
+            account_commitment,
             block_num,
         }]
     );
@@ -973,7 +977,7 @@ fn notes() {
     .unwrap();
     assert!(res.is_empty());
 
-    let sender = AccountId::try_from(ACCOUNT_ID_OFF_CHAIN_SENDER).unwrap();
+    let sender = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
 
     // test insertion
     let transaction = conn.transaction().unwrap();
@@ -1124,7 +1128,7 @@ fn insert_transactions(conn: &mut Connection) -> usize {
     let transaction = conn.transaction().unwrap();
 
     let account_updates = vec![mock_block_account_update(
-        AccountId::try_from(ACCOUNT_ID_OFF_CHAIN_SENDER).unwrap(),
+        AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(),
         1,
     )];
 

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -63,8 +63,8 @@ pub enum DatabaseError {
 
     // OTHER ERRORS
     // ---------------------------------------------------------------------------------------------
-    #[error("account hash mismatch (expected {expected}, but calculated is {calculated})")]
-    AccountHashesMismatch {
+    #[error("account commitment mismatch (expected {expected}, but calculated is {calculated})")]
+    AccountCommitmentsMismatch {
         expected: RpoDigest,
         calculated: RpoDigest,
     },
@@ -168,20 +168,20 @@ pub enum InvalidBlockError {
     DuplicatedNullifiers(Vec<Nullifier>),
     #[error("invalid output note type: {0:?}")]
     InvalidOutputNoteType(Box<OutputNote>),
-    #[error("invalid block tx hash: expected {expected}, but got {actual}")]
-    InvalidBlockTxHash { expected: RpoDigest, actual: RpoDigest },
+    #[error("invalid block tx commitment: expected {expected}, but got {actual}")]
+    InvalidBlockTxCommitment { expected: RpoDigest, actual: RpoDigest },
     #[error("received invalid account tree root")]
     NewBlockInvalidAccountRoot,
     #[error("new block number must be 1 greater than the current block number")]
     NewBlockInvalidBlockNum,
-    #[error("new block chain root is not consistent with chain MMR")]
-    NewBlockInvalidChainRoot,
+    #[error("new block chain commitment is not consistent with chain MMR")]
+    NewBlockInvalidChainCommitment,
     #[error("received invalid note root")]
     NewBlockInvalidNoteRoot,
     #[error("received invalid nullifier root")]
     NewBlockInvalidNullifierRoot,
-    #[error("new block `prev_hash` must match the chain's tip")]
-    NewBlockInvalidPrevHash,
+    #[error("new block `prev_block_commitment` must match the chain's tip")]
+    NewBlockInvalidPrevCommitment,
 }
 
 #[derive(Error, Debug)]

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -40,7 +40,7 @@ impl GenesisState {
 
                 BlockAccountUpdate::new(
                     account.id(),
-                    account.hash(),
+                    account.commitment(),
                     account_update_details,
                     vec![],
                 )
@@ -67,7 +67,7 @@ impl GenesisState {
             empty_nullifier_tree.root(),
             empty_block_note_tree.root(),
             Digest::default(),
-            TransactionKernel::kernel_root(),
+            TransactionKernel::kernel_commitment(),
             Digest::default(),
             self.timestamp,
         );

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -173,7 +173,7 @@ impl api_server::Api for StoreApi {
             .into_iter()
             .map(|account_info| AccountSummary {
                 account_id: Some(account_info.account_id.into()),
-                account_hash: Some(account_info.account_hash.into()),
+                account_commitment: Some(account_info.account_commitment.into()),
                 block_num: account_info.block_num.as_u32(),
             })
             .collect();
@@ -313,7 +313,7 @@ impl api_server::Api for StoreApi {
         info!(
             target: COMPONENT,
             block_num,
-            block_hash = %block.hash(),
+            block_commitment = %block.commitment(),
             account_count = block.updated_accounts().len(),
             note_count = block.output_notes().count(),
             nullifier_count = block.created_nullifiers().len(),
@@ -414,7 +414,7 @@ impl api_server::Api for StoreApi {
         Ok(Response::new(GetTransactionInputsResponse {
             account_state: Some(AccountTransactionInputRecord {
                 account_id: Some(account_id.into()),
-                account_hash: Some(tx_inputs.account_hash.into()),
+                account_commitment: Some(tx_inputs.account_commitment.into()),
             }),
             nullifiers: tx_inputs
                 .nullifiers

--- a/proto/account.proto
+++ b/proto/account.proto
@@ -18,8 +18,8 @@ message AccountSummary {
     // The account ID.
     AccountId account_id = 1;
 
-    // The current account hash or zero if the account does not exist.
-    digest.Digest account_hash = 2;
+    // The current account commitment or zero if the account does not exist.
+    digest.Digest account_commitment = 2;
 
     // Block number at which the summary was made.
     uint32 block_num = 3;

--- a/proto/block.proto
+++ b/proto/block.proto
@@ -9,14 +9,14 @@ message BlockHeader {
     // Specifies the version of the protocol.
     uint32 version = 1;
 
-    // The hash of the previous blocks header.
-    digest.Digest prev_hash = 2;
+    // The commitment of the previous blocks header.
+    digest.Digest prev_block_commitment = 2;
 
     // A unique sequential number of the current block.
     fixed32 block_num = 3;
 
     // A commitment to an MMR of the entire chain where each block is a leaf.
-    digest.Digest chain_root = 4;
+    digest.Digest chain_commitment = 4;
 
     // A commitment to account database.
     digest.Digest account_root = 5;
@@ -28,13 +28,13 @@ message BlockHeader {
     digest.Digest note_root = 7;
 
     // A commitment to a set of IDs of transactions which affected accounts in this block.
-    digest.Digest tx_hash = 8;
+    digest.Digest tx_commitment = 8;
 
-    // A hash of a STARK proof attesting to the correct state transition.
-    digest.Digest proof_hash = 9;
+    // A commitment to a STARK proof attesting to the correct state transition.
+    digest.Digest proof_commitment = 9;
 
     // A commitment to all transaction kernels supported by this block.
-    digest.Digest kernel_root = 10;
+    digest.Digest tx_kernel_commitment = 10;
 
     // The time when the block was created.
     fixed32 timestamp = 11;

--- a/proto/requests.proto
+++ b/proto/requests.proto
@@ -50,9 +50,9 @@ message SyncStateRequest {
     // if there are no notes.
     fixed32 block_num = 1;
 
-    // Accounts' hash to include in the response.
+    // Accounts' commitment to include in the response.
     //
-    // An account hash will be included if-and-only-if it is the latest update. Meaning it is
+    // An account commitment will be included if-and-only-if it is the latest update. Meaning it is
     // possible there was an update to the account for the given range, but if it is not the latest,
     // it won't be included in the response.
     repeated account.AccountId account_ids = 2;

--- a/proto/responses.proto
+++ b/proto/responses.proto
@@ -57,7 +57,7 @@ message SyncStateResponse {
     // Data needed to update the partial MMR from `request.block_num + 1` to `response.block_header.block_num`.
     mmr.MmrDelta mmr_delta = 3;
 
-    // List of account hashes updated after `request.block_num + 1` but not after `response.block_header.block_num`.
+    // List of account commitments updated after `request.block_num + 1` but not after `response.block_header.block_num`.
     repeated account.AccountSummary accounts = 5;
 
     // List of transactions executed against requested accounts between `request.block_num + 1` and
@@ -148,8 +148,8 @@ message AccountTransactionInputRecord {
     // The account ID.
     account.AccountId account_id = 1;
 
-    // The latest account hash, zero hash if the account doesn't exist.
-    digest.Digest account_hash = 2;
+    // The latest account commitment, zero commitment if the account doesn't exist.
+    digest.Digest account_commitment = 2;
 }
 
 // A nullifier returned as a response to the `GetTransactionInputs`.
@@ -220,8 +220,8 @@ message GetAccountProofsResponse {
 message AccountProofsResponse {
     // Account ID.
     account.AccountId account_id = 1;
-    // Account hash.
-    digest.Digest account_hash = 2;
+    // Account commitment.
+    digest.Digest account_commitment = 2;
     // Authentication path from the `account_root` of the block header to the account.
     merkle.MerklePath account_proof = 3;
     // State header for public accounts. Filled only if `include_headers` flag is set to `true`.


### PR DESCRIPTION
This PR deals with the new renames from miden-base. The most prevalent in the node is the change from "account hash" to "account commitment". I searched through all the instances and updated the relevant ones in variable names, docs, proto files, etc.

The branch uses `tomasarrachea-upgrade-rand` as a base as it fixes some issues with the new rand version in miden-base.

Some crate versions also needed to be updated to point to next.


This PR should bring the node up to date with base. This is needed because the client is also up to date with base and the integration tests are failing because the node is outdated.
