### PR TITLE
fix: block and batch default intervals

### DIFF
--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -13,8 +13,8 @@ const ENV_STORE_URL: &str = "MIDEN_NODE_STORE_URL";
 const ENV_DATA_DIRECTORY: &str = "MIDEN_NODE_DATA_DIRECTORY";
 const ENV_ENABLE_OTEL: &str = "MIDEN_NODE_ENABLE_OTEL";
 
-const DEFAULT_BLOCK_INTERVAL_MS: &str = "5_000";
-const DEFAULT_BATCH_INTERVAL_MS: &str = "2_000";
+const DEFAULT_BLOCK_INTERVAL_MS: &str = "5000";
+const DEFAULT_BATCH_INTERVAL_MS: &str = "2000";
 
 fn parse_duration_ms(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
     arg.parse().map(Duration::from_millis)


### PR DESCRIPTION
Currently, on `next`, using the default values when starting up is causing an error:
```bash
error: invalid value '5_000' for '--block.interval <MILLISECONDS>': invalid digit found in string

For more information, try '--help'.
```

I was running:
```
miden-node bundled start --rpc.url http://0.0.0.0:57291 --data-directory data
```

Removing the underscore from the default values fixed the issue.