### PR TITLE
Update miden-base dependencies to crates.io versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -1086,13 +1086,12 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fantoccini"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7722aeee9c2be6fa131166990295089d73d973012b758a2208b9ba51af5dd024"
+checksum = "e3a6a7a9a454c24453f9807c7f12b37e31ae43f3eb41888ae1f79a9a3e3be3f5"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
- "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body-util",
@@ -1305,10 +1304,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1318,9 +1315,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2054,7 +2053,8 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f423b23aa80d8950ef3fd369be860de35088eb32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d1c33a2f543adb8a3f0425f540a4f4607ea5a61f681be2fe6f59d8fe53e356"
 dependencies = [
  "miden-crypto",
  "miden-lib",
@@ -2147,7 +2147,8 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f423b23aa80d8950ef3fd369be860de35088eb32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea3fdad9ad0e50f71f4be0e27479d2de800a9b9262810d0cbedaea30e3f450b"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2346,10 +2347,11 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f423b23aa80d8950ef3fd369be860de35088eb32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb56355acfef551dc81f57667f01a46a37872e7590cb9a92d4efbb8933fe6ebb"
 dependencies = [
  "bech32",
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "miden-assembly",
  "miden-core",
  "miden-crypto",
@@ -2393,9 +2395,11 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f423b23aa80d8950ef3fd369be860de35088eb32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272e6749ad8a146ff62dc621f396021d347257d948eac26e4493c0b9d3d341"
 dependencies = [
  "async-trait",
+ "getrandom 0.3.2",
  "miden-objects",
  "miden-tx",
  "miette",
@@ -2415,9 +2419,9 @@ version = "0.8.0"
 
 [[package]]
 name = "miden-stdlib"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2694c29b37e953fec31bb912db604f16d4c1e9a692618eac876eb6d3c0473c36"
+checksum = "116d30a8db5167f88944509007b8bb7aad4fa0d9d03f2610b4e80be3a198ad37"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2426,7 +2430,8 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f423b23aa80d8950ef3fd369be860de35088eb32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d10cd912c13e30ee85f5a96940bdaa7c2d43bd311d3181edfd240415f65c4"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2443,7 +2448,8 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#f423b23aa80d8950ef3fd369be860de35088eb32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c23d17fca6ad1ad88fcafd1cf4744523aac0b4d95fe3bfb5dad61f468424a5"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -3987,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -4010,9 +4016,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,20 +25,21 @@ rust-version = "1.85"
 version      = "0.8.0"
 
 [workspace.dependencies]
+anyhow                    = { version = "1.0" }
 assert_matches            = { version = "1.5" }
-http                      = { version = "1.2" }
+http                      = { version = "1.3" }
 itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.13" }
-miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-lib                 = { version = "0.8" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.8" }
 miden-node-proto          = { path = "crates/proto", version = "0.8" }
 miden-node-rpc            = { path = "crates/rpc", version = "0.8" }
 miden-node-store          = { path = "crates/store", version = "0.8" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.8" }
-miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-objects             = { version = "0.8" }
 miden-processor           = { version = "0.13" }
-miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-tx                  = { version = "0.8" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
 thiserror                 = { version = "2.0", default-features = false }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 anyhow           = { workspace = true }
 axum             = { version = "0.8", features = ["tokio"] }
 clap             = { version = "4.5", features = ["derive", "string"] }
-http             = "1.1"
+http             = { workspace = true }
 http-body-util   = "0.1"
 miden-lib        = { workspace = true }
 miden-node-proto = { workspace = true }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
-anyhow           = "1.0"
+anyhow           = { workspace = true }
 axum             = { version = "0.8", features = ["tokio"] }
 clap             = { version = "4.5", features = ["derive", "string"] }
 http             = "1.1"

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 tracing-forest = ["miden-node-block-producer/tracing-forest"]
 
 [dependencies]
-anyhow                    = { version = "1.0" }
+anyhow                    = { workspace = true }
 clap                      = { version = "4.5", features = ["derive", "env", "string"] }
 miden-lib                 = { workspace = true }
 miden-node-block-producer = { workspace = true }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -18,29 +18,26 @@ workspace = true
 tracing-forest = ["miden-node-utils/tracing-forest"]
 
 [dependencies]
-async-trait = { version = "0.1" }
-futures = { version = "0.3" }
-itertools = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
-miden-lib = { workspace = true }
-miden-node-proto = { workspace = true }
-miden-node-utils = { workspace = true }
-miden-objects = { workspace = true }
-miden-processor = { workspace = true }
-miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", features = [
-  "batch-prover",
-  "block-prover",
-] }
-miden-tx = { workspace = true }
-miden-tx-batch-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
-rand = { version = "0.9" }
-thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tokio-stream = { workspace = true, features = ["net"] }
-tonic = { workspace = true, features = ["transport"] }
-tower-http = { workspace = true, features = ["util"] }
-tracing = { workspace = true }
-url = { workspace = true }
+async-trait                  = { version = "0.1" }
+futures                      = { version = "0.3" }
+itertools                    = { workspace = true }
+miden-block-prover           = { version = "0.8" }
+miden-lib                    = { workspace = true }
+miden-node-proto             = { workspace = true }
+miden-node-utils             = { workspace = true }
+miden-objects                = { workspace = true }
+miden-processor              = { workspace = true }
+miden-proving-service-client = { version = "0.8", features = ["batch-prover", "block-prover"] }
+miden-tx                     = { workspace = true }
+miden-tx-batch-prover        = { version = "0.8" }
+rand                         = { version = "0.9" }
+thiserror                    = { workspace = true }
+tokio                        = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-stream                 = { workspace = true, features = ["net"] }
+tonic                        = { workspace = true, features = ["transport"] }
+tower-http                   = { workspace = true, features = ["util"] }
+tracing                      = { workspace = true }
+url                          = { workspace = true }
 
 [dev-dependencies]
 assert_matches        = { workspace = true }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -26,7 +26,7 @@ tonic            = { workspace = true }
 proptest = { version = "1.5" }
 
 [build-dependencies]
-anyhow      = { version = "1.0" }
+anyhow      = { workspace = true }
 prost       = { workspace = true }
 prost-build = { version = "0.13" }
 protox      = { version = "0.7" }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 vergen = ["dep:vergen", "dep:vergen-gitcl"]
 
 [dependencies]
-anyhow                = { version = "1.0" }
+anyhow                = { workspace = true }
 figment               = { version = "0.10", features = ["env", "toml"] }
 http                  = { workspace = true }
 itertools             = { workspace = true }


### PR DESCRIPTION
This PR updates `miden-base` dependencies to be pulled from crates.io. Also:

- Updated `http` dependency version from `1.2` to `1.3`.
- Moved `anyhow` dependency declaration to the root `Cargo.toml` file.