### PR TITLE
ci: update deploy scripts for CLI changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,14 +141,14 @@ jobs:
       # The faucet uses the public faucet generated in the genesis block.
       - name: Configure environment
         uses: ./.github/actions/ssm_execute
+        env:
+          node_bin:   /usr/bin/miden-node
+          faucet_bin: /usr/bin/miden-faucet
         with:
           instance_id: ${{ secrets[env.instance-id] }}
           command: |
-            sudo /usr/bin/miden-node init -c /etc/opt/miden-node/miden-node.toml -g /etc/opt/miden-node/genesis.toml; \
-            sudo /usr/bin/miden-node make-genesis -i /etc/opt/miden-node/genesis.toml -o /opt/miden-node/genesis.dat --force; \
-            sudo /usr/bin/miden-faucet init -c /etc/opt/miden-faucet/miden-faucet.toml -f /opt/miden-faucet/accounts/faucet.mac; \
-            sudo mkdir /opt/miden-faucet/accounts; \
-            sudo cp /opt/miden-node/accounts/faucet.mac /opt/miden-faucet/accounts/faucet.mac; \
+            sudo ${{ env.node_bin }} bundled bootstrap --data-directory /opt/miden-node --accounts-directory /opt/miden-faucet; \
+            sudo ${{ env.faucet_bin }} init -c /etc/opt/miden-faucet/miden-faucet.toml -f /opt/miden-faucet/faucet.mac; \
             sudo chown -R miden-node /opt/miden-node; \
             sudo chown -R miden-faucet /opt/miden-faucet;
 

--- a/packaging/node/miden-node.service
+++ b/packaging/node/miden-node.service
@@ -7,9 +7,12 @@ WantedBy=multi-user.target
 
 [Service]
 Type=exec
-Environment="RUST_LOG=info"
-ExecStart=/usr/bin/miden-node start --config /etc/opt/miden-node/miden-node.toml node
+ExecStart=/usr/bin/miden-node bundled start
 WorkingDirectory=/opt/miden-node
+Environment="RUST_LOG=info"
+# Use the working directory as the data directory.
+Environment="MIDEN_NODE_DATA_DIRECTORY=./"
+Environment="MIDEN_NODE_RPC_URL=http://0.0.0.0:57291"
 User=miden-node
 RestartSec=5
 Restart=always


### PR DESCRIPTION
Closes #765 

This PR updates our deployment scripts to account for the change from `toml` config files to a CLI based approach.

- [ ] Test with devnet deployment

### OTel

This currently leaves OTel disabled. We likely want to enable this, but at present we don't have a sensible way of injecting the required environment variables via github deployment.

I recommend we simply do this manually by inserting some extra environment variables.

One alternative is to edit the service file manually and inserting the required values using github secrets. I don't have access myself so at minimum the secrets would require someone else to add.