### PR TITLE
ci: optimise test run time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ repository   = "https://github.com/0xPolygonMiden/miden-node"
 rust-version = "1.85"
 version      = "0.8.0"
 
+# Optimise the cryptography for faster tests involving account creation.
+[profile.test.package.miden-crypto]
+opt-level = 2
+
 [workspace.dependencies]
 anyhow                    = { version = "1.0" }
 assert_matches            = { version = "1.5" }

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ book: ## Builds the book & serves documentation site
 
 .PHONY: test
 test:  ## Runs all tests
-	cargo nextest run --all-features --workspace --no-capture
+	cargo nextest run --all-features --workspace 
 
 # --- checking ------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Our faucet website tests takes ~1 minute to run which is two orders of magnitude slower than the rest of our test suite. This PR reduces this to a few seconds by promoting `miden-crypto` to a more optimised compilation.

This works because the primary factor slowing the website test down was faucet account creation.

Additionally, this PR also removes the `make test` logging output. It will now print only for failing tests, which is a lot less noisy imo.