### PR TITLE
fix: OOM on block building error

### DIFF
--- a/crates/utils/src/tracing/span_ext.rs
+++ b/crates/utils/src/tracing/span_ext.rs
@@ -104,9 +104,10 @@ where
     fn set_error(&self, err: &dyn std::error::Error) {
         // Coalesce all sources into one string.
         let mut description = format!("{err}");
-        let current = err;
+        let mut current = err;
         while let Some(cause) = current.source() {
             description.push_str(format!("\nCaused by: {cause}").as_str());
+            current = cause;
         }
         tracing_opentelemetry::OpenTelemetrySpanExt::set_status(
             self,


### PR DESCRIPTION
Our OTel error report injector contains a logic bug. This PR fixes that.

The root cause was failing to update the loop variable to the child, causing an infinite loop and infinitely growing the error report.

Since this is error related it never exhibits on the happy path.

Fixes #756 