### PR TITLE
feat: remove `genesis.dat`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
 name = "miden-node-store"
 version = "0.9.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "deadpool",
  "deadpool-sync",

--- a/bin/node/src/commands/bundled.rs
+++ b/bin/node/src/commands/bundled.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf, time::Duration};
 use anyhow::Context;
 use miden_node_block_producer::server::BlockProducer;
 use miden_node_rpc::server::Rpc;
-use miden_node_store::server::Store;
+use miden_node_store::Store;
 use miden_node_utils::grpc::UrlExt;
 use tokio::{net::TcpListener, task::JoinSet};
 use url::Url;

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Context;
 use miden_lib::{AuthScheme, account::faucets::create_basic_fungible_faucet, utils::Serializable};
-use miden_node_store::{genesis::GenesisState, server::Store};
+use miden_node_store::{GenesisState, Store};
 use miden_node_utils::{crypto::get_rpo_random_coin, grpc::UrlExt};
 use miden_objects::{
     Felt, ONE,

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -137,10 +137,9 @@ impl StoreCommand {
 
         // Generate the accounts.
         let mut rng = ChaCha20Rng::from_seed(rand::random());
-        let n_accounts = accounts.as_ref().map(Vec::len).unwrap_or_default();
+        let n_accounts = accounts.len();
         let accounts = accounts
-            .into_iter()
-            .flatten()
+            .iter()
             .enumerate()
             .inspect(|(idx, _)| tracing::info!(index=%idx, total=n_accounts, "Generating account"))
             .map(|(idx, input)| {
@@ -174,7 +173,7 @@ impl StoreCommand {
             })
     }
 
-    fn generate_account(input: AccountInput, rng: &mut ChaChaRng) -> anyhow::Result<AccountFile> {
+    fn generate_account(input: &AccountInput, rng: &mut ChaChaRng) -> anyhow::Result<AccountFile> {
         let AccountInput::BasicFungibleFaucet(input) = input;
 
         let (auth_scheme, auth_secret_key) = input.auth_scheme.gen_auth_keys(rng);
@@ -203,7 +202,8 @@ impl StoreCommand {
 pub struct GenesisConfig {
     pub version: u32,
     pub timestamp: u32,
-    pub accounts: Option<Vec<AccountInput>>,
+    #[serde(default)]
+    pub accounts: Vec<AccountInput>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -249,13 +249,13 @@ impl Default for GenesisConfig {
                 .duration_since(UNIX_EPOCH)
                 .expect("Current timestamp should be greater than unix epoch")
                 .as_secs() as u32,
-            accounts: Some(vec![AccountInput::BasicFungibleFaucet(BasicFungibleFaucetInputs {
+            accounts: vec![AccountInput::BasicFungibleFaucet(BasicFungibleFaucetInputs {
                 auth_scheme: AuthSchemeInput::RpoFalcon512,
                 token_symbol: "POL".to_string(),
                 decimals: 12,
                 max_supply: 1_000_000,
                 storage_mode: "public".to_string(),
-            })]),
+            })],
         }
     }
 }

--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -18,7 +18,7 @@ use miden_lib::{
 };
 use miden_node_block_producer::store::StoreClient;
 use miden_node_proto::{domain::batch::BatchInputs, generated::store::api_client::ApiClient};
-use miden_node_store::{GENESIS_STATE_FILENAME, genesis::GenesisState, server::Store};
+use miden_node_store::{GENESIS_STATE_FILENAME, GenesisState, Store};
 use miden_node_utils::tracing::grpc::OtelInterceptor;
 use miden_objects::{
     Felt,

--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -18,7 +18,7 @@ use miden_lib::{
 };
 use miden_node_block_producer::store::StoreClient;
 use miden_node_proto::{domain::batch::BatchInputs, generated::store::api_client::ApiClient};
-use miden_node_store::{GENESIS_STATE_FILENAME, GenesisState, Store};
+use miden_node_store::{GenesisState, Store};
 use miden_node_utils::tracing::grpc::OtelInterceptor;
 use miden_objects::{
     Felt,
@@ -41,7 +41,7 @@ use rayon::{
     iter::{IntoParallelIterator, ParallelIterator},
     prelude::ParallelSlice,
 };
-use tokio::{fs, net::TcpListener, task};
+use tokio::{net::TcpListener, task};
 use winterfell::Proof;
 
 // CONSTANTS
@@ -96,35 +96,25 @@ async fn main() {
 async fn seed_store(data_directory: PathBuf, num_accounts: usize) {
     let start = Instant::now();
 
-    let genesis_filepath = data_directory.join(GENESIS_STATE_FILENAME);
-    let database_filepath = data_directory.join(STORE_FILENAME);
-
-    // if the data_directory does not exist, create it
-    if !data_directory.exists() {
-        fs::create_dir_all(&data_directory)
-            .await
-            .expect("Failed to create data directory");
-    }
-
-    // if the database file exists, remove it
-    if database_filepath.exists() {
-        fs::remove_file(&database_filepath)
-            .await
-            .expect("Failed to remove database file");
-    }
+    // Recreate the data directory (it should be empty for store bootstrapping).
+    //
+    // Ignore the error since it will also error if it does not exist.
+    let _ = std::fs::remove_dir_all(&data_directory);
+    std::fs::create_dir_all(&data_directory).expect("created data directory");
 
     // generate the faucet account and the genesis state
     let faucet = create_faucet();
     let genesis_state = GenesisState::new(vec![faucet.clone()], 1, 1);
-    fs::write(&genesis_filepath, genesis_state.to_bytes())
-        .await
-        .expect("Failed to write genesis state");
+    Store::bootstrap(genesis_state.clone(), data_directory.clone())
+        .expect("store should bootstrap");
 
     // start the store
     let store_addr = {
         let grpc_store = TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind store");
         let store_addr = grpc_store.local_addr().expect("Failed to get store address");
-        let store = Store::init(grpc_store, data_directory).await.expect("Failed to init store");
+        let store = Store::init(grpc_store, data_directory.clone())
+            .await
+            .expect("Failed to init store");
         task::spawn(async move { store.serve().await.context("Serving store") });
         store_addr
     };
@@ -141,6 +131,7 @@ async fn seed_store(data_directory: PathBuf, num_accounts: usize) {
     };
 
     // start generating blocks
+    let database_filepath = data_directory.join(STORE_FILENAME);
     let genesis_header = genesis_state.into_block().unwrap().into_inner();
     let metrics =
         generate_blocks(num_accounts, faucet, genesis_header, &store_client, database_filepath)

--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -141,7 +141,7 @@ async fn seed_store(data_directory: PathBuf, num_accounts: usize) {
     };
 
     // start generating blocks
-    let genesis_header = genesis_state.into_block().unwrap();
+    let genesis_header = genesis_state.into_block().unwrap().into_inner();
     let metrics =
         generate_blocks(num_accounts, faucet, genesis_header, &store_client, database_filepath)
             .await;

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
+anyhow             = { workspace = true }
 deadpool           = { version = "0.12", features = ["managed", "rt_tokio_1"], default-features = false }
 deadpool-sync      = { version = "0.1" }
 hex                = { version = "0.4" }

--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -1,6 +1,9 @@
-use std::{io::ErrorKind, path::PathBuf};
+use std::{io::ErrorKind, ops::Not, path::PathBuf};
 
+use miden_lib::utils::Serializable;
 use miden_objects::block::BlockNumber;
+
+use crate::genesis::GenesisBlock;
 
 #[derive(Debug)]
 pub struct BlockStore {
@@ -8,8 +11,43 @@ pub struct BlockStore {
 }
 
 impl BlockStore {
-    pub async fn new(store_dir: PathBuf) -> Result<Self, std::io::Error> {
-        tokio::fs::create_dir_all(&store_dir).await?;
+    /// Creates a new [`BlockStore`], creating the directory and inserting the genesis block data.
+    ///
+    /// This _does not_ create any parent directories, so it is expected that the caller has already
+    /// created these.
+    ///
+    /// # Errors
+    ///
+    /// Uses [`std::fs::create_dir`] and therefore has the same error conditions.
+    pub fn bootstrap(store_dir: PathBuf, genesis_block: &GenesisBlock) -> std::io::Result<Self> {
+        std::fs::create_dir(&store_dir)?;
+
+        let block_store = Self { store_dir };
+        block_store.save_block_blocking(BlockNumber::GENESIS, &genesis_block.inner().to_bytes())?;
+
+        Ok(block_store)
+    }
+
+    /// Loads an existing [`BlockStore`].
+    ///
+    /// A new [`BlockStore`] can be created using [`BlockStore::bootstrap`].
+    ///
+    /// A best effort is made to ensure the directory exists and is accessible, but will still run
+    /// afoul of TOCTOU issues as these are impossible to rule out.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///   - the directory does not exist, or
+    ///   - the directory is not accessible, or
+    ///   - it is not a directory
+    ///
+    /// See also: [`std::fs::metadata`].
+    pub fn load(store_dir: PathBuf) -> std::io::Result<Self> {
+        let meta = std::fs::metadata(&store_dir)?;
+        if meta.is_dir().not() {
+            return Err(ErrorKind::NotADirectory.into());
+        }
 
         Ok(Self { store_dir })
     }
@@ -69,5 +107,9 @@ impl BlockStore {
         let epoch_path = block_path.parent().ok_or(std::io::Error::from(ErrorKind::NotFound))?;
 
         Ok((epoch_path.to_path_buf(), block_path))
+    }
+
+    pub fn display(&self) -> std::path::Display<'_> {
+        self.store_dir.display()
     }
 }

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -1,10 +1,9 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs::{self, create_dir_all},
     path::PathBuf,
-    sync::Arc,
 };
 
+use anyhow::Context;
 use miden_node_proto::{
     domain::account::{AccountInfo, AccountSummary},
     generated::note as proto,
@@ -15,7 +14,6 @@ use miden_objects::{
     crypto::{hash::rpo::RpoDigest, merkle::MerklePath, utils::Deserializable},
     note::{NoteId, NoteInclusionProof, NoteMetadata, Nullifier},
     transaction::TransactionId,
-    utils::Serializable,
 };
 use sql::utils::{column_value_as_u64, read_block_number};
 use tokio::sync::oneshot;
@@ -23,13 +21,12 @@ use tracing::{info, info_span, instrument};
 
 use crate::{
     COMPONENT,
-    blocks::BlockStore,
     db::{
         migrations::apply_migrations,
         pool_manager::{Pool, SqlitePoolManager},
     },
-    errors::{DatabaseError, DatabaseSetupError, GenesisError, NoteSyncError, StateSyncError},
-    genesis::GenesisState,
+    errors::{DatabaseError, DatabaseSetupError, NoteSyncError, StateSyncError},
+    genesis::GenesisBlock,
 };
 
 mod migrations;
@@ -187,21 +184,29 @@ impl From<NoteRecord> for NoteSyncRecord {
 }
 
 impl Db {
-    /// Open a connection to the DB, apply any pending migrations, and ensure that the genesis block
-    /// is as expected and present in the database.
-    // TODO: This span is logged in a root span, we should connect it to the parent one.
+    pub fn bootstrap(database_filepath: PathBuf, genesis: &GenesisBlock) -> anyhow::Result<()> {
+        // Create database.
+        //
+        // This will create the file if it does not exist, but will also happily open it if already
+        // exists. In the latter case we will error out when attempting to insert the genesis
+        // block so this isn't such a problem.
+        let mut conn = connection::Connection::open(database_filepath)
+            .context("failed to open a database connection")?;
+
+        // Run migrations.
+        apply_migrations(&mut conn).context("failed to apply database migrations")?;
+
+        // Insert genesis block data.
+        let db_tx = conn.transaction().context("failed to create database transaction")?;
+        let genesis = genesis.inner();
+        sql::apply_block(&db_tx, &genesis.header(), &[], &[], genesis.updated_accounts())
+            .context("failed to insert genesis block")?;
+        db_tx.commit().context("failed to commit database transaction")
+    }
+
+    /// Open a connection to the DB and apply any pending migrations.
     #[instrument(target = COMPONENT, skip_all)]
-    pub async fn setup(
-        database_filepath: PathBuf,
-        genesis_filepath: &str,
-        block_store: Arc<BlockStore>,
-    ) -> Result<Self, DatabaseSetupError> {
-        info!(target: COMPONENT, ?database_filepath, "Connecting to the database");
-
-        if let Some(p) = database_filepath.parent() {
-            create_dir_all(p).map_err(DatabaseError::IoError)?;
-        }
-
+    pub async fn load(database_filepath: PathBuf) -> Result<Self, DatabaseSetupError> {
         let sqlite_pool_manager = SqlitePoolManager::new(database_filepath.clone());
         let pool = Pool::builder(sqlite_pool_manager).build()?;
 
@@ -217,10 +222,7 @@ impl Db {
             DatabaseError::InteractError(format!("Migration task failed: {err}"))
         })??;
 
-        let db = Db { pool };
-        db.ensure_genesis_block(genesis_filepath, block_store).await?;
-
-        Ok(db)
+        Ok(Db { pool })
     }
 
     /// Loads all the nullifiers from the DB.
@@ -546,84 +548,5 @@ impl Db {
             .map_err(|err| {
                 DatabaseError::InteractError(format!("Database optimization task failed: {err}"))
             })?
-    }
-
-    // HELPERS
-    // ---------------------------------------------------------------------------------------------
-
-    /// If the database is empty, generates and stores the genesis block. Otherwise, it ensures that
-    /// the genesis block in the database is consistent with the genesis block data in the
-    /// genesis JSON file.
-    #[instrument(target = COMPONENT, skip_all, err)]
-    async fn ensure_genesis_block(
-        &self,
-        genesis_filepath: &str,
-        block_store: Arc<BlockStore>,
-    ) -> Result<(), GenesisError> {
-        let genesis_block = {
-            let file_contents = fs::read(genesis_filepath).map_err(|source| {
-                GenesisError::FailedToReadGenesisFile {
-                    genesis_filepath: genesis_filepath.to_string(),
-                    source,
-                }
-            })?;
-
-            let genesis_state = GenesisState::read_from_bytes(&file_contents)
-                .map_err(GenesisError::GenesisFileDeserializationError)?;
-
-            genesis_state.into_block()?
-        };
-
-        let maybe_block_header_in_store = self
-            .select_block_header_by_block_num(Some(BlockNumber::GENESIS))
-            .await
-            .map_err(|err| GenesisError::SelectBlockHeaderByBlockNumError(err.into()))?;
-
-        let expected_genesis_header = genesis_block.header().clone();
-
-        match maybe_block_header_in_store {
-            Some(block_header_in_store) => {
-                // ensure that expected header is what's also in the store
-                if expected_genesis_header != block_header_in_store {
-                    Err(GenesisError::GenesisBlockHeaderMismatch {
-                        expected_genesis_header: Box::new(expected_genesis_header),
-                        block_header_in_store: Box::new(block_header_in_store),
-                    })?;
-                }
-            },
-            None => {
-                // add genesis header to store
-                self.pool
-                    .get()
-                    .await
-                    .map_err(DatabaseError::MissingDbConnection)?
-                    .interact(move |conn| -> Result<()> {
-                        // TODO: This span is logged in a root span, we should connect it to the
-                        // parent one.
-                        let span = info_span!(target: COMPONENT, "write_genesis_block_to_db");
-                        let guard = span.enter();
-
-                        let transaction = conn.transaction()?;
-                        sql::apply_block(
-                            &transaction,
-                            &expected_genesis_header,
-                            &[],
-                            &[],
-                            genesis_block.updated_accounts(),
-                        )?;
-
-                        block_store.save_block_blocking(0.into(), &genesis_block.to_bytes())?;
-
-                        transaction.commit()?;
-
-                        drop(guard);
-                        Ok(())
-                    })
-                    .await
-                    .map_err(GenesisError::ApplyBlockFailed)??;
-            },
-        }
-
-        Ok(())
     }
 }

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -1,11 +1,10 @@
 use std::io;
 
 use deadpool::managed::PoolError;
-use deadpool_sync::InteractError;
 use miden_objects::{
     AccountDeltaError, AccountError, NoteError,
     account::AccountId,
-    block::{BlockHeader, BlockNumber},
+    block::BlockNumber,
     crypto::{
         hash::rpo::RpoDigest,
         merkle::{MerkleError, MmrError},
@@ -139,25 +138,6 @@ pub enum GenesisError {
     MerkleError(#[from] MerkleError),
     #[error("failed to deserialize genesis file")]
     GenesisFileDeserializationError(#[from] DeserializationError),
-    #[error("retrieving genesis block header failed")]
-    SelectBlockHeaderByBlockNumError(#[from] Box<DatabaseError>),
-
-    // OTHER ERRORS
-    // ---------------------------------------------------------------------------------------------
-    #[error("apply block failed")]
-    ApplyBlockFailed(#[source] InteractError),
-    #[error("failed to read genesis file \"{genesis_filepath}\"")]
-    FailedToReadGenesisFile {
-        genesis_filepath: String,
-        source: io::Error,
-    },
-    #[error(
-        "block header in store doesn't match block header in genesis file. Expected {expected_genesis_header:?}, but store contained {block_header_in_store:?}"
-    )]
-    GenesisBlockHeaderMismatch {
-        expected_genesis_header: Box<BlockHeader>,
-        block_header_in_store: Box<BlockHeader>,
-    },
 }
 
 // ENDPOINT ERRORS

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -14,7 +14,7 @@ use crate::errors::GenesisError;
 // ================================================================================================
 
 /// Represents the state at genesis, which will be used to derive the genesis block.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenesisState {
     pub accounts: Vec<Account>,
     pub version: u32,

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -21,13 +21,27 @@ pub struct GenesisState {
     pub timestamp: u32,
 }
 
+/// A type-safety wrapper ensuring that genesis block data can only be created from
+/// [`GenesisState`].
+pub struct GenesisBlock(ProvenBlock);
+
+impl GenesisBlock {
+    pub fn inner(&self) -> &ProvenBlock {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> ProvenBlock {
+        self.0
+    }
+}
+
 impl GenesisState {
     pub fn new(accounts: Vec<Account>, version: u32, timestamp: u32) -> Self {
         Self { accounts, version, timestamp }
     }
 
     /// Returns the block header and the account SMT
-    pub fn into_block(self) -> Result<ProvenBlock, GenesisError> {
+    pub fn into_block(self) -> Result<GenesisBlock, GenesisError> {
         let accounts: Vec<BlockAccountUpdate> = self
             .accounts
             .iter()
@@ -75,12 +89,12 @@ impl GenesisState {
         // SAFETY: Header and accounts should be valid by construction.
         // No notes or nullifiers are created at genesis, which is consistent with the above empty
         // block note tree root and empty nullifier tree root.
-        Ok(ProvenBlock::new_unchecked(
+        Ok(GenesisBlock(ProvenBlock::new_unchecked(
             header,
             accounts,
             empty_output_notes,
             empty_nullifiers,
-        ))
+        )))
     }
 }
 

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -14,7 +14,6 @@ pub use server::Store;
 // CONSTANTS
 // =================================================================================================
 const COMPONENT: &str = "miden-store";
-pub const GENESIS_STATE_FILENAME: &str = "genesis.dat";
 
 /// Number of sql statements that each connection will cache.
 const SQL_STATEMENT_CACHE_CAPACITY: usize = 32;

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -1,16 +1,19 @@
 use std::time::Duration;
 
 mod blocks;
-pub mod db;
-pub mod errors;
-pub mod genesis;
+mod db;
+mod errors;
+mod genesis;
 mod nullifier_tree;
-pub mod server;
-pub mod state;
+mod server;
+mod state;
+
+pub use genesis::GenesisState;
+pub use server::Store;
 
 // CONSTANTS
 // =================================================================================================
-pub const COMPONENT: &str = "miden-store";
+const COMPONENT: &str = "miden-store";
 pub const GENESIS_STATE_FILENAME: &str = "genesis.dat";
 
 /// Number of sql statements that each connection will cache.

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{ops::Not, path::PathBuf, sync::Arc};
 
+use anyhow::Context;
 use miden_node_proto::generated::store::api_server;
 use miden_node_utils::{errors::ApiError, tracing::grpc::store_trace_fn};
 use tokio::net::TcpListener;
@@ -8,7 +9,7 @@ use tower_http::trace::TraceLayer;
 use tracing::info;
 
 use crate::{
-    COMPONENT, DATABASE_MAINTENANCE_INTERVAL, GENESIS_STATE_FILENAME, blocks::BlockStore, db::Db,
+    COMPONENT, DATABASE_MAINTENANCE_INTERVAL, GenesisState, blocks::BlockStore, db::Db,
     server::db_maintenance::DbMaintenance, state::State,
 };
 
@@ -28,23 +29,45 @@ pub struct Store {
 }
 
 impl Store {
+    /// Bootstraps the Store, creating the database state and inserting the genesis block data.
+    pub fn bootstrap(genesis: GenesisState, data_directory: PathBuf) -> anyhow::Result<()> {
+        let genesis = genesis
+            .into_block()
+            .context("failed to convert genesis configuration into the genesis block")?;
+
+        let data_directory = DataDirectory::load(data_directory.clone()).with_context(|| {
+            format!("failed to load data directory at {}", data_directory.display())
+        })?;
+        tracing::info!(target=COMPONENT, path=%data_directory.display(), "Data directory loaded");
+
+        let block_store = data_directory.block_store_dir();
+        let block_store =
+            BlockStore::bootstrap(block_store.clone(), &genesis).with_context(|| {
+                format!("failed to bootstrap block store at {}", block_store.display())
+            })?;
+        tracing::info!(target=COMPONENT, path=%block_store.display(), "Block store created");
+
+        // Create the genesis block and insert it into the database.
+        let database_filepath = data_directory.database_path();
+        Db::bootstrap(database_filepath.clone(), &genesis).with_context(|| {
+            format!("failed to bootstrap database at {}", database_filepath.display())
+        })?;
+        tracing::info!(target=COMPONENT, path=%database_filepath.display(), "Database created");
+
+        Ok(())
+    }
+
     /// Performs initialization tasks required before [`serve`](Self::serve) can be called.
     pub async fn init(listener: TcpListener, data_directory: PathBuf) -> Result<Self, ApiError> {
         info!(target: COMPONENT, endpoint=?listener, ?data_directory, "Loading database");
 
-        let block_store = data_directory.join("blocks");
-        let block_store = Arc::new(BlockStore::new(block_store).await?);
+        let data_directory = DataDirectory::load(data_directory)?;
 
-        let database_filepath = data_directory.join("miden-store.sqlite3");
-        let genesis_filepath = data_directory.join(GENESIS_STATE_FILENAME);
+        let block_store = Arc::new(BlockStore::load(data_directory.block_store_dir())?);
 
-        let db = Db::setup(
-            database_filepath,
-            &genesis_filepath.to_string_lossy(),
-            Arc::clone(&block_store),
-        )
-        .await
-        .map_err(|err| ApiError::ApiInitialisationFailed(err.to_string()))?;
+        let db = Db::load(data_directory.database_path())
+            .await
+            .map_err(|err| ApiError::ApiInitialisationFailed(err.to_string()))?;
 
         let state = Arc::new(
             State::load(db, block_store)
@@ -77,5 +100,35 @@ impl Store {
             .serve_with_incoming(TcpListenerStream::new(self.listener))
             .await
             .map_err(ApiError::ApiServeFailed)
+    }
+}
+
+/// Represents the store's data-directory and its content paths.
+///
+/// Used to keep our filepath assumptions in one location.
+struct DataDirectory(PathBuf);
+
+impl DataDirectory {
+    /// Creates a new [`DataDirectory`], ensuring that the directory exists and is accessible
+    /// insofar as is possible.
+    fn load(path: PathBuf) -> std::io::Result<Self> {
+        let meta = std::fs::metadata(&path)?;
+        if meta.is_dir().not() {
+            return Err(std::io::ErrorKind::NotConnected.into());
+        }
+
+        Ok(Self(path))
+    }
+
+    fn block_store_dir(&self) -> PathBuf {
+        self.0.join("blocks")
+    }
+
+    fn database_path(&self) -> PathBuf {
+        self.0.join("miden-store.sqlite3")
+    }
+
+    fn display(&self) -> std::path::Display<'_> {
+        self.0.display()
     }
 }

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -78,11 +78,6 @@ impl Blockchain {
         block_number.into()
     }
 
-    /// Returns the chain length.
-    pub fn chain_length(&self) -> BlockNumber {
-        self.chain_tip().child()
-    }
-
     /// Returns the current peaks of the MMR.
     pub fn peaks(&self) -> MmrPeaks {
         self.0.peaks()

--- a/docs/src/operator/usage.md
+++ b/docs/src/operator/usage.md
@@ -32,11 +32,11 @@ mkdir accounts
 
 # Bootstrap the node.
 #
-# This generates the genesis data and stores it in `<data-directory>/genesis.dat`.
-# This is used by the node to create and verify the database during node startup.
+# This creates the node's database and initializes it with the genesis data.
 #
-# Account secrets are stored as `<accounts-directory>/account_xx.mac`
-# where `xx` is the index of the account in the configuration file.
+# Account secrets generated as part of the genesis block are stored
+# as `<accounts-directory>/account_xx.mac` where `xx` is the index of the account
+# in the configuration file.
 #
 # These account files are not used by the node and should instead be used wherever
 # you intend to operate these accounts,


### PR DESCRIPTION
This PR moves the database initialization procedure from node/store startup, to the bootstrap command.

This feels more natural and also removes the need for the temporary `genesis.dat` file that was floating about. 

Closes #767.