### PR TITLE
Update to use `TransactionHeader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.9.0 (TBD)
 
-
+- Adapt to the use of `TransactionHeader` in batches and blocks (#781).
 
 ## v0.8.0 (2025-03-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v0.9.0 (TBD)
 
-- Adapt to the use of `TransactionHeader` in batches and blocks (#781).
 
 ## v0.8.0 (2025-03-26)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
 dependencies = [
  "miden-crypto",
  "miden-lib",
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2378,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
 dependencies = [
  "async-trait",
  "getrandom 0.3.2",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2472,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2550,9 +2550,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "29c72f6929239626840b28f919ce8981a317fc5dc63ce25c30d2ab372f94886f"
 dependencies = [
  "adler2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,11 +370,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core 0.5.2",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -424,12 +424,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.3.1",
  "http-body",
  "http-body-util",
@@ -548,9 +548,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake3"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1538,6 +1538,7 @@ dependencies = [
  "http 1.3.1",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1547,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1557,7 +1558,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -1793,10 +1794,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -2023,9 +2025,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-air"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72269e041e915d6c34325a8906f08a8ff6ec9b92c79ae07f3a0de8c3588694b5"
+checksum = "00e2e77c57ae798e02553af158c04d467f6479ab798a8c84459d343a89ff9c50"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -2035,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5680a0e75470389b65cc00900422ad7e1aa7972477c75ff88f63c3a01671e9"
+checksum = "75d1cb02d807c2481f365feca966bedb74c66c765923d04c3c23ea678afaf148"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -2054,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
 dependencies = [
  "miden-crypto",
  "miden-lib",
@@ -2064,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ba125a31e9ec0e732f47e639525c753973e553126cfc46cc63674049ea4134"
+checksum = "d7d408e01421b5df2e4cfaf1a91efefe3fb5b729f1c99b668d3a69eec0044a6b"
 dependencies = [
  "lock_api",
  "loom",
@@ -2107,7 +2109,7 @@ name = "miden-faucet"
 version = "0.8.1"
 dependencies = [
  "anyhow",
- "axum 0.8.1",
+ "axum 0.8.3",
  "clap",
  "fantoccini",
  "http 1.3.1",
@@ -2147,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2378,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
@@ -2398,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5f362138a7bfe6c20246de651e848566843a0d5062cc4a7a8ebff6bd14668d"
+checksum = "d4e70b053c587014396d06be3502e3952777923bee11729b7514c060fdc0d2c8"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2411,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6531711c8f3e25be9c607f82fc456594aba061acd3cde1df5d23eed88579340"
+checksum = "2baa571449e7811e934dae919285dfea4854fb867f6d20d757d60b0601ef0140"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -2425,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
 dependencies = [
  "async-trait",
  "getrandom 0.3.2",
@@ -2444,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116d30a8db5167f88944509007b8bb7aad4fa0d9d03f2610b4e80be3a198ad37"
+checksum = "77e59c4dd1079bffe8407694b386ae781feaf1f7acb9d1cefa858578bc99cad4"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2455,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2472,7 +2474,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#2409baa4b5e80a4e8a9e69779c02eaaa6aee20b9"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2484,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae6636d1e7a9d78a973fd59ffcfd87964eee235ecdf3264569add5ff89b0d91"
+checksum = "20ae024b022569d7117891a83cf51ccd5bceeda248f30690b394a6dfc4607061"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2738,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
@@ -3471,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -3775,9 +3777,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3808,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938d512196766101d333398efde81bc1f37b00cb42c2f8350e5df639f040bbbe"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
@@ -3903,7 +3905,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -3943,7 +3945,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -4854,24 +4856,28 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]
@@ -4886,10 +4892,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4912,13 +4940,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,9 +2053,8 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d1c33a2f543adb8a3f0425f540a4f4607ea5a61f681be2fe6f59d8fe53e356"
+version = "0.9.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
 dependencies = [
  "miden-crypto",
  "miden-lib",
@@ -2147,9 +2146,8 @@ dependencies = [
 
 [[package]]
 name = "miden-lib"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea3fdad9ad0e50f71f4be0e27479d2de800a9b9262810d0cbedaea30e3f450b"
+version = "0.9.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2379,9 +2377,8 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea350fdd6d025d2e4791ac0769bfbc04afca404fbb20f918354dcc758debd4c"
+version = "0.9.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
@@ -2427,9 +2424,8 @@ dependencies = [
 
 [[package]]
 name = "miden-proving-service-client"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272e6749ad8a146ff62dc621f396021d347257d948eac26e4493c0b9d3d341"
+version = "0.9.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
 dependencies = [
  "async-trait",
  "getrandom 0.3.2",
@@ -2458,9 +2454,8 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f253174345a55a08229cc7eb0094f290d515c0a39f46eb807881da4ce40c9e"
+version = "0.9.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2476,9 +2471,8 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c23d17fca6ad1ad88fcafd1cf4744523aac0b4d95fe3bfb5dad61f468424a5"
+version = "0.9.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#fb028b95182116e9dcfc404485f4c3c53713cc2b"
 dependencies = [
  "miden-core",
  "miden-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#85374fee025650465d3155b1261f4ca15ced7282"
 dependencies = [
  "miden-crypto",
  "miden-lib",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#85374fee025650465d3155b1261f4ca15ced7282"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#85374fee025650465d3155b1261f4ca15ced7282"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#85374fee025650465d3155b1261f4ca15ced7282"
 dependencies = [
  "async-trait",
  "getrandom 0.3.2",
@@ -2210,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#85374fee025650465d3155b1261f4ca15ced7282"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=pgackst-verified-tx#55087f2f17361e6e25cc29b9235eb5e07244036c"
+source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#85374fee025650465d3155b1261f4ca15ced7282"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2305,9 +2305,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c72f6929239626840b28f919ce8981a317fc5dc63ce25c30d2ab372f94886f"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ assert_matches            = { version = "1.5" }
 http                      = { version = "1.3" }
 itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.13" }
-miden-lib                 = { version = "0.8" }
+miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.9" }
 miden-node-proto          = { path = "crates/proto", version = "0.9" }
 miden-node-proto-build    = { path = "proto", version = "0.9" }
@@ -43,9 +43,9 @@ miden-node-rpc            = { path = "crates/rpc", version = "0.9" }
 miden-node-store          = { path = "crates/store", version = "0.9" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.9" }
-miden-objects             = { version = "0.8" }
+miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
 miden-processor           = { version = "0.13" }
-miden-tx                  = { version = "0.8" }
+miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
 thiserror                 = { version = "2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ assert_matches            = { version = "1.5" }
 http                      = { version = "1.3" }
 itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.13" }
-miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.9" }
 miden-node-proto          = { path = "crates/proto", version = "0.9" }
 miden-node-proto-build    = { path = "proto", version = "0.9" }
@@ -43,9 +43,9 @@ miden-node-rpc            = { path = "crates/rpc", version = "0.9" }
 miden-node-store          = { path = "crates/store", version = "0.9" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.9" }
-miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 miden-processor           = { version = "0.13" }
-miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
 thiserror                 = { version = "2.0", default-features = false }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive", "string"] }
 miden-air = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = [
+miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", features = [
   "testing",
 ] }
 miden-lib = { workspace = true }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -16,18 +16,20 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
-anyhow                    = { workspace = true }
-clap                      = { version = "4.5", features = ["derive", "string"] }
-miden-air                 = { workspace = true }
-miden-block-prover        = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = ["testing"] }
-miden-lib                 = { workspace = true }
+anyhow = { workspace = true }
+clap = { version = "4.5", features = ["derive", "string"] }
+miden-air = { workspace = true }
+miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = [
+  "testing",
+] }
+miden-lib = { workspace = true }
 miden-node-block-producer = { workspace = true }
-miden-node-proto          = { workspace = true }
-miden-node-store          = { workspace = true }
-miden-node-utils          = { workspace = true }
-miden-objects             = { workspace = true, features = ["testing"] }
-rand                      = { version = "0.9" }
-rayon                     = { version = "1.5" }
-tokio                     = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tonic                     = { workspace = true }
-winterfell                = { version = "0.12" }
+miden-node-proto = { workspace = true }
+miden-node-store = { workspace = true }
+miden-node-utils = { workspace = true }
+miden-objects = { workspace = true, features = ["testing"] }
+rand = { version = "0.9" }
+rayon = { version = "1.5" }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tonic = { workspace = true }
+winterfell = { version = "0.12" }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 anyhow                    = { workspace = true }
 clap                      = { version = "4.5", features = ["derive", "string"] }
 miden-air                 = { workspace = true }
-miden-block-prover        = { version = "0.8", features = ["testing"] }
+miden-block-prover        = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = ["testing"] }
 miden-lib                 = { workspace = true }
 miden-node-block-producer = { workspace = true }
 miden-node-proto          = { workspace = true }

--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -34,8 +34,8 @@ use miden_objects::{
     },
     note::{Note, NoteHeader, NoteId, NoteInclusionProof},
     transaction::{
-        InputNote, InputNotes, OutputNote, ProvenTransaction, ProvenTransactionBuilder,
-        TransactionHeader,
+        InputNote, InputNotes, OrderedTransactionHeaders, OutputNote, ProvenTransaction,
+        ProvenTransactionBuilder, TransactionHeader,
     },
     vm::ExecutionProof,
 };
@@ -356,7 +356,7 @@ fn create_batch(txs: &[ProvenTransaction], block_ref: &BlockHeader) -> ProvenBat
         InputNotes::new(input_notes).unwrap(),
         output_notes,
         BlockNumber::from(u32::MAX),
-        txs.iter().map(TransactionHeader::from).collect(),
+        OrderedTransactionHeaders::new_unchecked(txs.iter().map(TransactionHeader::from).collect()),
     )
 }
 

--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -33,7 +33,10 @@ use miden_objects::{
         rand::RpoRandomCoin,
     },
     note::{Note, NoteHeader, NoteId, NoteInclusionProof},
-    transaction::{InputNote, InputNotes, OutputNote, ProvenTransaction, ProvenTransactionBuilder},
+    transaction::{
+        InputNote, InputNotes, OutputNote, ProvenTransaction, ProvenTransactionBuilder,
+        TransactionHeader,
+    },
     vm::ExecutionProof,
 };
 use rand::Rng;
@@ -359,6 +362,7 @@ fn create_batch(txs: &[ProvenTransaction], block_ref: &BlockHeader) -> ProvenBat
         InputNotes::new(input_notes).unwrap(),
         output_notes,
         BlockNumber::from(u32::MAX),
+        txs.iter().map(TransactionHeader::from).collect(),
     )
 }
 

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -21,15 +21,15 @@ tracing-forest = ["miden-node-utils/tracing-forest"]
 async-trait                  = { version = "0.1" }
 futures                      = { version = "0.3" }
 itertools                    = { workspace = true }
-miden-block-prover           = { version = "0.8" }
+miden-block-prover           = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
 miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-utils             = { workspace = true }
 miden-objects                = { workspace = true }
 miden-processor              = { workspace = true }
-miden-proving-service-client = { version = "0.8", features = ["batch-prover", "block-prover"] }
+miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = ["batch-prover", "block-prover"] }
 miden-tx                     = { workspace = true }
-miden-tx-batch-prover        = { version = "0.8" }
+miden-tx-batch-prover        = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
 rand                         = { version = "0.9" }
 thiserror                    = { workspace = true }
 tokio                        = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -18,26 +18,29 @@ workspace = true
 tracing-forest = ["miden-node-utils/tracing-forest"]
 
 [dependencies]
-async-trait                  = { version = "0.1" }
-futures                      = { version = "0.3" }
-itertools                    = { workspace = true }
-miden-block-prover           = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
-miden-lib                    = { workspace = true }
-miden-node-proto             = { workspace = true }
-miden-node-utils             = { workspace = true }
-miden-objects                = { workspace = true }
-miden-processor              = { workspace = true }
-miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = ["batch-prover", "block-prover"] }
-miden-tx                     = { workspace = true }
-miden-tx-batch-prover        = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
-rand                         = { version = "0.9" }
-thiserror                    = { workspace = true }
-tokio                        = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tokio-stream                 = { workspace = true, features = ["net"] }
-tonic                        = { workspace = true, features = ["transport"] }
-tower-http                   = { workspace = true, features = ["util"] }
-tracing                      = { workspace = true }
-url                          = { workspace = true }
+async-trait = { version = "0.1" }
+futures = { version = "0.3" }
+itertools = { workspace = true }
+miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+miden-lib = { workspace = true }
+miden-node-proto = { workspace = true }
+miden-node-utils = { workspace = true }
+miden-objects = { workspace = true }
+miden-processor = { workspace = true }
+miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = [
+  "batch-prover",
+  "block-prover",
+] }
+miden-tx = { workspace = true }
+miden-tx-batch-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+rand = { version = "0.9" }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { workspace = true, features = ["net"] }
+tonic = { workspace = true, features = ["transport"] }
+tower-http = { workspace = true, features = ["util"] }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 assert_matches        = { workspace = true }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -21,18 +21,18 @@ tracing-forest = ["miden-node-utils/tracing-forest"]
 async-trait = { version = "0.1" }
 futures = { version = "0.3" }
 itertools = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 miden-lib = { workspace = true }
 miden-node-proto = { workspace = true }
 miden-node-utils = { workspace = true }
 miden-objects = { workspace = true }
 miden-processor = { workspace = true }
-miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx", features = [
+miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", features = [
   "batch-prover",
   "block-prover",
 ] }
 miden-tx = { workspace = true }
-miden-tx-batch-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-verified-tx" }
+miden-tx-batch-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
 rand = { version = "0.9" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -319,8 +319,11 @@ impl TelemetryInjectorExt for ProposedBlock {
                 .expect("should have less than u32::MAX output notes"),
         );
 
-        let num_batch_created_notes =
-            self.batches().iter().fold(0, |acc, batch| acc + batch.output_notes().len());
+        let num_batch_created_notes = self
+            .batches()
+            .as_slice()
+            .iter()
+            .fold(0, |acc, batch| acc + batch.output_notes().len());
         span.set_attribute(
             "block.batches.output_notes.count",
             u32::try_from(num_batch_created_notes)

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -50,7 +50,7 @@ impl AuthenticatedTransaction {
         inputs: TransactionInputs,
     ) -> Result<AuthenticatedTransaction, VerifyTxError> {
         let nullifiers_already_spent = tx
-            .get_nullifiers()
+            .nullifiers()
             .filter(|nullifier| inputs.nullifiers.get(nullifier).copied().flatten().is_some())
             .collect::<Vec<_>>();
         if !nullifiers_already_spent.is_empty() {
@@ -86,7 +86,7 @@ impl AuthenticatedTransaction {
     }
 
     pub fn nullifiers(&self) -> impl Iterator<Item = Nullifier> + '_ {
-        self.inner.get_nullifiers()
+        self.inner.nullifiers()
     }
 
     pub fn output_notes(&self) -> impl Iterator<Item = NoteId> + '_ {
@@ -109,7 +109,7 @@ impl AuthenticatedTransaction {
     /// not authenticated by the store inputs.
     pub fn unauthenticated_notes(&self) -> impl Iterator<Item = NoteId> + '_ {
         self.inner
-            .get_unauthenticated_notes()
+            .unauthenticated_notes()
             .copied()
             .map(|header| header.id())
             .filter(|note_id| !self.notes_authenticated_by_store.contains(note_id))
@@ -143,7 +143,7 @@ impl AuthenticatedTransaction {
         let inputs = TransactionInputs {
             account_id: inner.account_id(),
             account_commitment: store_account_state,
-            nullifiers: inner.get_nullifiers().map(|nullifier| (nullifier, None)).collect(),
+            nullifiers: inner.nullifiers().map(|nullifier| (nullifier, None)).collect(),
             found_unauthenticated_notes: BTreeSet::default(),
             current_block_height: 0.into(),
         };

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -163,9 +163,9 @@ impl StoreClient {
     ) -> Result<TransactionInputs, StoreError> {
         let message = GetTransactionInputsRequest {
             account_id: Some(proven_tx.account_id().into()),
-            nullifiers: proven_tx.get_nullifiers().map(Into::into).collect(),
+            nullifiers: proven_tx.nullifiers().map(Into::into).collect(),
             unauthenticated_notes: proven_tx
-                .get_unauthenticated_notes()
+                .unauthenticated_notes()
                 .map(|note| note.id().into())
                 .collect(),
         };

--- a/crates/block-producer/src/test_utils/batch.rs
+++ b/crates/block-producer/src/test_utils/batch.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     Digest,
     batch::{BatchAccountUpdate, BatchId, ProvenBatch},
     block::BlockNumber,
-    transaction::{InputNotes, ProvenTransaction},
+    transaction::{InputNotes, ProvenTransaction, TransactionHeader},
 };
 
 use crate::test_utils::MockProvenTxBuilder;
@@ -57,13 +57,14 @@ impl TransactionBatchConstructor for ProvenBatch {
         }
 
         ProvenBatch::new_unchecked(
-            BatchId::from_transactions(txs.into_iter()),
+            BatchId::from_transactions(txs.iter().copied()),
             Digest::default(),
             BlockNumber::GENESIS,
             account_updates,
             InputNotes::new_unchecked(input_notes),
             output_notes,
             BlockNumber::from(u32::MAX),
+            txs.into_iter().map(TransactionHeader::from).collect(),
         )
     }
 

--- a/crates/block-producer/src/test_utils/batch.rs
+++ b/crates/block-producer/src/test_utils/batch.rs
@@ -4,7 +4,7 @@ use miden_objects::{
     Digest,
     batch::{BatchAccountUpdate, BatchId, ProvenBatch},
     block::BlockNumber,
-    transaction::{InputNotes, ProvenTransaction, TransactionHeader},
+    transaction::{InputNotes, OrderedTransactionHeaders, ProvenTransaction, TransactionHeader},
 };
 
 use crate::test_utils::MockProvenTxBuilder;
@@ -64,7 +64,9 @@ impl TransactionBatchConstructor for ProvenBatch {
             InputNotes::new_unchecked(input_notes),
             output_notes,
             BlockNumber::from(u32::MAX),
-            txs.into_iter().map(TransactionHeader::from).collect(),
+            OrderedTransactionHeaders::new_unchecked(
+                txs.into_iter().map(TransactionHeader::from).collect(),
+            ),
         )
     }
 

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -7,7 +7,7 @@ use miden_objects::{
     },
     crypto::merkle::{Mmr, SimpleSmt},
     note::Nullifier,
-    transaction::OutputNote,
+    transaction::{OrderedTransactionHeaders, OutputNote},
 };
 
 use super::MockStoreSuccess;
@@ -149,7 +149,7 @@ impl MockBlockBuilder {
             self.updated_accounts.unwrap_or_default(),
             created_notes,
             self.produced_nullifiers.unwrap_or_default(),
-            vec![],
+            OrderedTransactionHeaders::new_unchecked(vec![]),
         )
     }
 }

--- a/crates/block-producer/src/test_utils/block.rs
+++ b/crates/block-producer/src/test_utils/block.rs
@@ -149,6 +149,7 @@ impl MockBlockBuilder {
             self.updated_accounts.unwrap_or_default(),
             created_notes,
             self.produced_nullifiers.unwrap_or_default(),
+            vec![],
         )
     }
 }

--- a/crates/block-producer/src/test_utils/store.rs
+++ b/crates/block-producer/src/test_utils/store.rs
@@ -276,7 +276,7 @@ impl MockStoreSuccess {
 
         let locked_notes = self.notes.read().await;
         let found_unauthenticated_notes = proven_tx
-            .get_unauthenticated_notes()
+            .unauthenticated_notes()
             .filter_map(|header| {
                 let id = header.id();
                 locked_notes.contains_key(&id).then_some(id)

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -492,6 +492,7 @@ impl Db {
                     &notes,
                     block.created_nullifiers(),
                     block.updated_accounts(),
+                    block.transactions(),
                 )?;
 
                 let _ = allow_acquire.send(());
@@ -626,6 +627,7 @@ impl Db {
                             &[],
                             &[],
                             genesis_block.updated_accounts(),
+                            &[],
                         )?;
 
                         block_store.save_block_blocking(0.into(), &genesis_block.to_bytes())?;

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -208,8 +208,15 @@ impl Db {
         // Insert genesis block data.
         let db_tx = conn.transaction().context("failed to create database transaction")?;
         let genesis = genesis.inner();
-        sql::apply_block(&db_tx, genesis.header(), &[], &[], genesis.updated_accounts())
-            .context("failed to insert genesis block")?;
+        sql::apply_block(
+            &db_tx,
+            genesis.header(),
+            &[],
+            &[],
+            genesis.updated_accounts(),
+            genesis.transactions(),
+        )
+        .context("failed to insert genesis block")?;
         db_tx.commit().context("failed to commit database transaction")
     }
 

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -22,7 +22,7 @@ use miden_objects::{
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNumber},
     crypto::{hash::rpo::RpoDigest, merkle::MerklePath},
     note::{NoteExecutionMode, NoteId, NoteInclusionProof, NoteMetadata, NoteType, Nullifier},
-    transaction::TransactionId,
+    transaction::{TransactionHeader, TransactionId},
     utils::serde::{Deserializable, Serializable},
 };
 use rusqlite::{params, types::Value};
@@ -1084,7 +1084,7 @@ pub fn select_all_block_headers(transaction: &Transaction) -> Result<Vec<BlockHe
 pub fn insert_transactions(
     transaction: &Transaction,
     block_num: BlockNumber,
-    accounts: &[BlockAccountUpdate],
+    transactions: &[TransactionHeader],
 ) -> Result<usize> {
     let mut stmt = transaction.prepare_cached(insert_sql!(transactions {
         transaction_id,
@@ -1092,15 +1092,12 @@ pub fn insert_transactions(
         block_num
     }))?;
     let mut count = 0;
-    for update in accounts {
-        let account_id = update.account_id();
-        for transaction_id in update.transactions() {
-            count += stmt.execute(params![
-                transaction_id.to_bytes(),
-                account_id.to_bytes(),
-                block_num.as_u32()
-            ])?;
-        }
+    for tx in transactions {
+        count += stmt.execute(params![
+            tx.id().to_bytes(),
+            tx.account_id().to_bytes(),
+            block_num.as_u32()
+        ])?;
     }
     Ok(count)
 }
@@ -1231,13 +1228,14 @@ pub fn apply_block(
     notes: &[(NoteRecord, Option<Nullifier>)],
     nullifiers: &[Nullifier],
     accounts: &[BlockAccountUpdate],
+    transactions: &[TransactionHeader],
 ) -> Result<usize> {
     let mut count = 0;
     // Note: ordering here is important as the relevant tables have FK dependencies.
     count += insert_block_header(transaction, block_header)?;
     count += upsert_accounts(transaction, accounts, block_header.block_num())?;
     count += insert_notes(transaction, notes)?;
-    count += insert_transactions(transaction, block_header.block_num(), accounts)?;
+    count += insert_transactions(transaction, block_header.block_num(), transactions)?;
     count += insert_nullifiers_for_block(transaction, nullifiers, block_header.block_num())?;
     Ok(count)
 }

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -22,7 +22,7 @@ use miden_objects::{
         ACCOUNT_ID_PRIVATE_SENDER, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET, ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
     },
-    transaction::{TransactionHeader, TransactionId},
+    transaction::{OrderedTransactionHeaders, TransactionHeader, TransactionId},
 };
 
 use super::{AccountInfo, NoteRecord, NullifierInfo, sql};
@@ -1146,7 +1146,7 @@ fn insert_transactions(conn: &mut Connection) -> usize {
         mock_block_transaction(AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(), 1);
     let mock_tx2 =
         mock_block_transaction(AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(), 2);
-    let transactions = vec![mock_tx1, mock_tx2];
+    let transactions = OrderedTransactionHeaders::new_unchecked(vec![mock_tx1, mock_tx2]);
 
     sql::upsert_accounts(&transaction, &account_updates, block_num).unwrap();
 

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -22,6 +22,7 @@ use miden_objects::{
         ACCOUNT_ID_PRIVATE_SENDER, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
         ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET, ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
     },
+    transaction::{TransactionHeader, TransactionId},
 };
 
 use super::{AccountInfo, NoteRecord, NullifierInfo, sql};
@@ -348,7 +349,6 @@ fn sql_unconsumed_network_notes() {
             account_id,
             account.commitment(),
             AccountUpdateDetails::New(account),
-            vec![],
         )],
         block_num,
     )
@@ -478,7 +478,6 @@ fn sql_select_accounts() {
                 account_id,
                 account_commitment,
                 AccountUpdateDetails::Private,
-                vec![],
             )],
             block_num,
         );
@@ -524,7 +523,6 @@ fn sql_public_account_details() {
             account.id(),
             account.commitment(),
             AccountUpdateDetails::New(account.clone()),
-            vec![],
         )],
         1.into(),
     )
@@ -572,7 +570,6 @@ fn sql_public_account_details() {
             account.id(),
             account.commitment(),
             AccountUpdateDetails::Delta(delta2.clone()),
-            vec![],
         )],
         2.into(),
     )
@@ -618,7 +615,6 @@ fn sql_public_account_details() {
             account.id(),
             account.commitment(),
             AccountUpdateDetails::Delta(delta3.clone()),
-            vec![],
         )],
         3.into(),
     )
@@ -903,7 +899,6 @@ fn db_account() {
             account_id.try_into().unwrap(),
             account_commitment,
             AccountUpdateDetails::Private,
-            vec![],
         )],
         block_num,
     )
@@ -1111,11 +1106,30 @@ fn num_to_nullifier(n: u64) -> Nullifier {
 }
 
 fn mock_block_account_update(account_id: AccountId, num: u64) -> BlockAccountUpdate {
-    BlockAccountUpdate::new(
+    BlockAccountUpdate::new(account_id, num_to_rpo_digest(num), AccountUpdateDetails::Private)
+}
+
+fn mock_block_transaction(account_id: AccountId, num: u64) -> TransactionHeader {
+    let initial_state_commitment = RpoDigest::try_from([num, 0, 0, 0]).unwrap();
+    let final_account_commitment = RpoDigest::try_from([0, num, 0, 0]).unwrap();
+    let input_notes_commitment = RpoDigest::try_from([0, 0, num, 0]).unwrap();
+    let output_notes_commitment = RpoDigest::try_from([0, 0, 0, num]).unwrap();
+
+    TransactionHeader::new_unchecked(
+        TransactionId::new(
+            initial_state_commitment,
+            final_account_commitment,
+            input_notes_commitment,
+            output_notes_commitment,
+        ),
         account_id,
-        num_to_rpo_digest(num),
-        AccountUpdateDetails::Private,
-        vec![num_to_rpo_digest(num + 1000).into(), num_to_rpo_digest(num + 1001).into()],
+        initial_state_commitment,
+        final_account_commitment,
+        vec![num_to_nullifier(num)],
+        vec![NoteId::new(
+            RpoDigest::try_from([num, num, 0, 0]).unwrap(),
+            RpoDigest::try_from([0, 0, num, num]).unwrap(),
+        )],
     )
 }
 
@@ -1124,15 +1138,19 @@ fn insert_transactions(conn: &mut Connection) -> usize {
     create_block(conn, block_num);
 
     let transaction = conn.transaction().unwrap();
+    let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
 
-    let account_updates = vec![mock_block_account_update(
-        AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(),
-        1,
-    )];
+    let account_updates = vec![mock_block_account_update(account_id, 1)];
+
+    let mock_tx1 =
+        mock_block_transaction(AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(), 1);
+    let mock_tx2 =
+        mock_block_transaction(AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(), 2);
+    let transactions = vec![mock_tx1, mock_tx2];
 
     sql::upsert_accounts(&transaction, &account_updates, block_num).unwrap();
 
-    let count = sql::insert_transactions(&transaction, block_num, &account_updates).unwrap();
+    let count = sql::insert_transactions(&transaction, block_num, &transactions).unwrap();
     transaction.commit().unwrap();
 
     count

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -38,12 +38,7 @@ impl GenesisState {
                     AccountUpdateDetails::Private
                 };
 
-                BlockAccountUpdate::new(
-                    account.id(),
-                    account.commitment(),
-                    account_update_details,
-                    vec![],
-                )
+                BlockAccountUpdate::new(account.id(), account.commitment(), account_update_details)
             })
             .collect();
 
@@ -57,6 +52,8 @@ impl GenesisState {
 
         let empty_output_notes = Vec::new();
         let empty_block_note_tree = BlockNoteTree::empty();
+
+        let empty_transactions = Vec::new();
 
         let header = BlockHeader::new(
             self.version,
@@ -80,6 +77,7 @@ impl GenesisState {
             accounts,
             empty_output_notes,
             empty_nullifiers,
+            empty_transactions,
         ))
     }
 }

--- a/crates/store/src/genesis.rs
+++ b/crates/store/src/genesis.rs
@@ -5,6 +5,7 @@ use miden_objects::{
     block::{BlockAccountUpdate, BlockHeader, BlockNoteTree, BlockNumber, ProvenBlock},
     crypto::merkle::{MmrPeaks, SimpleSmt, Smt},
     note::Nullifier,
+    transaction::OrderedTransactionHeaders,
     utils::serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
@@ -67,7 +68,7 @@ impl GenesisState {
         let empty_output_notes = Vec::new();
         let empty_block_note_tree = BlockNoteTree::empty();
 
-        let empty_transactions = Vec::new();
+        let empty_transactions = OrderedTransactionHeaders::new_unchecked(Vec::new());
 
         let header = BlockHeader::new(
             self.version,

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -239,7 +239,9 @@ impl State {
 
         let header = block.header();
 
-        let tx_commitment = BlockHeader::compute_tx_commitment(block.transactions());
+        let tx_commitment = BlockHeader::compute_tx_commitment(
+            block.transactions().iter().map(|tx| (tx.id(), tx.account_id())),
+        );
         if header.tx_commitment() != tx_commitment {
             return Err(InvalidBlockError::InvalidBlockTxCommitment {
                 expected: tx_commitment,

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -235,7 +235,7 @@ impl State {
         let header = block.header();
 
         let tx_commitment = BlockHeader::compute_tx_commitment(
-            block.transactions().iter().map(|tx| (tx.id(), tx.account_id())),
+            block.transactions().as_slice().iter().map(|tx| (tx.id(), tx.account_id())),
         );
         if header.tx_commitment() != tx_commitment {
             return Err(InvalidBlockError::InvalidBlockTxCommitment {


### PR DESCRIPTION
Update usages of account updates and batch and block to use the newly introduced `TransactionHeader` from https://github.com/0xPolygonMiden/miden-base/pull/1247.

These are relatively minor updates. I think the only thing worth calling out is the insertion of the transactions into the DB. Currently the table has these fields:

```sql
CREATE TABLE transactions (
    transaction_id BLOB    NOT NULL,
    account_id     BLOB    NOT NULL,
    block_num      INTEGER NOT NULL,
```

We could insert more data here from the `TransactionHeader`, but how exactly depends on some details I'm not familiar with, like should we insert notes into this table and reference them via a foreign key or is that a bad idea because we remove notes from the notes table when they're consumed?.

If we want to support the explorer to get the transactions of a block, then we probably have to insert the full headers?