### PR TITLE
chore: fix cargo clippy warning

### DIFF
--- a/crates/utils/src/tracing/span_ext.rs
+++ b/crates/utils/src/tracing/span_ext.rs
@@ -106,7 +106,7 @@ where
         let mut report = err.to_string();
 
         std::iter::successors(err.source(), |child| child.source())
-            .for_each(|source| report.push_str(&format!("\nCaused by: {source}")));
+            .for_each(|source| write!(report, "\nCaused by: {source}").unwrap());
 
         tracing_opentelemetry::OpenTelemetrySpanExt::set_status(
             self,


### PR DESCRIPTION
Running cargo clippy reports the following error.


```shell
warning: `format!(..)` appended to existing `String`
   --> crates/utils/src/tracing/span_ext.rs:109:32
    |
109 |             .for_each(|source| report.push_str(&format!("
Caused by: {source}")));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `write!` to avoid the extra allocation
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
    = note: `-W clippy::format-push-string` implied by `-W clippy::pedantic`
    = help: to override `-W clippy::pedantic` add `#[allow(clippy::format_push_string)]`

warning: `miden-node-utils` (lib) generated 1 warning
```


This commit resolves the issue.