### PR TITLE
feat: crate to start node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Data directory is no longer created but is instead expected to exist.
   - The genesis block can no longer be configured which also removes the `store dump-genesis` command.
 
+### Enhancements
+
+- Introduced the crate `node-builder` to programatically start nodes (#789).
+
 ## v0.8.0 (2025-03-26)
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-node-builder"
+version = "0.9.0"
+dependencies = [
+ "anyhow",
+ "miden-node-block-producer",
+ "miden-node-rpc",
+ "miden-node-store",
+ "miden-node-utils",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "miden-node-proto"
 version = "0.9.0"
 dependencies = [
@@ -3459,6 +3474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3788,7 +3812,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "bin/node",
   "bin/stress-test",
   "crates/block-producer",
+  "crates/node-builder",
   "crates/proto",
   "crates/rpc",
   "crates/store",

--- a/crates/node-builder/Cargo.toml
+++ b/crates/node-builder/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+authors.workspace      = true
+description            = "A library for programmatically starting up Miden node components"
+edition.workspace      = true
+homepage.workspace     = true
+keywords               = ["miden", "node", "protobuf", "rpc"]
+license.workspace      = true
+name                   = "miden-node-builder"
+readme                 = "README.md"
+repository.workspace   = true
+rust-version.workspace = true
+version.workspace      = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow                    = "1.0"
+miden-node-block-producer = { path = "../block-producer" }
+miden-node-rpc            = { path = "../rpc" }
+miden-node-store          = { path = "../store" }
+miden-node-utils          = { path = "../utils" }
+tokio                     = { version = "1.0", features = ["full"] }
+tracing                   = "0.1"
+url                       = "2.0"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/crates/node-builder/README.md
+++ b/crates/node-builder/README.md
@@ -1,0 +1,75 @@
+# Miden Node Builder
+
+A builder crate for configuring and starting a Miden node with all its components. This crate provides a convenient way to initialize and manage a complete Miden node instance.
+
+## Features
+
+- Configurable node components initialization
+- Support for both local and remote provers
+- Configurable block and batch intervals
+- Telemetry support
+- Graceful component management
+
+## Usage
+
+```rust
+use miden_node_builder::NodeBuilder;
+use std::path::PathBuf;
+use std::time::Duration;
+use url::Url;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Create a new node builder
+    let builder = NodeBuilder::new(PathBuf::from("./data"))
+        // Optional: Configure batch prover URL
+        .with_batch_prover_url(Url::parse("http://localhost:8080")?)
+        // Optional: Configure block prover URL
+        .with_block_prover_url(Url::parse("http://localhost:8081")?)
+        // Optional: Configure block interval
+        .with_block_interval(Duration::from_millis(1000))
+        // Optional: Configure batch interval
+        .with_batch_interval(Duration::from_millis(1000))
+        // Optional: Enable telemetry
+        .with_telemetry(true);
+
+    // Start the node
+    let node_handle = builder.start().await?;
+
+    // Get the RPC URL
+    println!("RPC server listening at: {}", node_handle.rpc_url());
+
+    // ... do something with the node ...
+
+    // Stop the node when done
+    node_handle.stop().await?;
+
+    Ok(())
+}
+```
+
+For a complete working example, see the `simple.rs` example in the crate's source code.
+
+## Components
+
+The builder initializes and manages the following components:
+
+1. **Store**: Manages the node's state and data persistence
+2. **Block Producer**: Handles block production and validation
+3. **RPC Server**: Provides an interface for interacting with the node
+
+## Configuration Options
+
+- `data_directory`: Path to store node data
+- `batch_prover_url`: URL for the batch prover service (optional)
+- `block_prover_url`: URL for the block prover service (optional)
+- `block_interval`: Duration between block production attempts
+- `batch_interval`: Duration between batch production attempts
+- `enable_telemetry`: Whether to enable telemetry collection
+
+## Error Handling
+
+The crate uses `anyhow::Result` for error handling, providing detailed error messages when something goes wrong. All component failures are treated as fatal and will cause the node to stop.
+
+## License
+This project is [MIT licensed](../../LICENSE).

--- a/crates/node-builder/examples/simple.rs
+++ b/crates/node-builder/examples/simple.rs
@@ -1,0 +1,30 @@
+#![recursion_limit = "256"]
+use std::time::Duration;
+
+use anyhow::Result;
+use miden_node_builder::NodeBuilder;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create a temporary directory for the node's data
+    let data_dir = tempfile::tempdir()?.into_path();
+
+    // Create a node builder with default settings
+    let node = NodeBuilder::new(data_dir)
+        .with_block_interval(Duration::from_millis(1000))
+        .with_batch_interval(Duration::from_millis(1000))
+        .with_telemetry(true);
+
+    // Start the node
+    let handle = node.start().await?;
+    println!("Node started at {}", handle.rpc_url());
+
+    // Wait for 10 seconds
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // Stop the node
+    handle.stop().await?;
+    println!("Node stopped");
+
+    Ok(())
+}

--- a/crates/node-builder/src/lib.rs
+++ b/crates/node-builder/src/lib.rs
@@ -1,0 +1,181 @@
+use std::{collections::HashMap, path::PathBuf, time::Duration};
+
+use anyhow::{Context, Result};
+use miden_node_block_producer::server::BlockProducer;
+use miden_node_rpc::server::Rpc;
+use miden_node_store::{GenesisState, Store};
+use tokio::{net::TcpListener, task::JoinSet};
+use url::Url;
+
+// NODE BUILDER
+// ================================================================================================
+
+/// Builder for configuring and starting a Miden node with all components.
+pub struct NodeBuilder {
+    data_directory: PathBuf,
+    batch_prover_url: Option<Url>,
+    block_prover_url: Option<Url>,
+    block_interval: Duration,
+    batch_interval: Duration,
+    enable_telemetry: bool,
+}
+
+impl NodeBuilder {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new [`NodeBuilder`] with default settings.
+    pub fn new(data_directory: PathBuf) -> Self {
+        Self {
+            data_directory,
+            batch_prover_url: None,
+            block_prover_url: None,
+            block_interval: Duration::from_millis(1000),
+            batch_interval: Duration::from_millis(1000),
+            enable_telemetry: false,
+        }
+    }
+
+    // CONFIGURATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Sets the batch prover URL.
+    #[must_use]
+    pub fn with_batch_prover_url(mut self, url: Url) -> Self {
+        self.batch_prover_url = Some(url);
+        self
+    }
+
+    /// Sets the block prover URL.
+    #[must_use]
+    pub fn with_block_prover_url(mut self, url: Url) -> Self {
+        self.block_prover_url = Some(url);
+        self
+    }
+
+    /// Sets the block production interval.
+    #[must_use]
+    pub fn with_block_interval(mut self, interval: Duration) -> Self {
+        self.block_interval = interval;
+        self
+    }
+
+    /// Sets the batch production interval.
+    #[must_use]
+    pub fn with_batch_interval(mut self, interval: Duration) -> Self {
+        self.batch_interval = interval;
+        self
+    }
+
+    /// Enables or disables telemetry.
+    #[must_use]
+    pub fn with_telemetry(mut self, enable: bool) -> Self {
+        self.enable_telemetry = enable;
+        self
+    }
+
+    // START
+    // --------------------------------------------------------------------------------------------
+
+    /// Starts all node components and returns a handle to manage them.
+    pub async fn start(self) -> Result<NodeHandle> {
+        miden_node_utils::logging::setup_tracing(
+            miden_node_utils::logging::OpenTelemetry::Disabled,
+        )?;
+        let mut join_set = JoinSet::new();
+
+        // Create a store component
+        let store_listener = TcpListener::bind("127.0.0.1:50051").await?;
+        let store_addr = store_listener.local_addr()?;
+        let genesis = GenesisState::new(vec![], 0, 0);
+        Store::bootstrap(genesis, &self.data_directory).context("failed to bootstrap store")?;
+        let store = Store::init(store_listener, self.data_directory)
+            .await
+            .context("failed to initialize store")?;
+        let store_id =
+            join_set.spawn(async move { store.serve().await.context("Serving store") }).id();
+
+        // Create a block producer component
+        let block_producer_listener = TcpListener::bind("127.0.0.1:50052").await?;
+        let block_producer_addr = block_producer_listener.local_addr()?;
+        let block_producer = BlockProducer::init(
+            block_producer_listener,
+            store_addr,
+            self.block_prover_url,
+            self.batch_prover_url,
+            self.block_interval,
+            self.batch_interval,
+        )
+        .await
+        .context("failed to initialize block producer")
+        .unwrap();
+        let block_producer_id = join_set
+            .spawn(async move { block_producer.serve().await.context("Serving block-producer") })
+            .id();
+
+        // Create an RPC component
+        let rpc_listener = TcpListener::bind("127.0.0.1:50053").await?;
+        let rpc = Rpc::init(rpc_listener, store_addr, block_producer_addr)
+            .await
+            .context("failed to initialize RPC")?;
+
+        let rpc_id = join_set.spawn(async move { rpc.serve().await.context("Serving RPC") }).id();
+
+        // Lookup table so we can identify the failed component.
+        let component_ids = HashMap::from([
+            (store_id, "store"),
+            (block_producer_id, "block-producer"),
+            (rpc_id, "rpc"),
+        ]);
+
+        // SAFETY: The joinset is definitely not empty.
+        let component_result = join_set.join_next_with_id().await.unwrap();
+
+        // We expect components to run indefinitely, so we treat any return as fatal.
+        //
+        // Map all outcomes to an error, and provide component context.
+        let (id, err) = match component_result {
+            Ok((id, Ok(_))) => (id, Err(anyhow::anyhow!("Component completed unexpectedly"))),
+            Ok((id, Err(err))) => (id, Err(err)),
+            Err(join_err) => (join_err.id(), Err(join_err).context("Joining component task")),
+        };
+        let component = component_ids.get(&id).unwrap_or(&"unknown");
+
+        // We could abort and gracefully shutdown the other components, but since we're crashing the
+        // node there is no point.
+
+        err.context(format!("Component {component} failed"))
+    }
+}
+
+// NODE HANDLE
+// ================================================================================================
+
+/// Handle to manage running node components.
+pub struct NodeHandle {
+    rpc_url: String,
+    rpc_handle: tokio::task::JoinHandle<()>,
+    block_producer_handle: tokio::task::JoinHandle<()>,
+    store_handle: tokio::task::JoinHandle<()>,
+}
+
+impl NodeHandle {
+    /// Returns the URL where the RPC server is listening.
+    pub fn rpc_url(&self) -> &str {
+        &self.rpc_url
+    }
+
+    /// Stops all node components.
+    pub async fn stop(self) -> Result<()> {
+        self.rpc_handle.abort();
+        self.block_producer_handle.abort();
+        self.store_handle.abort();
+
+        // Wait for the tasks to complete
+        let _ = self.rpc_handle.await;
+        let _ = self.block_producer_handle.await;
+        let _ = self.store_handle.await;
+
+        Ok(())
+    }
+}

--- a/docs/src/developer/codebase.md
+++ b/docs/src/developer/codebase.md
@@ -8,6 +8,7 @@ instead simply serve to enforce code organisation and decoupling.
 
 | Crate            | Description                                                                                                                                              |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `node-builder`   | A builder crate that provides a programmatic way to configure and start Miden nodes with all their components.                                           |
 | `node`           | The node executable. Configure and run the node and its components.                                                                                      |
 | `faucet`         | A reference faucet app implementation used by the official Miden faucet.                                                                                 |
 | `block-producer` | Block-producer component implementation.                                                                                                                 |
@@ -17,7 +18,6 @@ instead simply serve to enforce code organisation and decoupling.
 | `rpc-proto`      | Contains the RPC protobuf definitions. Currently this is an awkward clone of `proto` because we re-use the definitions from the internal protobuf types. |
 | `utils`          | Variety of utility functionality.                                                                                                                        |
 | `test-macro`     | Provides a procedural macro to enable tracing in tests.                                                                                                  |
-
 
 -------
 


### PR DESCRIPTION
On the client side, we used node to run integration tests, and when it came time to add it to the CI (and considering that we always rely on using the latest version available in the `next` branch), we decided to clone the repository and compile the binary. The latter caused long compilation times in the CI, and we had to add a sketchy cache. To resolve this, I created the `miden-node-builder` crate, which contains two main methods: starting the node with all its components and stopping it.