### PR TITLE
Add trace unit tests for block-producer mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -2128,6 +2129,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand 0.9.1",
  "serde",
+ "tokio",
  "tonic",
  "tracing",
  "tracing-forest",
@@ -3296,6 +3298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,6 +3326,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "security-framework"
@@ -3437,6 +3454,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -24,7 +24,7 @@ itertools = { workspace = true }
 miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-partial-blockchain" }
 miden-lib = { workspace = true }
 miden-node-proto = { workspace = true }
-miden-node-utils = { workspace = true }
+miden-node-utils = { workspace = true, features = ["testing"] }
 miden-objects = { workspace = true }
 miden-processor = { workspace = true }
 miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "pgackst-partial-blockchain", features = [
@@ -51,6 +51,7 @@ miden-objects         = { workspace = true, features = ["testing"] }
 miden-tx              = { workspace = true, features = ["testing"] }
 pretty_assertions     = "1.4"
 rand_chacha           = { version = "0.9", default-features = false }
+serial_test           = "3.2"
 tempfile              = { version = "3.5" }
 tokio                 = { workspace = true, features = ["test-util"] }
 winterfell            = { version = "0.12" }

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -384,7 +384,7 @@ impl Mempool {
     ///
     /// Returns an error if any transaction was not in the transaction graph i.e. if the transaction
     /// is unknown.
-    #[instrument(target = COMPONENT, name = "mempool.revert_transactions", skip_all, fields(transactions.ids))]
+    #[instrument(target = COMPONENT, name = "mempool.revert_transactions", skip_all, fields(transactions.expired.ids))]
     fn revert_transactions(
         &mut self,
         txs: Vec<TransactionId>,

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -1,5 +1,6 @@
 use miden_objects::block::BlockNumber;
 use pretty_assertions::assert_eq;
+use serial_test::serial;
 
 use super::*;
 use crate::test_utils::{MockProvenTxBuilder, batch::TransactionBatchConstructor};
@@ -14,6 +15,55 @@ impl Mempool {
             u32::default(),
         )
     }
+}
+
+// OTEL TRACE TESTS
+// ================================================================================================
+
+#[tokio::test]
+#[serial(open_telemetry_tracing)]
+async fn add_transaction_traces_are_correct() {
+    let (mut rx_export, _rx_shutdown) = miden_node_utils::logging::setup_test_tracing().unwrap();
+
+    let mut uut = Mempool::for_tests();
+    let txs = MockProvenTxBuilder::sequential();
+    uut.add_transaction(txs[0].clone()).unwrap();
+
+    let span_data = rx_export.recv().await.unwrap();
+    assert_eq!(span_data.name, "mempool.add_transaction");
+    assert!(span_data.attributes.iter().any(|kv| kv.key == "code.namespace".into()
+        && kv.value == "miden_node_block_producer::mempool".into()));
+    assert!(
+        span_data
+            .attributes
+            .iter()
+            .any(|kv| kv.key == "tx".into() && kv.value.to_string().starts_with("0x"))
+    );
+}
+
+#[tokio::test]
+#[serial(open_telemetry_tracing)]
+async fn revert_transactions_traces_are_correct() {
+    let (mut rx_export, _rx_shutdown) = miden_node_utils::logging::setup_test_tracing().unwrap();
+
+    let mut uut = Mempool::for_tests();
+    let txs = MockProvenTxBuilder::sequential();
+    uut.add_transaction(txs[0].clone()).unwrap();
+    let span_data = rx_export.recv().await.unwrap();
+    assert_eq!(span_data.name, "mempool.add_transaction");
+
+    uut.revert_transactions(vec![txs[0].id()]).unwrap();
+    let span_data = rx_export.recv().await.unwrap();
+    assert_eq!(span_data.name, "mempool.revert_transactions");
+    assert!(span_data.attributes.iter().any(|kv| kv.key == "code.namespace".into()
+        && kv.value == "miden_node_block_producer::mempool".into()));
+
+    assert!(
+        span_data
+            .attributes
+            .iter()
+            .any(|kv| kv.key == "transactions.expired.ids".into())
+    );
 }
 
 // BATCH FAILED TESTS

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -17,6 +17,8 @@ workspace = true
 [features]
 # Enables depedencies intended for build script generation of version metadata.
 vergen = ["dep:vergen", "dep:vergen-gitcl"]
+# Enables utility functions for testing traces created by some other crate's stack.
+testing = ["dep:tokio"]
 
 [dependencies]
 anyhow                = { workspace = true }
@@ -40,3 +42,5 @@ url                   = { workspace = true }
 # This must match the version expected by `vergen-gitcl`.
 vergen       = { "version" = "9.0", optional = true }
 vergen-gitcl = { version = "1.0", features = ["cargo", "rustc"], optional = true }
+# Optional dependencies enabled by `testing` feature.
+tokio = { workspace = true, optional = true }

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -57,6 +57,30 @@ pub fn setup_tracing(otel: OpenTelemetry) -> Result<()> {
     tracing::subscriber::set_global_default(subscriber).map_err(Into::into)
 }
 
+/// Initializes tracing to a test exporter.
+///
+/// Allows trace content to be inspected via the returned receiver.
+///
+/// All tests that use this function must be annotated with `#[serial(open_telemetry_tracing)]`.
+/// This forces serialization of all such tests. Otherwise, the tested spans could
+/// be interleaved during runtime. Also, the global exporter could be re-initialized in
+/// the middle of a concurrently running test.
+#[cfg(feature = "testing")]
+pub fn setup_test_tracing() -> Result<(
+    tokio::sync::mpsc::UnboundedReceiver<opentelemetry_sdk::trace::SpanData>,
+    tokio::sync::mpsc::UnboundedReceiver<()>,
+)> {
+    let (exporter, rx_export, rx_shutdown) =
+        opentelemetry_sdk::testing::trace::new_tokio_test_exporter();
+
+    let otel_layer = open_telemetry_layer(exporter);
+    let subscriber = Registry::default()
+        .with(stdout_layer().with_filter(env_or_default_filter()))
+        .with(otel_layer.with_filter(env_or_default_filter()));
+    tracing::subscriber::set_global_default(subscriber)?;
+    Ok((rx_export, rx_shutdown))
+}
+
 fn open_telemetry_layer<S>(
     exporter: impl SpanExporter + 'static,
 ) -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>


### PR DESCRIPTION
Relates to #725

### Changes
- Adds support for testing trace content via `miden_node_utils::logging::setup_test_tracing()`.
- Imports the [serial_test](https://crates.io/crates/serial_test) crate for testing purposes.
- Adds tests to block-producer crate's mempool module and fixes instrumentation typo.