### PR TITLE
ci: test on beta toolchain

### DIFF
--- a/.github/workflows/test-beta.yml
+++ b/.github/workflows/test-beta.yml
@@ -1,0 +1,18 @@
+name: Beta toolchain
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Everyday at 06:00am UTC
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@next
+      - name: Rustup
+        run: rustup install beta && rustup default beta
+      - uses: taiki-e/install-action@nextest 
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
Fix #691

Placing into a separated file to allow an independent execution that doesn't affect other jobs. Runs every day at 06:00am UTC.

AFAICT cron jobs target the current active branch, which already is `next`.

Although nice, IMO it shouldn't be necessary to test against beta toolchains because an official team already does it in every new pre-release. For example, https://github.com/rust-lang/rust/issues/139827.
