### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2404,13 +2404,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3560,7 +3560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3751,9 +3751,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ miden-tx                  = { version = "0.9" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
 thiserror                 = { default-features = false, version = "2.0" }
-tokio                     = { features = ["rt-multi-thread"], version = "1.44" }
+tokio                     = { features = ["rt-multi-thread"], version = "1.45" }
 tokio-stream              = { version = "0.1" }
 tonic                     = { version = "0.12" }
 tower                     = { version = "0.5" }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -27,7 +27,7 @@ miden-node-store          = { workspace = true }
 miden-node-utils          = { workspace = true }
 miden-objects             = { features = ["testing"], workspace = true }
 rand                      = { workspace = true }
-rayon                     = { version = "1.5" }
+rayon                     = { version = "1.10" }
 tokio                     = { workspace = true }
 tonic                     = { workspace = true }
 winterfell                = { version = "0.12" }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -52,6 +52,6 @@ miden-tx              = { features = ["testing"], workspace = true }
 pretty_assertions     = "1.4"
 rand_chacha           = { default-features = false, version = "0.9" }
 serial_test           = "3.2"
-tempfile              = { version = "3.5" }
+tempfile              = { version = "3.20" }
 tokio                 = { features = ["test-util"], workspace = true }
 winterfell            = { version = "0.12" }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -24,7 +24,7 @@ thiserror        = { workspace = true }
 tonic            = { workspace = true }
 
 [dev-dependencies]
-proptest = { version = "1.5" }
+proptest = { version = "1.6" }
 
 [build-dependencies]
 anyhow                 = { workspace = true }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -37,4 +37,4 @@ url              = { workspace = true }
 miden-node-rpc   = { workspace = true }
 miden-node-store = { workspace = true }
 miden-node-utils = { features = ["tracing-forest"], workspace = true }
-tempfile         = { version = "3.5" }
+tempfile         = { version = "3.20" }


### PR DESCRIPTION
Updates dependencies.

I tried to update the above mentioned dependencies, now that the opentelemetry 0.30 version is out. Sadly, we are not limited by tokio's tracing-opentelemetry, since it does not supports the latest opentelemetry yet. This PR their repo updates it https://github.com/tokio-rs/tracing-opentelemetry/pull/205 . Opened https://github.com/0xMiden/miden-node/pull/879 updating some other dependencies.