### PR TITLE
refactor: Add async to proving-service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,12 @@ BUILD_PROTO=BUILD_PROTO=1
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo clippy --locked --all-targets --all-features --workspace --exclude miden-proving-service -- -D warnings # miden-tx async feature on.
-	cargo clippy --locked --all-targets --all-features -p miden-proving-service -- -D warnings # miden-tx async feature off.
+	cargo clippy --locked --all-targets --all-features --workspace
 
 
 .PHONY: fix
 fix: ## Runs Fix with configs
-	cargo fix --allow-staged --allow-dirty --all-targets --all-features --workspace --exclude miden-proving-service # miden-tx async feature on.
-	cargo fix --allow-staged --allow-dirty --all-targets --all-features -p miden-proving-service # miden-tx async feature off.
+	cargo fix --allow-staged --allow-dirty --all-targets --all-features --workspace
 
 
 .PHONY: format
@@ -65,22 +63,19 @@ book: ## Builds the book & serves documentation site
 
 .PHONY: test
 test:  ## Runs all tests
-	cargo nextest run --all-features --workspace --exclude miden-proving-service # miden-tx async feature on.
-	cargo nextest run --all-features -p miden-proving-service # miden-tx async feature off.
+	cargo nextest run --all-features --workspace
 
 # --- checking ------------------------------------------------------------------------------------
 
 .PHONY: check
 check: ## Check all targets and features for errors without code generation
-	${BUILD_PROTO} cargo check --all-features --all-targets --locked --workspace --exclude miden-proving-service # miden-tx async feature on.
-	${BUILD_PROTO} cargo check --all-features --all-targets --locked -p miden-proving-service  # miden-tx async feature off
+	${BUILD_PROTO} cargo check --all-features --all-targets --locked --workspace
 
 # --- building ------------------------------------------------------------------------------------
 
 .PHONY: build
 build: ## Builds all crates and re-builds ptotobuf bindings for proto crates
-	${BUILD_PROTO} cargo build --locked --workspace --exclude miden-proving-service # miden-tx async feature on.
-	${BUILD_PROTO} cargo build --locked -p miden-proving-service  # miden-tx async feature off
+	${BUILD_PROTO} cargo build --locked --workspace
 	${BUILD_PROTO} cargo build --locked -p miden-proving-service-client --target wasm32-unknown-unknown --no-default-features  # no-std compatible build
 
 # --- installing ----------------------------------------------------------------------------------

--- a/bin/proving-service/Cargo.toml
+++ b/bin/proving-service/Cargo.toml
@@ -31,7 +31,7 @@ miden-block-prover                 = { workspace = true }
 miden-lib                          = { workspace = true }
 miden-node-utils                   = { workspace = true }
 miden-objects                      = { features = ["std"], workspace = true }
-miden-tx                           = { features = ["std"], workspace = true }
+miden-tx                           = { features = ["async", "std"], workspace = true }
 miden-tx-batch-prover              = { features = ["std"], workspace = true }
 opentelemetry                      = { features = ["metrics", "trace"], version = "0.30" }
 opentelemetry-otlp                 = { features = ["grpc-tonic"], version = "0.30" }
@@ -62,7 +62,7 @@ uuid                               = { features = ["v4"], version = "1.16" }
 [dev-dependencies]
 miden-lib     = { features = ["testing"], workspace = true }
 miden-objects = { features = ["testing"], workspace = true }
-miden-testing = { workspace = true }
+miden-testing = { features = ["async"], workspace = true }
 miden-tx      = { features = ["testing"], workspace = true }
 [build-dependencies]
 miette      = { features = ["fancy"], version = "7.5" }

--- a/bin/proving-service/src/main.rs
+++ b/bin/proving-service/src/main.rs
@@ -105,7 +105,7 @@ mod test {
             .tx_script(tx_script)
             .build();
 
-        let executed_transaction = tx_context.execute().unwrap();
+        let executed_transaction = tx_context.execute().await.unwrap();
 
         let transaction_witness = TransactionWitness::from(executed_transaction);
 


### PR DESCRIPTION
Closes #978.

WIP

Might not work or might require changes to upstream crate that has `maybe_async` macro.