### PR TITLE
fix typo: "depIyed" → "deployed" in genesis block comment

### DIFF
--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -192,7 +192,7 @@ impl StoreCommand {
         // to be deployed. An account is deployed onchain along with its first transaction which
         // results in a non-zero nonce onchain.
         //
-        // The genesis block is special in that accounts are "deplyed" without transactions and
+        // The genesis block is special in that accounts are "deployed" without transactions and
         // therefore we need bump the nonce manually to uphold this invariant.
         let (id, vault, sorage, code, _) = account.into_parts();
         let updated_account = Account::from_parts(id, vault, sorage, code, ONE);


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a minor typo in the `StoreCommand` implementation comment, changing "depIyed" to "deployed" for improved clarity and professionalism in documentation.