### PR TITLE
ci: restrict workflow permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   typos:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-beta.yml
+++ b/.github/workflows/test-beta.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 6 * * *" # Everyday at 06:00am UTC
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 # Limits workflow concurrency to only the latest commit in the PR.
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"


### PR DESCRIPTION
Sets the workflow permissions to the lowest setting (`read`) for those workflows without any set.

This fixes a bunch of the security complaints from the github bot.