### PR TITLE
adjust to latest clippy lints and rust doc quotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ url                = { features = ["serde"], version = "2.5" }
 pedantic = { level = "warn", priority = -1 }
 
 cast_possible_truncation     = "allow" # Overly many instances especially regarding indices.
+collapsible-if               = "allow" # Too new to enforce.
 from_iter_instead_of_collect = "allow" # at times `FromIter` is much more readable
 ignored_unit_patterns        = "allow" # Stylistic choice.
 large_types_passed_by_value  = "allow" # Triggered by BlockHeader being Copy + 334 bytes.
@@ -96,5 +97,6 @@ missing_errors_doc           = "allow" # TODO: fixup and enable this.
 missing_panics_doc           = "allow" # TODO: fixup and enable this.
 module_name_repetitions      = "allow" # Many triggers, and is a stylistic choice.
 must_use_candidate           = "allow" # This marks many fn's which isn't helpful.
+needless_for_each            = "allow" # Context dependent if that's useful.
 should_panic_without_expect  = "allow" # We don't care about the specific panic message.
 # End of pedantic lints.

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -443,16 +443,15 @@ impl Faucet {
     ) -> MintResult<ExecutedTransaction> {
         let executor =
             TransactionExecutor::new(self.data_store.as_ref(), Some(&self.authenticator));
-        executor
-            .execute_transaction(
-                self.id.account_id,
-                BlockNumber::GENESIS,
-                InputNotes::default(),
-                tx_args,
-                Arc::new(DefaultSourceManager::default()),
-            )
-            .await
-            .map_err(MintError::Execution)
+        Box::pin(executor.execute_transaction(
+            self.id.account_id,
+            BlockNumber::GENESIS,
+            InputNotes::default(),
+            tx_args,
+            Arc::new(DefaultSourceManager::default()),
+        ))
+        .await
+        .map_err(MintError::Execution)
     }
 
     async fn submit_transaction(

--- a/bin/remote-prover/src/commands/update_workers.rs
+++ b/bin/remote-prover/src/commands/update_workers.rs
@@ -46,7 +46,7 @@ pub enum Action {
     Remove,
 }
 
-/// Update workers in the proxy performing the specified [Action]
+/// Update workers in the proxy performing the specified [`Action`]
 #[derive(Debug, Parser, Clone, Serialize, Deserialize)]
 pub struct UpdateWorkers {
     pub action: Action,

--- a/bin/remote-prover/src/proxy/health_check.rs
+++ b/bin/remote-prover/src/proxy/health_check.rs
@@ -7,7 +7,7 @@ use tracing::{debug_span, error};
 
 use super::LoadBalancerState;
 
-/// Implement the BackgroundService trait for the LoadBalancer
+/// Implement the `BackgroundService` trait for the `LoadBalancer`
 ///
 /// A [BackgroundService] can be run as part of a Pingora application to add supporting logic that
 /// exists outside of the request/response lifecycle.

--- a/bin/remote-prover/src/proxy/mod.rs
+++ b/bin/remote-prover/src/proxy/mod.rs
@@ -350,21 +350,21 @@ pub struct LoadBalancer(pub Arc<LoadBalancerState>);
 /// Implements load-balancing of incoming requests across a pool of workers.
 ///
 /// At the backend-level, a request lifecycle works as follows:
-/// - When a new requests arrives, [LoadBalancer::request_filter()] method is called. In this method
-///   we apply IP-based rate-limiting to the request and check if the request queue is full. In this
-///   method we also handle the special case update workers request.
-/// - Next, the [Self::upstream_peer()] method is called. We use it to figure out which worker will
-///   process the request. Inside `upstream_peer()`, we add the request to the queue of requests.
-///   Once the request gets to the front of the queue, we forward it to an available worker. This
-///   step is also in charge of setting the SNI, timeouts, and enabling HTTP/2. Finally, we
-///   establish a connection with the worker.
+/// - When a new requests arrives, [`LoadBalancer::request_filter()`] method is called. In this
+///   method we apply IP-based rate-limiting to the request and check if the request queue is full.
+///   In this method we also handle the special case update workers request.
+/// - Next, the [`Self::upstream_peer()`] method is called. We use it to figure out which worker
+///   will process the request. Inside `upstream_peer()`, we add the request to the queue of
+///   requests. Once the request gets to the front of the queue, we forward it to an available
+///   worker. This step is also in charge of setting the SNI, timeouts, and enabling HTTP/2.
+///   Finally, we establish a connection with the worker.
 /// - Before sending the request to the upstream server and if the connection succeed, the
-///   [Self::upstream_request_filter()] method is called. In this method, we ensure that the correct
-///   headers are forwarded for gRPC requests.
-/// - If the connection fails, the [Self::fail_to_connect()] method is called. In this method, we
-///   retry the request [self.max_retries_per_request] times.
+///   [`Self::upstream_request_filter()`] method is called. In this method, we ensure that the
+///   correct headers are forwarded for gRPC requests.
+/// - If the connection fails, the [`Self::fail_to_connect()`] method is called. In this method, we
+///   retry the request [`self.max_retries_per_request`] times.
 /// - Once the worker processes the request (either successfully or with a failure),
-///   [Self::logging()] method is called. In this method, we log the request lifecycle and set the
+///   [`Self::logging()`] method is called. In this method, we log the request lifecycle and set the
 ///   worker as available.
 #[async_trait]
 impl ProxyHttp for LoadBalancer {
@@ -446,14 +446,14 @@ impl ProxyHttp for LoadBalancer {
         Ok(false)
     }
 
-    /// Returns [HttpPeer] corresponding to the worker that will handle the current request.
+    /// Returns [`HttpPeer`] corresponding to the worker that will handle the current request.
     ///
     /// Here we enqueue the request and wait for it to be at the front of the queue and a worker
     /// becomes available, then we dequeue the request and process it. We then set the SNI,
     /// timeouts, and enable HTTP/2.
     ///
     /// Note that the request will be assigned a worker here, and the worker will be removed from
-    /// the list of available workers once it reaches the [Self::logging] method.
+    /// the list of available workers once it reaches the [`Self::logging`] method.
     #[tracing::instrument(name = "proxy.upstream_peer", parent = &ctx.parent_span, skip(_session))]
     async fn upstream_peer(
         &self,
@@ -512,7 +512,7 @@ impl ProxyHttp for LoadBalancer {
     ///
     /// Here we ensure that the correct headers are forwarded for gRPC requests.
     ///
-    /// This method is called right after [Self::upstream_peer()] returns a [HttpPeer] and a
+    /// This method is called right after [`Self::upstream_peer()`] returns a [`HttpPeer`] and a
     /// connection is established with the worker.
     #[tracing::instrument(name = "proxy.upstream_request_filter", parent = &_ctx.parent_span, skip(_session))]
     async fn upstream_request_filter(

--- a/crates/block-producer/src/mempool/graph/mod.rs
+++ b/crates/block-producer/src/mempool/graph/mod.rs
@@ -14,27 +14,27 @@ mod tests;
 ///
 /// # Node lifecycle
 /// ```text
-///                                    │                           
-///                                    │                           
-///                      insert_pending│                           
-///                              ┌─────▼─────┐                     
-///                              │  pending  │────┐                
-///                              └─────┬─────┘    │                
-///                                    │          │                
-///                     promote_pending│          │                
-///                              ┌─────▼─────┐    │                
-///                   ┌──────────► in queue  │────│                
-///                   │          └─────┬─────┘    │                
-///   revert_processed│                │          │                
-///                   │    process_root│          │                
-///                   │          ┌─────▼─────┐    │                
-///                   └──────────┼ processed │────│                
-///                              └─────┬─────┘    │                
-///                                    │          │                
+///                                    │
+///                                    │
+///                      insert_pending│
+///                              ┌─────▼─────┐
+///                              │  pending  │────┐
+///                              └─────┬─────┘    │
+///                                    │          │
+///                     promote_pending│          │
+///                              ┌─────▼─────┐    │
+///                   ┌──────────► in queue  │────│
+///                   │          └─────┬─────┘    │
+///   revert_processed│                │          │
+///                   │    process_root│          │
+///                   │          ┌─────▼─────┐    │
+///                   └──────────┼ processed │────│
+///                              └─────┬─────┘    │
+///                                    │          │
 ///                     prune_processed│          │purge_subgraphs
-///                              ┌─────▼─────┐    │                
-///                              │  <null>   ◄────┘                
-///                              └───────────┘                     
+///                              ┌─────▼─────┐    │
+///                              │  <null>   ◄────┘
+///                              └───────────┘
 /// ```
 #[derive(Clone, PartialEq, Eq)]
 pub struct DependencyGraph<K, V> {
@@ -405,7 +405,7 @@ impl<K: Ord + Copy + Display + Debug, V: Clone> DependencyGraph<K, V> {
         self.vertices.get(key)
     }
 
-    /// Returns the parents of the node, or [None] if the node does not exist.
+    /// Returns the parents of the node, or `None` if the node does not exist.
     pub fn parents(&self, key: &K) -> Option<&BTreeSet<K>> {
         self.parents.get(key)
     }

--- a/crates/remote-prover-client/Cargo.toml
+++ b/crates/remote-prover-client/Cargo.toml
@@ -39,7 +39,7 @@ tonic-web = { optional = true, version = "0.13" }
 workspace = true
 
 [dependencies]
-async-trait   = { version = "0.1" }
+async-trait   = { workspace = true }
 miden-objects = { optional = true, workspace = true }
 miden-tx      = { optional = true, workspace = true }
 prost         = { default-features = false, features = ["derive"], version = "0.13" }

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -268,7 +268,7 @@ impl Db {
         .await
     }
 
-    /// Search for a [BlockHeader] from the database by its `block_num`.
+    /// Search for a [`BlockHeader`] from the database by its `block_num`.
     ///
     /// When `block_number` is [None], the latest block header is returned.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
@@ -371,7 +371,7 @@ impl Db {
         .await
     }
 
-    /// Loads all the Note's matching a certain NoteId from the database.
+    /// Loads all the Note's matching a certain `NoteId` from the database.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_notes_by_id(&self, note_ids: Vec<NoteId>) -> Result<Vec<NoteRecord>> {
         self.transact("note by id", move |conn| {
@@ -392,7 +392,7 @@ impl Db {
         .await
     }
 
-    /// Loads all note IDs matching a certain NoteId from the database.
+    /// Loads all note IDs matching a certain `NoteId` from the database.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_note_ids(&self, note_ids: Vec<NoteId>) -> Result<HashSet<NoteId>> {
         self.select_notes_by_id(note_ids)
@@ -403,7 +403,7 @@ impl Db {
     /// Inserts the data of a new block into the DB.
     ///
     /// `allow_acquire` and `acquire_done` are used to synchronize writes to the DB with writes to
-    /// the in-memory trees. Further details available on [super::state::State::apply_block].
+    /// the in-memory trees. Further details available on [`super::state::State::apply_block`].
     // TODO: This span is logged in a root span, we should connect it to the parent one.
     #[instrument(target = COMPONENT, skip_all, err)]
     pub async fn apply_block(

--- a/crates/store/src/db/models/queries.rs
+++ b/crates/store/src/db/models/queries.rs
@@ -88,7 +88,8 @@ use crate::db::{
 };
 use crate::errors::{NoteSyncError, StateSyncError};
 
-/// Select notes matching the tags and account IDs search criteria using the given [Connection].
+/// Select notes matching the tags and account IDs search criteria using the given
+/// [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -179,7 +180,7 @@ pub(crate) fn select_notes_since_block_by_tag_and_sender(
     vec_raw_try_into(notes)
 }
 
-/// Select a [`BlockHeader`] from the DB by its `block_num` using the given [Connection].
+/// Select a [`BlockHeader`] from the DB by its `block_num` using the given [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -207,7 +208,7 @@ pub(crate) fn select_block_header_by_block_num(
     row.map(std::convert::TryInto::try_into).transpose()
 }
 
-/// Select note inclusion proofs matching the `NoteId`, using the given [Connection].
+/// Select note inclusion proofs matching the `NoteId`, using the given [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -874,7 +875,8 @@ pub(crate) fn select_nullifiers_by_prefix(
     vec_raw_try_into(nullifiers_raw)
 }
 
-/// Select the latest account details by account id from the DB using the given [Connection].
+/// Select the latest account details by account id from the DB using the given
+/// [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -909,10 +911,11 @@ pub(crate) fn select_account(
 }
 
 // TODO: Handle account prefix collision in a more robust way
-/// Select the latest account details by account ID prefix from the DB using the given [Connection]
-/// This method is meant to be used by the network transaction builder. Because network notes get
-/// matched through accounts through the account's 30-bit prefix, it is possible that multiple
-/// accounts match against a single prefix. In this scenario, the first account is returned.
+/// Select the latest account details by account ID prefix from the DB using the given
+/// [`SqliteConnection`] This method is meant to be used by the network transaction builder. Because
+/// network notes get matched through accounts through the account's 30-bit prefix, it is possible
+/// that multiple accounts match against a single prefix. In this scenario, the first account is
+/// returned.
 ///
 /// # Returns
 ///
@@ -949,7 +952,7 @@ pub(crate) fn select_account_by_id_prefix(
     result
 }
 
-/// Select all account commitments from the DB using the given [Connection].
+/// Select all account commitments from the DB using the given [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -1167,7 +1170,7 @@ pub(crate) fn select_unconsumed_network_notes_by_tag(
     Ok((notes, page))
 }
 
-/// Select all accounts from the DB using the given [Connection].
+/// Select all accounts from the DB using the given [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -1222,7 +1225,7 @@ pub(crate) fn select_accounts_by_id(
 }
 
 /// Selects and merges account deltas by account id and block range from the DB using the given
-/// [Connection].
+/// [`SqliteConnection`].
 ///
 /// # Note:
 ///
@@ -1559,7 +1562,7 @@ pub(crate) fn select_non_fungible_asset_updates_stmt(
     Ok(entries)
 }
 
-/// Select all the given block headers from the DB using the given [Connection].
+/// Select all the given block headers from the DB using the given [`SqliteConnection`].
 ///
 /// # Note
 ///
@@ -1587,7 +1590,7 @@ pub fn select_block_headers(
     vec_raw_try_into(raw_block_headers)
 }
 
-/// Select all block headers from the DB using the given [Connection].
+/// Select all block headers from the DB using the given [`SqliteConnection`].
 ///
 /// # Returns
 ///
@@ -1660,8 +1663,8 @@ pub(crate) fn get_note_sync(
     Ok(NoteSyncUpdate { notes, block_header })
 }
 
-/// Select [`AccountSummary`] from the DB using the given [Connection], given that the account
-/// update was done between `(block_start, block_end]`.
+/// Select [`AccountSummary`] from the DB using the given [`SqliteConnection`], given that the
+/// account update was done between `(block_start, block_end]`.
 ///
 /// # Returns
 ///

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -206,9 +206,9 @@ impl rpc_server::Rpc for StoreApi {
         }))
     }
 
-    /// Returns a list of Note's for the specified NoteId's.
+    /// Returns a list of `Note`'s for the specified `NoteId`'s.
     ///
-    /// If the list is empty or no Note matched the requested NoteId and empty list is returned.
+    /// If the list is empty or no Note matched the requested `NoteId` and empty list is returned.
     #[instrument(
         parent = None,
         target = COMPONENT,


### PR DESCRIPTION
* Adds backticks around the argument inside `[]` ```[`Self::foo()`]```
* Disable some new lints - the purpose of them become increasingly questionable
* Apply the sane lints (i.e. future size warnings) 