### PR TITLE
feat: add target to install dev tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,25 @@ docker-run-faucet: ## Runs the Miden faucet as a Docker container
 	docker run --name miden-faucet \
 			   -p 8080:8080 \
                -d miden-faucet-image
+
+## --- setup --------------------------------------------------------------------------------------
+
+.PHONY: check-tools
+check-tools: ## Checks if development tools are installed
+	@echo "Checking development tools..."
+	@command -v mdbook        >/dev/null 2>&1 && echo "[OK] mdbook is installed"        || echo "[MISSING] mdbook       (make install-tools)"
+	@command -v typos         >/dev/null 2>&1 && echo "[OK] typos is installed"         || echo "[MISSING] typos        (make install-tools)"
+	@command -v cargo nextest >/dev/null 2>&1 && echo "[OK] cargo-nextest is installed" || echo "[MISSING] cargo-nextest(make install-tools)"
+	@command -v taplo         >/dev/null 2>&1 && echo "[OK] taplo is installed"         || echo "[MISSING] taplo        (make install-tools)"
+	@command -v cargo-machete >/dev/null 2>&1 && echo "[OK] cargo-machete is installed" || echo "[MISSING] cargo-machete (make install-tools)"
+
+.PHONY: install-tools
+install-tools: ## Installs tools required by the Makefile
+	@echo "Installing development tools..."
+	# Rust-related
+	cargo install mdbook --locked
+	cargo install typos-cli --locked
+	cargo install cargo-nextest --locked
+	cargo install taplo-cli --locked
+	cargo install cargo-machete --locked
+	@echo "Development tools installation complete!"


### PR DESCRIPTION
closes #1029 

Copied the target from the miden-client's repository, did not add `chromedriver` since the faucet was moved to a different repository in practice.