### PR TITLE
fix: add env var to enable OTel in network monitor

### DIFF
--- a/bin/network-monitor/.env
+++ b/bin/network-monitor/.env
@@ -1,3 +1,4 @@
 MIDEN_MONITOR_RPC_URL=http://0.0.0.0:57291
 MIDEN_MONITOR_REMOTE_PROVER_URLS=https://tx-prover.devnet.miden.io/,https://batch-prover.devnet.miden.io/
 MIDEN_MONITOR_PORT=3001
+MIDEN_MONITOR_ENABLE_OTEL=true

--- a/bin/network-monitor/README.md
+++ b/bin/network-monitor/README.md
@@ -17,6 +17,7 @@ The monitor application uses environment variables for configuration:
 - `MIDEN_MONITOR_RPC_URL`: RPC service URL (default: `http://localhost:50051`)
 - `MIDEN_MONITOR_REMOTE_PROVER_URLS`: Comma-separated list of remote prover URLs (default: `http://localhost:50052`)
 - `MIDEN_MONITOR_PORT`: Web server port (default: `3000`)
+- `MIDEN_MONITOR_ENABLE_OTEL`: Enable OpenTelemetry tracing (default: `false`)
 
 ## Usage
 

--- a/bin/network-monitor/src/status.rs
+++ b/bin/network-monitor/src/status.rs
@@ -34,6 +34,7 @@ const DEFAULT_PORT: u16 = 3000;
 const RPC_URL_ENV_VAR: &str = "MIDEN_MONITOR_RPC_URL";
 const REMOTE_PROVER_URLS_ENV_VAR: &str = "MIDEN_MONITOR_REMOTE_PROVER_URLS";
 const PORT_ENV_VAR: &str = "MIDEN_MONITOR_PORT";
+pub(crate) const ENABLE_OTEL_ENV_VAR: &str = "MIDEN_MONITOR_ENABLE_OTEL";
 
 /// Configuration for the monitor.
 ///


### PR DESCRIPTION
Create a new env var to enable OTel. The variable name is defined in the `status.rs` file, which doesn't make much sense. A new `config.rs` file was created (along with the remote prover tests feature), and it is currently open for reviews here: https://github.com/0xMiden/miden-node/pull/1236/