### PR TITLE
fix: predefine otel.name field with empty value

### DIFF
--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -10,18 +10,20 @@ use crate::tracing::OpenTelemetrySpanExt;
 /// Additionally also pulls in remote tracing context which allows the server trace to be connected
 /// to the client's origin trace.
 pub fn grpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
-    // Create a span with a generic, static name. Fields to be recorded after needs to be
-    // initialized as empty since otherwise the assignment will have no effect.
-    let span = tracing::info_span!("rpc", rpc.uri = %request.uri(), otel.name = field::Empty);
-
     // A gRPC request's path ends with `../<service>/<method>`.
     let mut path_segments = request.uri().path().rsplit('/');
 
     let service = path_segments.next().unwrap_or_default();
-    span.set_attribute("rpc.service", service);
-
     let method = path_segments.next().unwrap_or_default();
-    span.set_attribute("rpc.method", method);
+
+    // Create a span with a generic, static name. Fields to be recorded after needs to be
+    // initialized as empty since otherwise the assignment will have no effect.
+    let span = tracing::info_span!(
+        "rpc",
+        otel.name = field::Empty,
+        rpc.service = service,
+        rpc.method = method
+    );
 
     // Set the span name via otel.name
     let otel_name = format!("{service}/{method}");


### PR DESCRIPTION
fixes #1263

