### PR TITLE
refactor: replace most BTreeMap/BTreeSet with HashMap/HashSet

### DIFF
--- a/crates/block-producer/src/mempool/batch_graph.rs
+++ b/crates/block-producer/src/mempool/batch_graph.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use miden_objects::account::AccountId;
 use miden_objects::batch::{BatchId, ProvenBatch};
@@ -58,13 +58,13 @@ pub struct BatchGraph {
     ///
     /// Incoming batches are defined entirely in terms of transactions, including parent edges.
     /// This let's us transform these parent transactions into the relevant parent batches.
-    transactions: BTreeMap<TransactionId, BatchId>,
+    transactions: HashMap<TransactionId, BatchId>,
 
     /// Maps each batch to its transaction set.
     ///
     /// Required because the dependency graph is defined in terms of batches. This let's us
     /// translate between batches and their transactions when required.
-    batches: BTreeMap<BatchId, Vec<TransactionId>>,
+    batches: HashMap<BatchId, Vec<TransactionId>>,
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]

--- a/crates/block-producer/src/mempool/transaction_expiration.rs
+++ b/crates/block-producer/src/mempool/transaction_expiration.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use miden_objects::block::BlockNumber;
 use miden_objects::transaction::TransactionId;
@@ -13,7 +13,7 @@ pub struct TransactionExpirations {
     /// Transaction lookup index.
     by_tx: HashMap<TransactionId, BlockNumber>,
     /// Block number lookup index.
-    by_block: HashMap<BlockNumber, BTreeSet<TransactionId>>,
+    by_block: HashMap<BlockNumber, HashSet<TransactionId>>,
 }
 
 impl TransactionExpirations {
@@ -25,7 +25,11 @@ impl TransactionExpirations {
 
     /// Returns all transactions that are expiring at the given block number.
     pub fn get(&mut self, block: BlockNumber) -> BTreeSet<TransactionId> {
-        self.by_block.get(&block).cloned().unwrap_or_default()
+        self
+            .by_block
+            .get(&block)
+            .map(|set| set.iter().copied().collect())
+            .unwrap_or_default()
     }
 
     /// Removes the transactions from the tracker.

--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 
 use account::{AccountState, InflightNetworkNote, NetworkAccountUpdate};
@@ -79,10 +79,10 @@ pub struct State {
     ///
     /// This is tracked so we can commit or revert such transaction effects. Transactions _without_
     /// an impact are ignored.
-    inflight_txs: BTreeMap<TransactionId, TransactionImpact>,
+    inflight_txs: HashMap<TransactionId, TransactionImpact>,
 
     /// A mapping of network note's to their account.
-    nullifier_idx: BTreeMap<Nullifier, NetworkAccountPrefix>,
+    nullifier_idx: HashMap<Nullifier, NetworkAccountPrefix>,
 
     /// gRPC client used to retrieve the network account state from the store.
     store: StoreClient,
@@ -110,8 +110,8 @@ impl State {
             accounts: HashMap::default(),
             queue: VecDeque::default(),
             in_progress: HashSet::default(),
-            inflight_txs: BTreeMap::default(),
-            nullifier_idx: BTreeMap::default(),
+            inflight_txs: HashMap::default(),
+            nullifier_idx: HashMap::default(),
         };
 
         let notes = state.store.get_unconsumed_network_notes().await?;
@@ -468,10 +468,10 @@ struct TransactionImpact {
     account_delta: Option<NetworkAccountPrefix>,
 
     /// Network notes this transaction created.
-    notes: BTreeSet<Nullifier>,
+    notes: HashSet<Nullifier>,
 
     /// Network notes this transaction consumed.
-    nullifiers: BTreeSet<Nullifier>,
+    nullifiers: HashSet<Nullifier>,
 }
 
 impl TransactionImpact {


### PR DESCRIPTION
Convert internal maps/sets to HashMap/HashSet across block-producer and ntx-builder for better average-case performance.

Preserve ordering where required:
- Keep BTreeMap in mempool subscription to maintain chronological event order.
- Keep BTreeSet in public-facing return types where determinism is relied upon (e.g., TransactionExpirations::get), adapting internals to HashSet and collecting to BTreeSet on return.

Update DependencyGraph internals to use HashMap and tighten generic bounds (K: Ord + Eq + Hash).

fix #1064 