### PR TITLE
feat: create data and accounts dir if not already existing

### DIFF
--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -194,7 +194,7 @@ impl StoreCommand {
                             .file_name()
                             .unwrap_or(std::ffi::OsStr::new("directory"))
                             .display(),
-                        accounts_directory.display()
+                        directory.display()
                     )
                 })?;
             }


### PR DESCRIPTION
Currently, the `miden-node` utility requires for the `data` and `accounts` directories to already exist in order for the `miden-node bundled bootstrap` command to function correctly.

This PR makes it so that `miden-node` CLI will create the passed in directories if they do not exist already, but will error out if they do, following the already present behavior regarding file creation inside said directories. 

This is used in `midenup` in order to auto-initialize the node without requiring previous user input and is related to this discussion: https://github.com/0xMiden/miden-client/issues/1366