### PR TITLE
fix: trim MAX_NOTE_ATTEMPTS to 1

### DIFF
--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -90,7 +90,7 @@ pub struct State {
 
 impl State {
     /// Maximum number of attempts to execute a network note.
-    const MAX_NOTE_ATTEMPTS: usize = 30;
+    const MAX_NOTE_ATTEMPTS: usize = 1;
 
     /// Load's all available network notes from the store, along with the required account states.
     #[instrument(target = COMPONENT, name = "ntx.state.load", skip_all)]


### PR DESCRIPTION
Reduces noise significantly on testnet, and we don't have many practical error cases _yet_. In the future we should increment it again.