### PR TITLE
doc: correct SQL query documentation

### DIFF
--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -58,19 +58,25 @@ use crate::errors::DatabaseError;
 ///
 /// ```sql
 /// SELECT
-///     account_id,
-///     account_commitment,
-///     block_num,
-///     details
+///     accounts.account_id,
+///     accounts.account_commitment,
+///     accounts.block_num,
+///     accounts.storage,
+///     accounts.vault,
+///     accounts.nonce,
+///     accounts.code_commitment,
+///     account_codes.code
 /// FROM
 ///     accounts
+/// LEFT JOIN
+///     account_codes ON accounts.code_commitment = account_codes.code_commitment
 /// WHERE
-///     account_id = ?1;
+///     account_id = ?1
 /// ```
 pub(crate) fn select_account(
     conn: &mut SqliteConnection,
     account_id: AccountId,
-) -> Result<proto::domain::account::AccountInfo, DatabaseError> {
+) -> Result<AccountInfo, DatabaseError> {
     let raw = SelectDsl::select(
         schema::accounts::table.left_join(schema::account_codes::table.on(
             schema::accounts::code_commitment.eq(schema::account_codes::code_commitment.nullable()),
@@ -100,14 +106,20 @@ pub(crate) fn select_account(
 ///
 /// ```sql
 /// SELECT
-///     account_id,
-///     account_commitment,
-///     block_num,
-///     details
+///     accounts.account_id,
+///     accounts.account_commitment,
+///     accounts.block_num,
+///     accounts.storage,
+///     accounts.vault,
+///     accounts.nonce,
+///     accounts.code_commitment,
+///     account_codes.code
 /// FROM
 ///     accounts
+/// LEFT JOIN
+///     account_codes ON accounts.code_commitment = account_codes.code_commitment
 /// WHERE
-///     network_account_id_prefix = ?1;
+///     network_account_id_prefix = ?1
 /// ```
 pub(crate) fn select_account_by_id_prefix(
     conn: &mut SqliteConnection,
@@ -137,10 +149,21 @@ pub(crate) fn select_account_by_id_prefix(
 /// # Returns
 ///
 /// The vector with the account id and corresponding commitment, or an error.
+///
+/// # Raw SQL
+///
+/// ```sql
+/// SELECT
+///     account_id,
+///     account_commitment
+/// FROM
+///     accounts
+/// ORDER BY
+///     block_num ASC
+/// ```
 pub(crate) fn select_all_account_commitments(
     conn: &mut SqliteConnection,
 ) -> Result<Vec<(AccountId, Word)>, DatabaseError> {
-    // SELECT account_id, account_commitment FROM accounts ORDER BY block_num ASC
     let raw = SelectDsl::select(
         schema::accounts::table,
         (schema::accounts::account_id, schema::accounts::account_commitment),
@@ -174,13 +197,13 @@ pub(crate) fn select_all_account_commitments(
 /// FROM
 ///     account_vault_assets
 /// WHERE
-///     account_id = ?
-///     AND block_num >= ?
-///     AND block_num <= ?
+///     account_id = ?1
+///     AND block_num >= ?2
+///     AND block_num <= ?3
 /// ORDER BY
 ///     block_num ASC
 /// LIMIT
-///     ROW_LIMIT;
+///     ?4
 /// ```
 pub(crate) fn select_account_vault_assets(
     conn: &mut SqliteConnection,
@@ -261,7 +284,7 @@ pub(crate) fn select_account_vault_assets(
 /// WHERE
 ///     block_num > ?1 AND
 ///     block_num <= ?2 AND
-///     account_id IN rarray(?3)
+///     account_id IN (?3)
 /// ORDER BY
 ///     block_num ASC
 /// ```
@@ -295,14 +318,20 @@ pub fn select_accounts_by_block_range(
 ///
 /// ```sql
 /// SELECT
-///     account_id,
-///     account_commitment,
-///     block_num,
-///     details
+///     accounts.account_id,
+///     accounts.account_commitment,
+///     accounts.block_num,
+///     accounts.storage,
+///     accounts.vault,
+///     accounts.nonce,
+///     accounts.code_commitment,
+///     account_codes.code
 /// FROM
 ///     accounts
+/// LEFT JOIN
+///     account_codes ON accounts.code_commitment = account_codes.code_commitment
 /// ORDER BY
-///     block_num ASC;
+///     block_num ASC
 /// ```
 #[cfg(test)]
 pub(crate) fn select_all_accounts(
@@ -377,7 +406,7 @@ impl StorageMapValue {
 /// ORDER BY
 ///     block_num ASC
 /// LIMIT
-///     :row_limit;
+///     ?4
 /// ```
 /// Select account storage map values within a block range (inclusive).
 ///

--- a/crates/store/src/db/models/queries/block_headers.rs
+++ b/crates/store/src/db/models/queries/block_headers.rs
@@ -28,10 +28,16 @@ use crate::db::schema;
 /// the given block height is returned.
 ///
 /// ```sql
-/// # with argument
-/// SELECT block_header FROM block_headers WHERE block_num = ?1
-/// # without
-/// SELECT block_header FROM block_headers ORDER BY block_num DESC LIMIT 1
+/// -- with argument
+/// SELECT block_num, block_header
+/// FROM block_headers
+/// WHERE block_num = ?1
+///
+/// -- without argument
+/// SELECT block_num, block_header
+/// FROM block_headers
+/// ORDER BY block_num DESC
+/// LIMIT 1
 /// ```
 pub(crate) fn select_block_header_by_block_num(
     conn: &mut SqliteConnection,
@@ -70,7 +76,9 @@ pub(crate) fn select_block_header_by_block_num(
 /// # Raw SQL
 ///
 /// ```sql
-/// SELECT block_header FROM block_headers WHERE block_num IN (?1)
+/// SELECT block_num, block_header
+/// FROM block_headers
+/// WHERE block_num IN (?1)
 /// ```
 pub fn select_block_headers(
     conn: &mut SqliteConnection,
@@ -101,7 +109,9 @@ pub fn select_block_headers(
 /// # Raw SQL
 ///
 /// ```sql
-/// SELECT block_header FROM block_headers ORDER BY block_num ASC
+/// SELECT block_num, block_header
+/// FROM block_headers
+/// ORDER BY block_num ASC
 /// ```
 pub fn select_all_block_headers(
     conn: &mut SqliteConnection,

--- a/crates/store/src/db/models/queries/notes.rs
+++ b/crates/store/src/db/models/queries/notes.rs
@@ -114,9 +114,10 @@ use crate::errors::NoteSyncError;
 ///             block_num <= ?4
 ///         ORDER BY
 ///             block_num ASC
-///     LIMIT 1) AND
-///     -- filter the block's notes and return only the ones matching the requested tags or
-/// senders     (tag IN (?1) OR sender IN (?2))
+///         LIMIT 1
+///     ) AND
+///     -- filter the block's notes and return only the ones matching the requested tags or senders
+///     (tag IN (?1) OR sender IN (?2))
 /// ```
 pub(crate) fn select_notes_since_block_by_tag_and_sender(
     conn: &mut SqliteConnection,
@@ -175,10 +176,24 @@ pub(crate) fn select_notes_since_block_by_tag_and_sender(
 /// # Raw SQL
 ///
 /// ```sql
-/// SELECT {}
+/// SELECT
+///     notes.committed_at,
+///     notes.batch_index,
+///     notes.note_index,
+///     notes.note_id,
+///     notes.note_type,
+///     notes.sender,
+///     notes.tag,
+///     notes.aux,
+///     notes.execution_hint,
+///     notes.assets,
+///     notes.inputs,
+///     notes.serial_num,
+///     notes.inclusion_path,
+///     note_scripts.script
 /// FROM notes
 /// LEFT JOIN note_scripts ON notes.script_root = note_scripts.script_root
-/// WHERE note_id IN rarray(?1),
+/// WHERE note_id IN (?1)
 /// ```
 pub(crate) fn select_notes_by_id(
     conn: &mut SqliteConnection,
@@ -211,11 +226,25 @@ pub(crate) fn select_notes_by_id(
 ///
 /// # Raw SQL
 ///
-/// ```
-/// SELECT {cols}
+/// ```sql
+/// SELECT
+///     notes.committed_at,
+///     notes.batch_index,
+///     notes.note_index,
+///     notes.note_id,
+///     notes.note_type,
+///     notes.sender,
+///     notes.tag,
+///     notes.aux,
+///     notes.execution_hint,
+///     notes.assets,
+///     notes.inputs,
+///     notes.serial_num,
+///     notes.inclusion_path,
+///     note_scripts.script
 /// FROM notes
 /// LEFT JOIN note_scripts ON notes.script_root = note_scripts.script_root
-/// ORDER BY block_num ASC
+/// ORDER BY committed_at ASC
 /// ```
 #[cfg(test)]
 pub(crate) fn select_all_notes(
@@ -252,7 +281,7 @@ pub(crate) fn select_all_notes(
 ///
 /// ```sql
 /// SELECT
-///     block_num,
+///     committed_at,
 ///     note_id,
 ///     batch_index,
 ///     note_index,
@@ -262,7 +291,7 @@ pub(crate) fn select_all_notes(
 /// WHERE
 ///     note_id IN (?1)
 /// ORDER BY
-///     block_num ASC
+///     committed_at ASC
 /// ```
 pub(crate) fn select_note_inclusion_proofs(
     conn: &mut SqliteConnection,
@@ -305,12 +334,12 @@ pub(crate) fn select_note_inclusion_proofs(
 ///
 /// ```sql
 /// SELECT
-///     root,
+///     script_root,
 ///     script
 /// FROM
 ///     note_scripts
 /// WHERE
-///     root = ?1;
+///     script_root = ?1
 /// ```
 pub(crate) fn select_note_script_by_root(
     conn: &mut SqliteConnection,
@@ -339,14 +368,29 @@ pub(crate) fn select_note_script_by_root(
 ///
 /// # Raw SQL
 ///
-/// ```
-/// SELECT *, rowid
+/// ```sql
+/// SELECT
+///     notes.committed_at,
+///     notes.batch_index,
+///     notes.note_index,
+///     notes.note_id,
+///     notes.note_type,
+///     notes.sender,
+///     notes.tag,
+///     notes.aux,
+///     notes.execution_hint,
+///     notes.assets,
+///     notes.inputs,
+///     notes.serial_num,
+///     notes.inclusion_path,
+///     note_scripts.script,
+///     notes.rowid
 /// FROM notes
 /// LEFT JOIN note_scripts ON notes.script_root = note_scripts.script_root
 /// WHERE
-///     execution_mode = 0 AND consumed_block_num = NULL AND rowid >= ?
-/// ORDER BY rowid
-/// LIMIT ?
+///     execution_mode = 0 AND consumed_at IS NULL AND notes.rowid >= ?1
+/// ORDER BY notes.rowid ASC
+/// LIMIT ?2
 /// ```
 #[allow(
     clippy::cast_sign_loss,
@@ -437,15 +481,30 @@ pub(crate) fn unconsumed_network_notes(
 /// statements.
 ///
 /// ```sql
-/// SELECT *, rowid
+/// SELECT
+///     notes.committed_at,
+///     notes.batch_index,
+///     notes.note_index,
+///     notes.note_id,
+///     notes.note_type,
+///     notes.sender,
+///     notes.tag,
+///     notes.aux,
+///     notes.execution_hint,
+///     notes.assets,
+///     notes.inputs,
+///     notes.serial_num,
+///     notes.inclusion_path,
+///     note_scripts.script,
+///     notes.rowid
 /// FROM notes
 /// LEFT JOIN note_scripts ON notes.script_root = note_scripts.script_root
 /// WHERE
-///  execution_mode = 0 AND tag = ?1 AND
-///  block_num <= ?2 AND
-///  (consumed_block_num IS NULL OR consumed_block_num > ?2) AND rowid >= ?3
-/// ORDER BY rowid
-/// LIMIT ?
+///     execution_mode = 0 AND tag = ?1 AND
+///     committed_at <= ?2 AND
+///     (consumed_at IS NULL OR consumed_at > ?2) AND notes.rowid >= ?3
+/// ORDER BY notes.rowid ASC
+/// LIMIT ?4
 /// ```
 #[allow(
     clippy::cast_sign_loss,

--- a/crates/store/src/db/models/queries/transactions.rs
+++ b/crates/store/src/db/models/queries/transactions.rs
@@ -46,7 +46,7 @@ use crate::db::{TransactionSummary, schema};
 /// WHERE
 ///     block_num > ?1 AND
 ///     block_num <= ?2 AND
-///     account_id IN rarray(?3)
+///     account_id IN (?3)
 /// ORDER BY
 ///     transaction_id ASC
 /// ```
@@ -257,10 +257,10 @@ impl TransactionSummaryRowInsert {
 /// WHERE
 ///     block_num >= ?1
 ///     AND block_num <= ?2
-///     AND account_id IN rarray(?3)
+///     AND account_id IN (?3)
 ///     AND (
 ///         block_num > ?4 OR (block_num = ?4 AND transaction_id > ?5)
-///     )  -- cursor-based pagination
+///     )
 /// ORDER BY
 ///     block_num ASC,
 ///     transaction_id ASC


### PR DESCRIPTION
The representation of SQL queries and the raw SQL docs in the doc-comment have skewed apart a bit. This PR addresses the representation in the doc comment to be aligned with the actual implementation.