### PR TITLE
`AccountTreeWithHistory` - full integration

### DIFF
--- a/crates/store/src/db/migrations/2025062000000_setup/up.sql
+++ b/crates/store/src/db/migrations/2025062000000_setup/up.sql
@@ -22,7 +22,7 @@ CREATE TABLE accounts (
     vault                                   BLOB,
     nonce                                   INTEGER,
 
-    PRIMARY KEY (account_id),
+    PRIMARY KEY (account_id, block_num),
     FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
     FOREIGN KEY (code_commitment) REFERENCES account_codes(code_commitment),
     CONSTRAINT all_null_or_none_null CHECK
@@ -34,6 +34,7 @@ CREATE TABLE accounts (
 ) WITHOUT ROWID;
 
 CREATE INDEX idx_accounts_network_prefix ON accounts(network_account_id_prefix) WHERE network_account_id_prefix IS NOT NULL;
+CREATE INDEX idx_accounts_id_block ON accounts(account_id, block_num DESC);
 
 CREATE TABLE notes (
     committed_at             INTEGER NOT NULL, -- Block number when the note was committed

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -406,6 +406,19 @@ impl Db {
             .await
     }
 
+    /// Loads account details at a specific block number from the DB.
+    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    pub async fn select_historical_account_at(
+        &self,
+        id: AccountId,
+        block_num: BlockNumber,
+    ) -> Result<AccountInfo> {
+        self.transact("Get historical account details", move |conn| {
+            queries::select_historical_account_at(conn, id, block_num)
+        })
+        .await
+    }
+
     /// Loads public account details from the DB based on the account ID's prefix.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_network_account_by_prefix(

--- a/crates/store/src/db/schema.rs
+++ b/crates/store/src/db/schema.rs
@@ -22,7 +22,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    accounts (account_id) {
+    accounts (account_id, block_num) {
         account_id -> Binary,
         network_account_id_prefix -> Nullable<BigInt>,
         account_commitment -> Binary,
@@ -100,11 +100,12 @@ diesel::table! {
 
 diesel::joinable!(accounts -> account_codes (code_commitment));
 diesel::joinable!(accounts -> block_headers (block_num));
-diesel::joinable!(notes -> accounts (sender));
+// Note: Cannot use diesel::joinable! with accounts table due to composite primary key
+// diesel::joinable!(notes -> accounts (sender));
+// diesel::joinable!(transactions -> accounts (account_id));
 diesel::joinable!(notes -> block_headers (committed_at));
 diesel::joinable!(notes -> note_scripts (script_root));
 diesel::joinable!(nullifiers -> block_headers (block_num));
-diesel::joinable!(transactions -> accounts (account_id));
 diesel::joinable!(transactions -> block_headers (block_num));
 
 diesel::allow_tables_to_appear_in_same_query!(

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -98,6 +98,8 @@ pub enum DatabaseError {
     AccountNotFoundInDb(AccountId),
     #[error("account {0} state at block height {1} not found")]
     AccountAtBlockHeightNotFoundInDb(AccountId, BlockNumber),
+    #[error("historical block {block_num} not available: {reason}")]
+    HistoricalBlockNotAvailable { block_num: BlockNumber, reason: String },
     #[error("accounts {0:?} not found")]
     AccountsNotFoundInDb(Vec<AccountId>),
     #[error("account {0} is not on the chain")]


### PR DESCRIPTION
The first preliminary full integration of recent, historical account states. Part of #1227 


## How is it achieved 

For the purpose of accessing historical data, we add the `fn select_historical_account_at` to query the database accordingly.
For sake of query efficiency, we use `(account_id, block_num)` as primary key instead of `account_id`, and add indices as required.

### In scope

* End to end functionality
* Query optimization

### Out of scope

* SQL schema optimization (split tables/columns into multiple tables)
