### PR TITLE
ci: Use larger runner on some workflows

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         component: [node]
-    runs-on: ubuntu-latest
+    runs-on: Linux-ARM64-Runner
     name: Build ${{ matrix.component }}
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   typos:
-    runs-on: ubuntu-latest
+    runs-on: Linux-ARM64-Runner
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: Linux-ARM64-Runner
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@main
@@ -28,6 +28,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      - uses: taiki-e/install-action@nextest 
+      - uses: taiki-e/install-action@nextest
       - name: Run tests
         run: make test


### PR DESCRIPTION
Some workflows are running out of disk space. We are allocating a larger runner to those. If more workflows exhibit the same failure, we can add them to the runner too.