### PR TITLE
feat: configure script cache via MIDEN_NODE_NTX_SCRIPT_CACHE_SIZE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [BREAKING] Added `AccountTreeWithHistory` and integrate historical queries into `GetAccountProof` ([#1292](https://github.com/0xMiden/miden-node/pull/1292)).
 - Implement `DataStore::get_note_script()` for `NtxDataStore` (#[1332](https://github.com/0xMiden/miden-node/pull/1332)).
 - Started validating notes by their commitment instead of ID before entering the mempool ([#1338](https://github.com/0xMiden/miden-node/pull/1338)).
+- Make `NtxDataStore` script cache size configurable via `MIDEN_NODE_NTX_SCRIPT_CACHE_SIZE` (#[1340](https://github.com/0xMiden/miden-node/pull/1340)).
 
 ## v0.11.3 (2025-11-04)
 


### PR DESCRIPTION
Replaced the hardcoded script cache size (1000) in NtxDataStore with an environment-configurable capacity read from MIDEN_NODE_NTX_SCRIPT_CACHE_SIZE.
A small helper parses the value to NonZeroUsize, falls back to 1000 when the variable is unset, and logs a single warn on invalid or non‑unicode values. This lets operators tune memory/performance without rebuilding while keeping default behavior unchanged when the env var isn’t set.

fix #1335 