### PR TITLE
chore: start counter at zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.12.4 (TBD)
+
+- Updated the counter account from the `miden-network-monitor` to start at 0 ([#1367](https://github.com/0xMiden/miden-node/pull/1367)).
+
 ## v0.12.3 (2025-11-15)
 
 - Added configurable timeout support to `RemoteBatchProver`, `RemoteBlockProver`, and `RemoteTransactionProver` clients ([#1365](https://github.com/0xMiden/miden-node/pull/1365)).

--- a/bin/network-monitor/src/deploy/counter.rs
+++ b/bin/network-monitor/src/deploy/counter.rs
@@ -38,8 +38,7 @@ pub fn create_counter_account(owner_account_id: AccountId) -> Result<Account> {
         owner_account_id_prefix,
     ]));
 
-    let counter_slot =
-        StorageSlot::Value(Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]));
+    let counter_slot = StorageSlot::Value(Word::empty());
 
     let account_code = AccountComponent::compile(
         script,


### PR DESCRIPTION
In miden-base v0.12.3 the empty storage value initialization bug was fixed, that bug was making us to start the counter in 1 instead of 0.