### PR TITLE
chore: add timeout support for WASM clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [BREAKING] Renamed `ProxyWorkerStatus::address` to `ProxyWorkerStatus::name` ([#1348](https://github.com/0xMiden/miden-node/pull/1348)).
 - Remove `trait AccountTreeStorage` ([#1352](https://github.com/0xMiden/miden-node/issues/1352)).
 - [BREAKING] `SubmitProvenTransaction` now **requires** that the network's genesis commitment is set in the request's `ACCEPT` header ([#1298](https://github.com/0xMiden/miden-node/pull/1298)).
+- Added support for timeouts in the WASM remote prover clients ([#1383](https://github.com/0xMiden/miden-node/pull/1383)).
 
 ### Fixes
 

--- a/crates/remote-prover-client/src/remote_prover/batch_prover.rs
+++ b/crates/remote-prover-client/src/remote_prover/batch_prover.rs
@@ -71,7 +71,12 @@ impl RemoteBatchProver {
 
         #[cfg(target_arch = "wasm32")]
         let new_client = {
-            let web_client = tonic_web_wasm_client::Client::new(self.endpoint.clone());
+            let mut fetch_options =
+                tonic_web_wasm_client::FetchOptions::new().timeout(self.timeout);
+            let web_client = tonic_web_wasm_client::Client::new_with_options(
+                self.endpoint.clone(),
+                fetch_options,
+            );
             ApiClient::new(web_client)
         };
 

--- a/crates/remote-prover-client/src/remote_prover/block_prover.rs
+++ b/crates/remote-prover-client/src/remote_prover/block_prover.rs
@@ -72,7 +72,12 @@ impl RemoteBlockProver {
 
         #[cfg(target_arch = "wasm32")]
         let new_client = {
-            let web_client = tonic_web_wasm_client::Client::new(self.endpoint.clone());
+            let mut fetch_options =
+                tonic_web_wasm_client::FetchOptions::new().timeout(self.timeout);
+            let web_client = tonic_web_wasm_client::Client::new_with_options(
+                self.endpoint.clone(),
+                fetch_options,
+            );
             ApiClient::new(web_client)
         };
 

--- a/crates/remote-prover-client/src/remote_prover/tx_prover.rs
+++ b/crates/remote-prover-client/src/remote_prover/tx_prover.rs
@@ -72,7 +72,12 @@ impl RemoteTransactionProver {
 
         #[cfg(target_arch = "wasm32")]
         let new_client = {
-            let web_client = tonic_web_wasm_client::Client::new(self.endpoint.clone());
+            let mut fetch_options =
+                tonic_web_wasm_client::FetchOptions::new().timeout(self.timeout);
+            let web_client = tonic_web_wasm_client::Client::new_with_options(
+                self.endpoint.clone(),
+                fetch_options,
+            );
             ApiClient::new(web_client)
         };
 


### PR DESCRIPTION
Adds support for timeout in the remote prover clients for WASM.