### PR TITLE
chore: update protocol and v0.12.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.12.5 (2025-11-27)
+
+- Actually update `miden-base` dependencies ([#1384](https://github.com/0xMiden/miden-node/pull/1384)).
+
 ## v0.12.4 (2025-11-27)
 
 - Updated the counter account from the `miden-network-monitor` to start at 0 ([#1367](https://github.com/0xMiden/miden-node/pull/1367)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "clap 4.5.51",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "quote",
  "syn 2.0.110",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "fs-err",
  "miette",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "clap 4.5.51",
  "fs-err",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "getrandom 0.3.4",
  "miden-node-proto-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.90"
-version      = "0.12.4"
+version      = "0.12.5"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]


### PR DESCRIPTION
Node v0.12.4 only updated the node deps and not the protocol in the lockfile. I've also "enforced" this regardless of lockfile via the toml.

This is the new v0.12.5 release which does.