### PR TITLE
chore: use share cache in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,8 @@ jobs:
           rustup +nightly component add rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Fmt
         run: make format-check
@@ -53,6 +55,8 @@ jobs:
           rustup component add clippy
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Clippy
         run: make clippy
@@ -87,6 +91,8 @@ jobs:
         run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Build docs
         run: make doc

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install cargo-msrv
         run: cargo install cargo-msrv

--- a/.github/workflows/network-monitor.yml
+++ b/.github/workflows/network-monitor.yml
@@ -27,6 +27,8 @@ jobs:
         run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Check network monitor (release)
         run: |

--- a/.github/workflows/stress-test-check.yml
+++ b/.github/workflows/stress-test-check.yml
@@ -27,6 +27,8 @@ jobs:
         run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - uses: taiki-e/install-action@nextest 
       - name: Install stress test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         run: rustup update --no-self-update
       - uses: Swatinem/rust-cache@v2
         with:
+          # Share Rust build cache across workflows/jobs on the same OS/arch.
+          shared-key: miden-node
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - uses: taiki-e/install-action@nextest
       - name: Run tests


### PR DESCRIPTION
part of https://github.com/0xMiden/miden-node/issues/1376

This PR adds a share key for the workflows that compiles all the workspace.

@Mirko-von-Leipzig this is pretty much experimental, lmk if you have any thought about this