### PR TITLE
ci: reduce doc lint cache usage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Build docs
-        run: make doc
+        run: cargo doc --no-deps --workspace --all-features --locked
 
   unused_deps:
     name: check for unused dependencies


### PR DESCRIPTION
As per #1376, our doc lints consume 2.6GB of our 10GB github cache. This PR replaces the lint command in CI from our makefile to a more normal one.

The makefile one includes building _all_ dependency docs in _release_ profile for reasons.. so I suspect this bloats the cache significantly though we can only tell post-merge.

I'm tempted to remove the makefile one (if you want docs you should know these commands...). But I've left it as is for now.