### PR TITLE
chore: display success rate as percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added support for caching mempool statistics in the block producer server ([#1388](https://github.com/0xMiden/miden-node/pull/1388)).
 - Added mempool statistics to the block producer status in the `miden-network-monitor` binary ([#1392](https://github.com/0xMiden/miden-node/pull/1392)).
 - Add `S` generic to `NullifierTree` to allow usage with `LargeSmt`s ([#1353](https://github.com/0xMiden/miden-node/issues/1353)).
+- Added success rate to the `miden-network-monitor` binary ([#1420](https://github.com/0xMiden/miden-node/pull/1420)).
 
 ### Fixes
 

--- a/bin/network-monitor/assets/index.html
+++ b/bin/network-monitor/assets/index.html
@@ -49,6 +49,15 @@
         let statusData = null;
         let updateInterval = null;
 
+        function formatSuccessRate(successCount, failureCount) {
+            const total = successCount + failureCount;
+            if (!total) {
+                return 'N/A';
+            }
+
+            return `${((successCount / total) * 100).toFixed(1)}%`;
+        }
+
         async function fetchStatus() {
             try {
                 const response = await fetch('/status');
@@ -243,7 +252,7 @@
                                     <div class="test-metrics ${service.status === 'Healthy' ? 'healthy' : 'unhealthy'}">
                                         <div class="metric-row">
                                             <span class="metric-label">Success Rate:</span>
-                                            <span class="metric-value">${details.FaucetTest.success_count}/${details.FaucetTest.success_count + details.FaucetTest.failure_count}</span>
+                                            <span class="metric-value">${formatSuccessRate(details.FaucetTest.success_count, details.FaucetTest.failure_count)}</span>
                                         </div>
                                         <div class="metric-row">
                                             <span class="metric-label">Last Response Time:</span>
@@ -326,12 +335,8 @@
                                     <strong>Counter Increment:</strong>
                                     <div class="test-metrics ${service.status === 'Healthy' ? 'healthy' : 'unhealthy'}">
                                         <div class="metric-row">
-                                            <span class="metric-label">Successes:</span>
-                                            <span class="metric-value">${details.NtxIncrement.success_count}</span>
-                                        </div>
-                                        <div class="metric-row">
-                                            <span class="metric-label">Failures:</span>
-                                            <span class="metric-value">${details.NtxIncrement.failure_count}</span>
+                                            <span class="metric-label">Success Rate:</span>
+                                            <span class="metric-value">${formatSuccessRate(details.NtxIncrement.success_count, details.NtxIncrement.failure_count)}</span>
                                         </div>
                                         ${details.NtxIncrement.last_tx_id ? `
                                             <div class="metric-row">
@@ -384,7 +389,7 @@
                                     <div class="test-metrics ${service.testStatus === 'Healthy' ? 'healthy' : 'unhealthy'}">
                                         <div class="metric-row">
                                             <span class="metric-label">Success Rate:</span>
-                                            <span class="metric-value">${service.testDetails.success_count}/${service.testDetails.success_count + service.testDetails.failure_count}</span>
+                                            <span class="metric-value">${formatSuccessRate(service.testDetails.success_count, service.testDetails.failure_count)}</span>
                                         </div>
                                         <div class="metric-row">
                                             <span class="metric-label">Last Response Time:</span>


### PR DESCRIPTION
closes #1358 

About the tooltip mentioned in the issue: After the NTX tasks splits merged a couple days ago, the card became understandable so it isn't needed anymore.

<img width="388" height="349" alt="image" src="https://github.com/user-attachments/assets/c11f8e73-e20a-4618-a7e0-78dbc92b02f4" />
<img width="392" height="305" alt="image" src="https://github.com/user-attachments/assets/f10fadfa-31c4-481e-8782-51843d8b6ddc" />

