### PR TITLE
ci: disable debug info

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Reduce cache usage by removing debug information.
+  CARGO_PROFILE_DEV_DEBUG: 0
+
 jobs:
   typos:
     runs-on: Linux-ARM64-Runner

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -14,6 +14,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Reduce cache usage by removing debug information.
+  CARGO_PROFILE_DEV_DEBUG: 0
+
 jobs:
   # Check MSRV (aka `rust-version`) in `Cargo.toml` is valid for workspace members
   msrv:

--- a/.github/workflows/network-monitor.yml
+++ b/.github/workflows/network-monitor.yml
@@ -16,6 +16,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Reduce cache usage by removing debug information.
+  CARGO_PROFILE_DEV_DEBUG: 0
+
 jobs:
   check:
     name: check

--- a/.github/workflows/stress-test-check.yml
+++ b/.github/workflows/stress-test-check.yml
@@ -16,6 +16,10 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+env:
+  # Reduce cache usage by removing debug information.
+  CARGO_PROFILE_DEV_DEBUG: 0
+
 jobs:
   stress-test-check:
     name: stress-test-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+env:
+  # Reduce cache usage by removing debug information.
+  # This works for tests as well because TEST inherits from DEV.
+  CARGO_PROFILE_DEV_DEBUG: 0
+
 jobs:
   test:
     name: test


### PR DESCRIPTION
This disables `debuginfo` for rust builds within CI workflows in the hopes of reducing build time and size and in turn easing cache usage.

Local testing shows quite a large reduction in build artifact size, but we'll have to see how much is actually cached.

Using our `check-msrv.sh` for example:

```
before  after  path
4.0K    4.0K   target/debug/examples
15M     15M    target/debug/.fingerprint
140M    95M    target/debug/incremental
1.7G    1.7G   target/x86_64-unknown-linux-gnu
1.7G    1.7G   target/x86_64-unknown-linux-gnu/debug
2.5G    476M   target/debug/build
3.8G    1.8G   target/debug/deps
6.4G    2.3G   target/debug
8.0G    4.0G   target/
```