### PR TITLE
fix: make get account proof retrieve latest known state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@
 - Added support for caching mempool statistics in the block producer server ([#1388](https://github.com/0xMiden/miden-node/pull/1388)).
 - Added mempool statistics to the block producer status in the `miden-network-monitor` binary ([#1392](https://github.com/0xMiden/miden-node/pull/1392)).
 - Add `S` generic to `NullifierTree` to allow usage with `LargeSmt`s ([#1353](https://github.com/0xMiden/miden-node/issues/1353)).
-- Modify `AccountProofRequest` to retrieve the latest known state in case specified block number (or chain tip) does not contain account updates ([#1422](https://github.com/0xMiden/miden-node/issues/1422)).
 
 ### Fixes
 
 - RPC client now correctly sets `genesis` value in `ACCEPT` header if `version` is unspecified ([#1370](https://github.com/0xMiden/miden-node/pull/1370)).
 - Pin protobuf (`protox`) dependencies to avoid breaking changes in transitive dependency ([#1403](https://github.com/0xMiden/miden-node/pull/1403)).
 - Fixed no-std compatibility for remote prover clients ([#1407](https://github.com/0xMiden/miden-node/pull/1407)).
+- Fixed `AccountProofRequest` to retrieve the latest known state in case specified block number (or chain tip) does not contain account updates ([#1422](https://github.com/0xMiden/miden-node/issues/1422)).
 
 ## v0.12.6
 

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -18,10 +18,9 @@ pub struct AccountProofRequest {
     /// ID of the account for which we want to get data
     #[prost(message, optional, tag = "1")]
     pub account_id: ::core::option::Option<super::account::AccountId>,
-    /// Block at which we'd like to get this data. If present, must be close to the chain tip.
-    /// If not present, data from the latest block will be returned.
-    /// If the specified block does not contain an update for the specified account,
-    /// the latest available data will be returned.
+    /// Optional block height at which to return the proof.
+    ///
+    /// Defaults to current chain tip if unspecified.
     #[prost(message, optional, tag = "2")]
     pub block_num: ::core::option::Option<super::blockchain::BlockNumber>,
     /// Request for additional account details; valid only for public accounts.

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -408,7 +408,7 @@ impl Db {
             .await
     }
 
-    /// Loads account details up to a specific block number from the DB.
+    /// Loads account details at a specific block number from the DB.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_historical_account_at(
         &self,

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -921,7 +921,7 @@ impl State {
     /// Returns the respective account proof with optional details, such as asset and storage
     /// entries.
     ///
-    /// When `block_num` is provided, this method will return the account state up to that specific
+    /// When `block_num` is provided, this method will return the account state at that specific
     /// block using both the historical account tree witness and historical database state.
     pub async fn get_account_proof(
         &self,
@@ -977,7 +977,7 @@ impl State {
         Ok((block_num, witness))
     }
 
-    /// Fetches the account details (code, vault, storage) for a public account up to the specified
+    /// Fetches the account details (code, vault, storage) for a public account at the specified
     /// block.
     ///
     /// This method queries the database to fetch the account state and processes the detail

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -147,10 +147,9 @@ message AccountProofRequest {
     // ID of the account for which we want to get data
     account.AccountId account_id = 1;
 
-    // Block at which we'd like to get this data. If present, must be close to the chain tip.
-    // If not present, data from the latest block will be returned.
-    // If the specified block does not contain an update for the specified account,
-    // the latest available data will be returned.
+    // Optional block height at which to return the proof.
+    //
+    // Defaults to current chain tip if unspecified.
     optional blockchain.BlockNumber block_num = 2;
 
     // Request for additional account details; valid only for public accounts.


### PR DESCRIPTION
As observed while updating the client with the latest node version, retrieval of account proof is prone to failure when the block number used for the request is different from the block where the last account update happened, as it returns a _not found_ in those cases.

This PRs lighly refactors the logic of proof retrieval to return the account proof of an account **up to** the specified block.  