### PR TITLE
fix: use proper trait impl

### DIFF
--- a/crates/store/src/db/models/conv.rs
+++ b/crates/store/src/db/models/conv.rs
@@ -133,11 +133,9 @@ impl SqlTypeConvert for NoteTag {
 
 impl SqlTypeConvert for StorageSlotName {
     type Raw = String;
-    type Error = DatabaseTypeConversionError;
 
-    fn from_raw_sql(raw: Self::Raw) -> Result<Self, Self::Error> {
-        StorageSlotName::new(raw)
-            .map_err(|_| DatabaseTypeConversionError(type_name::<StorageSlotName>()))
+    fn from_raw_sql(raw: Self::Raw) -> Result<Self, DatabaseTypeConversionError> {
+        StorageSlotName::new(raw).map_err(Self::map_err)
     }
 
     fn to_raw_sql(self) -> Self::Raw {


### PR DESCRIPTION
After https://github.com/0xMiden/miden-node/pull/1442 , `next` broke. This was due to to CI running before the https://github.com/0xMiden/miden-node/pull/1445 merge.

We can consider to add a merge queue to avoid this problems in the future.