### PR TITLE
fix: proper private account_id check

### DIFF
--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -934,7 +934,7 @@ impl State {
     ) -> Result<AccountProofResponse, DatabaseError> {
         let AccountProofRequest { block_num, account_id, details } = account_request;
 
-        if details.is_some() && !account_id.is_public() {
+        if details.is_some() && !account_id.has_public_state() {
             return Err(DatabaseError::AccountNotPublic(account_id));
         }
 


### PR DESCRIPTION
## Description

While testing the new public account retrieval flow in the [miden-client](https://github.com/0xMiden/miden-client/pull/1591), we stumbled upon an error when requesting details of a network account.

This PR simply changes the check to allow the retrieval of details for public and network accounts.