### PR TITLE
fix: correct log message in get_genesis_header_with_retry

### DIFF
--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -140,7 +140,7 @@ impl RpcService {
                         ?backoff,
                         %retry_counter,
                         %err,
-                        "connection failed while subscribing to the mempool, retrying"
+                        "connection failed while fetching genesis header, retrying"
                     );
 
                     retry_counter += 1;


### PR DESCRIPTION
Wrong log message - fixed to match what the method actually does.