### PR TITLE
fix: reduce notes limits to 100

### DIFF
--- a/crates/utils/src/limiter.rs
+++ b/crates/utils/src/limiter.rs
@@ -47,6 +47,9 @@ pub const MAX_RESPONSE_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
 
 /// Used for the following RPC endpoints
 /// * `state_sync`
+///
+/// Capped at 1000 account IDs to keep SQL `IN` clauses bounded and response payloads under the
+/// 4 MB budget.
 pub struct QueryParamAccountIdLimit;
 impl QueryParamLimiter for QueryParamAccountIdLimit {
     const PARAM_NAME: &str = "account_id";
@@ -55,6 +58,9 @@ impl QueryParamLimiter for QueryParamAccountIdLimit {
 
 /// Used for the following RPC endpoints
 /// * `select_nullifiers_by_prefix`
+///
+/// Capped at 1000 prefixes to keep queries and responses comfortably within the 4 MB payload
+/// budget and to avoid unbounded prefix scans.
 pub struct QueryParamNullifierPrefixLimit;
 impl QueryParamLimiter for QueryParamNullifierPrefixLimit {
     const PARAM_NAME: &str = "nullifier_prefix";
@@ -65,6 +71,8 @@ impl QueryParamLimiter for QueryParamNullifierPrefixLimit {
 /// * `select_nullifiers_by_prefix`
 /// * `sync_nullifiers`
 /// * `sync_state`
+///
+/// Capped at 1000 nullifiers to bound `IN` clauses and keep response sizes under the 4 MB budget.
 pub struct QueryParamNullifierLimit;
 impl QueryParamLimiter for QueryParamNullifierLimit {
     const PARAM_NAME: &str = "nullifier";
@@ -73,6 +81,8 @@ impl QueryParamLimiter for QueryParamNullifierLimit {
 
 /// Used for the following RPC endpoints
 /// * `get_note_sync`
+///
+/// Capped at 1000 tags so note sync responses remain within the 4 MB payload budget.
 pub struct QueryParamNoteTagLimit;
 impl QueryParamLimiter for QueryParamNoteTagLimit {
     const PARAM_NAME: &str = "note_tag";
@@ -91,6 +101,9 @@ impl QueryParamLimiter for QueryParamNoteIdLimit {
 }
 
 /// Used for internal queries retrieving note inclusion proofs by commitment.
+///
+/// Capped at 1000 commitments to keep internal proof lookups bounded and responses under the 4 MB
+/// payload cap.
 pub struct QueryParamNoteCommitmentLimit;
 impl QueryParamLimiter for QueryParamNoteCommitmentLimit {
     const PARAM_NAME: &str = "note_commitment";
@@ -98,6 +111,9 @@ impl QueryParamLimiter for QueryParamNoteCommitmentLimit {
 }
 
 /// Only used internally, not exposed via public RPC.
+///
+/// Capped at 1000 block headers to bound internal batch operations and keep payloads below the
+/// 4 MB limit.
 pub struct QueryParamBlockLimit;
 impl QueryParamLimiter for QueryParamBlockLimit {
     const PARAM_NAME: &str = "block_header";


### PR DESCRIPTION
This is a followup of https://github.com/0xMiden/miden-node/pull/1443

In that PR the limits were generalized to 1000, but for notes it can exceed the maximum payload size.

Related to the docs:

> Separately, it may be good to also include limits in the RPC endpoint [docs](https://docs.miden.xyz/miden-node/rpc). Let's create another issue for this (unless we already have one).

There is a draft to get the limits through a RPC call, so it could be documented in that endpoint. Should I add it anyways here? cc @bobbinth 