### PR TITLE
fix: correct account vault and storage pagination cutoff

### DIFF
--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -301,7 +301,7 @@ pub(crate) fn select_account_vault_assets(
 
     // Discard the last block in the response (assumes more than one block may be present)
     let (last_block_included, values) = if let Some(&(last_block_num, ..)) = raw.last()
-        && raw.len() >= MAX_ROWS
+        && raw.len() > MAX_ROWS
     {
         // NOTE: If the query contains at least one more row than the amount of storage map updates
         // allowed in a single block for an account, then the response is guaranteed to have at
@@ -542,7 +542,7 @@ pub(crate) fn select_account_storage_map_values(
     // Discard the last block in the response (assumes more than one block may be present)
 
     let (last_block_included, values) = if let Some(&(last_block_num, ..)) = raw.last()
-        && raw.len() >= MAX_ROWS
+        && raw.len() > MAX_ROWS
     {
         // NOTE: If the query contains at least one more row than the amount of storage map updates
         // allowed in a single block for an account, then the response is guaranteed to have at


### PR DESCRIPTION
The pagination for account vault assets and storage maps was a bit too aggressive: it treated raw.len() >= MAX_ROWS as “we overflowed”, even though we ask the DB for MAX_ROWS + 1 rows. In the edge case where we get exactly MAX_ROWS rows back, we don't actually know that there's more data, but the code already cuts the last block and moves last_block_included back. This means that we sometimes return less data than we can, and the client has to make an extra request. I changed the condition to raw.len() > MAX_ROWS, as already done for nullifiers. Now we consider a page truncated only when we actually see an extra row, and in other cases we return all available data up to block_range.end(), correctly setting last_block_included.