### PR TITLE
fix: order select_all_nullifiers by block_num

### DIFF
--- a/crates/store/src/db/models/queries/nullifiers.rs
+++ b/crates/store/src/db/models/queries/nullifiers.rs
@@ -132,6 +132,7 @@ pub(crate) fn select_all_nullifiers(
 ) -> Result<Vec<NullifierInfo>, DatabaseError> {
     let nullifiers_raw =
         SelectDsl::select(schema::nullifiers::table, NullifierWithoutPrefixRawRow::as_select())
+            .order(schema::nullifiers::block_num.asc())
             .load::<NullifierWithoutPrefixRawRow>(conn)?;
     vec_raw_try_into(nullifiers_raw)
 }


### PR DESCRIPTION
The select_all_nullifiers query was relying on SQLite's implicit row order, while the documented SQL and tests expect results ordered by block_num ascending. This change adds an explicit ORDER BY clause to the Diesel query so the implementation matches the documented contract and the tests no longer depend on undefined database behavior.