### PR TITLE
feat/db: add schema generation make target

### DIFF
--- a/crates/store/schema.patch
+++ b/crates/store/schema.patch
@@ -1,0 +1,122 @@
+--- /tmp/schema_base.rs	2026-01-12 15:09:35.714958597 +0100
++++ crates/store/src/db/schema.rs	2026-01-12 15:14:12.430988158 +0100
+@@ -7,48 +7,48 @@
+     }
+ }
+ 
+ diesel::table! {
+     account_storage_map_values (account_id, block_num, slot_name, key) {
+         account_id -> Binary,
+-        block_num -> Integer,
++        block_num -> BigInt,
+         slot_name -> Text,
+         key -> Binary,
+         value -> Binary,
+         is_latest -> Bool,
+     }
+ }
+ 
+ diesel::table! {
+     account_vault_assets (account_id, block_num, vault_key) {
+         account_id -> Binary,
+-        block_num -> Integer,
++        block_num -> BigInt,
+         vault_key -> Binary,
+         asset -> Nullable<Binary>,
+         is_latest -> Bool,
+     }
+ }
+ 
+ diesel::table! {
+     accounts (account_id, block_num) {
+         account_id -> Binary,
+-        network_account_id_prefix -> Nullable<Integer>,
+-        block_num -> Integer,
++        network_account_id_prefix -> Nullable<BigInt>,
++        block_num -> BigInt,
+         account_commitment -> Binary,
+         code_commitment -> Nullable<Binary>,
+-        nonce -> Nullable<Integer>,
++        nonce -> Nullable<BigInt>,
+         storage_header -> Nullable<Binary>,
+         vault_root -> Nullable<Binary>,
+         is_latest -> Bool,
+-        created_at_block -> Integer,
++        created_at_block -> BigInt,
+     }
+ }
+ 
+ diesel::table! {
+     block_headers (block_num) {
+-        block_num -> Integer,
++        block_num -> BigInt,
+         block_header -> Binary,
+     }
+ }
+ 
+ diesel::table! {
+     note_scripts (script_root) {
+@@ -56,54 +56,56 @@
+         script -> Binary,
+     }
+ }
+ 
+ diesel::table! {
+     notes (committed_at, batch_index, note_index) {
+-        committed_at -> Integer,
++        committed_at -> BigInt,
+         batch_index -> Integer,
+         note_index -> Integer,
+         note_id -> Binary,
+         note_commitment -> Binary,
+         note_type -> Integer,
+         sender -> Binary,
+         tag -> Integer,
+         execution_mode -> Integer,
+-        aux -> Integer,
+-        execution_hint -> Integer,
++        aux -> BigInt,
++        execution_hint -> BigInt,
+         inclusion_path -> Binary,
+-        consumed_at -> Nullable<Integer>,
++        consumed_at -> Nullable<BigInt>,
+         nullifier -> Nullable<Binary>,
+         assets -> Nullable<Binary>,
+         inputs -> Nullable<Binary>,
+         script_root -> Nullable<Binary>,
+         serial_num -> Nullable<Binary>,
+     }
+ }
+ 
+ diesel::table! {
+     nullifiers (nullifier) {
+         nullifier -> Binary,
+         nullifier_prefix -> Integer,
+-        block_num -> Integer,
++        block_num -> BigInt,
+     }
+ }
+ 
+ diesel::table! {
+     transactions (transaction_id) {
+         transaction_id -> Binary,
+         account_id -> Binary,
+-        block_num -> Integer,
++        block_num -> BigInt,
+         initial_state_commitment -> Binary,
+         final_state_commitment -> Binary,
+         nullifiers -> Binary,
+         output_notes -> Binary,
+-        size_in_bytes -> Integer,
++        size_in_bytes -> BigInt,
+     }
+ }
+ 
++diesel::joinable!(accounts -> account_codes (code_commitment));
++
+ diesel::allow_tables_to_appear_in_same_query!(
+     account_codes,
+     account_storage_map_values,
+     account_vault_assets,
+     accounts,
+     block_headers,

--- a/crates/store/src/db/schema.rs
+++ b/crates/store/src/db/schema.rs
@@ -1,6 +1,13 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    account_codes (code_commitment) {
+        code_commitment -> Binary,
+        code -> Binary,
+    }
+}
+
+diesel::table! {
     account_storage_map_values (account_id, block_num, slot_name, key) {
         account_id -> Binary,
         block_num -> BigInt,
@@ -25,21 +32,14 @@ diesel::table! {
     accounts (account_id, block_num) {
         account_id -> Binary,
         network_account_id_prefix -> Nullable<BigInt>,
+        block_num -> BigInt,
         account_commitment -> Binary,
         code_commitment -> Nullable<Binary>,
         nonce -> Nullable<BigInt>,
         storage_header -> Nullable<Binary>,
         vault_root -> Nullable<Binary>,
-        block_num -> BigInt,
         is_latest -> Bool,
         created_at_block -> BigInt,
-    }
-}
-
-diesel::table! {
-    account_codes (code_commitment) {
-        code_commitment -> Binary,
-        code -> Binary,
     }
 }
 
@@ -102,20 +102,12 @@ diesel::table! {
 }
 
 diesel::joinable!(accounts -> account_codes (code_commitment));
-diesel::joinable!(accounts -> block_headers (block_num));
-// Note: Cannot use diesel::joinable! with accounts table due to composite primary key
-// diesel::joinable!(notes -> accounts (sender));
-// diesel::joinable!(transactions -> accounts (account_id));
-diesel::joinable!(notes -> block_headers (committed_at));
-diesel::joinable!(notes -> note_scripts (script_root));
-diesel::joinable!(nullifiers -> block_headers (block_num));
-diesel::joinable!(transactions -> block_headers (block_num));
 
 diesel::allow_tables_to_appear_in_same_query!(
     account_codes,
     account_storage_map_values,
-    accounts,
     account_vault_assets,
+    accounts,
     block_headers,
     note_scripts,
     notes,

--- a/docs/internal/src/store.md
+++ b/docs/internal/src/store.md
@@ -14,6 +14,35 @@ Note that the migration logic includes both a schema number _and_ a hash based o
 on node startup to ensure that any existing database matches the expected schema. If you're seeing database failures on
 startup its likely that you created the database _before_ making schema changes resulting in different schema hashes.
 
+### Regenerating the Schema
+
+After modifying SQL migrations in `crates/store/src/db/migrations/`, regenerate the Diesel schema:
+
+```sh
+make schema
+```
+
+This runs the migrations against an ephemeral SQLite database and generates `crates/store/src/db/schema.rs`.
+
+A patch file (`crates/store/schema.patch`) applies customizations to the generated schema:
+
+- **`BigInt` type mappings**: SQLite `INTEGER` columns map to Diesel's `Integer` (i32) by default, but our code uses `i64` for block numbers, nonces, timestamps, etc. The patch changes these to `BigInt`.
+- **`joinable!` macro**: Adds `accounts -> account_codes` relationship for implicit joins.
+
+#### Updating the Patch
+
+When adding new columns that need `i64` in Rust:
+
+1. Run `make schema` to regenerate with the current patch
+2. Edit `schema.rs` to change `Integer` to `BigInt` for the new column
+3. Regenerate the patch:
+   ```sh
+   diesel migration run --database-url=/tmp/miden.db --migration-dir=crates/store/src/db/migrations --config-file=crates/store/diesel.toml
+   diesel print-schema --database-url=/tmp/miden.db --config-file=crates/store/diesel.toml > /tmp/base.rs
+   diff -U6 /tmp/base.rs crates/store/src/db/schema.rs > crates/store/schema.patch
+   rm /tmp/miden.db /tmp/base.rs
+   ```
+
 ## Architecture
 
 The store consists mainly of a gRPC server which answers requests from the RPC and block-producer components, as well as


### PR DESCRIPTION
Ref https://github.com/0xMiden/miden-node/issues/1470

Adds a `make schema` target to regenerate the diesel schema from an existing.

## Attention

I do not like the approach, since we require a patch file, which is brittle at best for changing schemas. 

### Alternatives

Consider using a `build.rs` based approach. 