### PR TITLE
fix: remove parent trace

### DIFF
--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -208,15 +208,6 @@ async fn setup_increment_task(
 /// # Returns
 ///
 /// This function runs indefinitely, only returning on error.
-#[instrument(
-    parent = None,
-    target = COMPONENT,
-    name = "network_monitor.counter.run_increment_task",
-    skip_all,
-    level = "info",
-    ret(level = "debug"),
-    err
-)]
 pub async fn run_increment_task(
     config: MonitorConfig,
     tx: watch::Sender<ServiceStatus>,
@@ -376,15 +367,6 @@ fn send_status(tx: &watch::Sender<ServiceStatus>, status: ServiceStatus) -> Resu
 /// # Returns
 ///
 /// This function runs indefinitely, only returning on error.
-#[instrument(
-    parent = None,
-    target = COMPONENT,
-    name = "network_monitor.counter.run_counter_tracking_task",
-    skip_all,
-    level = "info",
-    ret(level = "debug"),
-    err
-)]
 pub async fn run_counter_tracking_task(
     config: MonitorConfig,
     tx: watch::Sender<ServiceStatus>,

--- a/bin/network-monitor/src/explorer.rs
+++ b/bin/network-monitor/src/explorer.rs
@@ -64,7 +64,6 @@ const LATEST_BLOCK_REQUEST: GraphqlRequest<EmptyVariables> = GraphqlRequest {
 ///
 /// `Ok(())` if the monitoring task runs and completes successfully, or an error if there are
 /// connection issues or failures while checking the explorer status.
-#[instrument(target = COMPONENT, name = "explorer-status-task", skip_all)]
 pub async fn run_explorer_status_task(
     explorer_url: Url,
     name: String,

--- a/bin/network-monitor/src/faucet.rs
+++ b/bin/network-monitor/src/faucet.rs
@@ -88,14 +88,6 @@ pub struct GetMetadataResponse {
 /// # Returns
 ///
 /// `Ok(())` if the task completes successfully, or an error if the task fails.
-#[instrument(
-    parent = None,
-    target = COMPONENT,
-    name = "network_monitor.faucet.run_faucet_test_task",
-    skip_all,
-    level = "info",
-    ret(level = "debug")
-)]
 pub async fn run_faucet_test_task(
     faucet_url: Url,
     status_sender: watch::Sender<ServiceStatus>,

--- a/bin/network-monitor/src/frontend.rs
+++ b/bin/network-monitor/src/frontend.rs
@@ -36,7 +36,6 @@ pub struct ServerState {
 ///
 /// * `server_state` - The server state containing watch receivers for all services.
 /// * `config` - The configuration of the network.
-#[instrument(target = COMPONENT, name = "frontend.serve", skip_all, fields(port = %config.port))]
 pub async fn serve(server_state: ServerState, config: MonitorConfig) {
     // build our application with routes
     let app = Router::new()

--- a/bin/network-monitor/src/remote_prover.rs
+++ b/bin/network-monitor/src/remote_prover.rs
@@ -87,14 +87,6 @@ pub struct ProverTestDetails {
 /// # Returns
 ///
 /// `Ok(())` if the task completes successfully, or an error if the task fails.
-#[instrument(
-    parent = None,
-    target = COMPONENT,
-    name = "network_monitor.remote_prover.run_remote_prover_test_task",
-    skip_all,
-    level = "info",
-    ret(level = "debug")
-)]
 pub async fn run_remote_prover_test_task(
     prover_url: Url,
     name: &str,

--- a/bin/network-monitor/src/status.rs
+++ b/bin/network-monitor/src/status.rs
@@ -310,14 +310,6 @@ impl RpcStatusDetails {
 /// # Returns
 ///
 /// `Ok(())` if the task completes successfully, or an error if the task fails.
-#[instrument(
-    parent = None,
-    target = COMPONENT,
-    name = "network_monitor.status.run_rpc_status_task",
-    skip_all,
-    level = "info",
-    ret(level = "debug")
-)]
 pub async fn run_rpc_status_task(
     rpc_url: Url,
     status_sender: watch::Sender<ServiceStatus>,
@@ -422,14 +414,6 @@ pub(crate) async fn check_rpc_status(
 ///
 /// `Ok(())` if the monitoring task runs and completes successfully, or an error if there are
 /// connection issues or failures while checking the remote prover status.
-#[instrument(
-    parent = None,
-    target = COMPONENT,
-    name = "network_monitor.status.run_remote_prover_status_task",
-    skip_all,
-    level = "info",
-    ret(level = "debug")
-)]
 pub async fn run_remote_prover_status_task(
     prover_url: Url,
     name: String,


### PR DESCRIPTION
After [Mirko's comment](https://github.com/0xMiden/miden-node/pull/1495#discussion_r2689733084) on https://github.com/0xMiden/miden-node/pull/1495 I realized that the network monitor was having the same issue.

This PR aims to remove the tracing from long-running tasks.