### PR TITLE
feat(store): enable database traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.12.7 (2026-01-14)
+## v0.12.8 (2026-01-15)
+
+### Enhancements
+
+- Enable traces within database closures ([#1511](https://github.com/0xMiden/miden-node/pull/1511)).
+
+## v0.12.7 (2026-01-15)
 
 ### Enhancements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
 dependencies = [
  "deadpool-runtime",
+ "tracing",
 ]
 
 [[package]]
@@ -2652,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2679,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "clap 4.5.51",
@@ -2699,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2735,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "quote",
  "syn 2.0.110",
@@ -2743,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "futures",
@@ -2765,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -2787,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "fs-err",
  "miette",
@@ -2797,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "futures",
@@ -2829,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2866,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "clap 4.5.51",
  "fs-err",
@@ -2896,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2925,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -3001,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3046,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "getrandom 0.3.4",
  "miden-node-proto-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.90"
-version      = "0.12.7"
+version      = "0.12.8"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 anyhow                 = { workspace = true }
 deadpool               = { default-features = false, features = ["managed", "rt_tokio_1"], version = "0.12" }
 deadpool-diesel        = { features = ["sqlite"], version = "0.6" }
-deadpool-sync          = { version = "0.1" }
+deadpool-sync          = { default-features = false, features = ["tracing"], version = "0.1" }
 diesel                 = { features = ["numeric", "sqlite"], version = "2.2" }
 diesel_migrations      = { features = ["sqlite"], version = "2.2" }
 hex                    = { version = "0.4" }


### PR DESCRIPTION
> [!WARNING]
> Targets `main`

This enables the `trace` feature in `deadpool` which is otherwise disabled by default. 

This means that tracing hasn't worked inside any of our database interactions since these are passed into `deadpool` which only passes the span on if `trace` is enabled.

I'm primarily interested in this since this will actually emit database table sizes, though it likely also fixes some other inconsistencies that I've seen in the traces.

In addition this PR bumps version to v0.12.8.