### PR TITLE
feat/build: allow to override container runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 
 WARNINGS=RUSTDOCFLAGS="-D warnings"
 BUILD_PROTO=BUILD_PROTO=1
+CONTAINER_RUNTIME ?= docker
 
 # -- linting --------------------------------------------------------------------------------------
 
@@ -114,20 +115,20 @@ install-network-monitor: ## Installs network monitor binary
 # --- docker --------------------------------------------------------------------------------------
 
 .PHONY: docker-build-node
-docker-build-node: ## Builds the Miden node using Docker
+docker-build-node: ## Builds the Miden node using Docker (override with CONTAINER_RUNTIME=podman)
 	@CREATED=$$(date) && \
 	VERSION=$$(cat bin/node/Cargo.toml | grep -m 1 '^version' | cut -d '"' -f 2) && \
 	COMMIT=$$(git rev-parse HEAD) && \
-	docker build --build-arg CREATED="$$CREATED" \
+	$(CONTAINER_RUNTIME) build --build-arg CREATED="$$CREATED" \
         		 --build-arg VERSION="$$VERSION" \
           		 --build-arg COMMIT="$$COMMIT" \
                  -f bin/node/Dockerfile \
                  -t miden-node-image .
 
 .PHONY: docker-run-node
-docker-run-node: ## Runs the Miden node as a Docker container
-	docker volume create miden-db
-	docker run --name miden-node \
+docker-run-node: ## Runs the Miden node as a Docker container (override with CONTAINER_RUNTIME=podman)
+	$(CONTAINER_RUNTIME) volume create miden-db
+	$(CONTAINER_RUNTIME) run --name miden-node \
 			   -p 57291:57291 \
                -v miden-db:/db \
                -d miden-node-image


### PR DESCRIPTION
## Why

Some distros don't ship with `docker` anymore but use `podman`, the latter also has better integration with Mac OS.

## What

Default to `docker` but allow to override by `CONTAINER_RUNTIME` env var `CONTAINER_RUNTIME=podman` or `make docker-build-node CONTAINER_RUNTIME=podman`

This PR does _not_ rename the makefile target for backwards compat, but adds another `container-..` prefixed one.

## Open Questions

1. prefix the env var with `MIDEN_`  ? Might be misleading for users of the binary :man_shrugging: 