### PR TITLE
chore: increase store shutdown timeout and delay post shutdown 

### DIFF
--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -458,9 +458,11 @@ async fn start_store(store_addr: SocketAddr) -> (Runtime, TempDir, Word) {
 /// Shuts down the store runtime properly to allow `RocksDB` to flush before the temp directory is
 /// deleted.
 async fn shutdown_store(store_runtime: Runtime) {
-    task::spawn_blocking(move || store_runtime.shutdown_timeout(Duration::from_millis(500)))
+    task::spawn_blocking(move || store_runtime.shutdown_timeout(Duration::from_secs(3)))
         .await
         .expect("shutdown should complete");
+    // Give RocksDB time to release its lock file after the runtime shutdown
+    tokio::time::sleep(Duration::from_millis(200)).await;
 }
 
 /// Restarts a store using an existing data directory. Returns the runtime handle for shutdown.


### PR DESCRIPTION
Previously the following appeared _sporadically_ on restart. Adding `200ms` sleep should be sufficient even on an over-provisioned machine to ensure ordering until we get `fn flush()` on `Large*` types (see https://midengroup.slack.com/archives/C093G3C6MV2/p1768831883256199 ) 
```
<snip>
    thread 'tests::rpc_startup_is_robust_to_network_failures' panicked at crates/rpc/src/tests.rs:147:25:
    called `Result::unwrap()` on an `Err` value: Status { code: Unknown, message: "transport error", metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Mon, 19 Jan 2026 12:57:44 GMT", "access-control-expose-headers": "grpc-status,grpc-message,grpc-status-details-bin", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-credentials": "true"} }, source: None }
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

    thread 'tokio-runtime-worker' panicked at crates/rpc/src/tests.rs:487:10:
    store should start serving: failed to load state

    Caused by:
        account tree IO error: backend error: IO error: lock hold by current process, acquire time 1768827462 acquiring thread 4780: /tmp/.tmpZT9k5n/accounttree/LOCK: No locks available
```