### PR TITLE
fix(validator): load foreign code from inputs

### DIFF
--- a/crates/validator/src/tx_validation/data_store.rs
+++ b/crates/validator/src/tx_validation/data_store.rs
@@ -24,6 +24,9 @@ impl TransactionInputsDataStore {
     pub fn new(tx_inputs: TransactionInputs) -> Self {
         let mast_store = TransactionMastStore::new();
         mast_store.load_account_code(tx_inputs.account().code());
+        for code in tx_inputs.foreign_account_code() {
+            mast_store.load_account_code(code);
+        }
         Self { tx_inputs, mast_store }
     }
 }


### PR DESCRIPTION
Also load foreign code from tx inputs into data store pre-execution.

Fixes #1561.