### PR TITLE
ci: add cargo-hack to check all feature combinations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,3 +127,22 @@ jobs:
         run: make check
       - name: Diff check
         run: git diff --exit-code
+
+  check-features:
+    name: check all feature combinations
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+      - name: Install RocksDB
+        uses: ./.github/actions/install-rocksdb
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Install rust
+        run: rustup update --no-self-update
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: Check all feature combinations
+        run: make check-features

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ test:  ## Runs all tests
 check: ## Check all targets and features for errors without code generation
 	${BUILD_PROTO} cargo check --all-features --all-targets --locked --workspace
 
+.PHONY: check-features
+check-features: ## Checks all feature combinations compile without warnings using cargo-hack
+	@scripts/check-features.sh
+
 # --- building ------------------------------------------------------------------------------------
 
 .PHONY: build

--- a/scripts/check-features.sh
+++ b/scripts/check-features.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Script to check all feature combinations compile without warnings
+# This script ensures that warnings are treated as errors for CI
+
+echo "Checking all feature combinations with cargo-hack..."
+
+# Set environment variables to treat warnings as errors and build protos
+export RUSTFLAGS="-D warnings"
+export BUILD_PROTO=1
+
+# Run cargo-hack with comprehensive feature checking
+cargo hack check \
+    --workspace \
+    --each-feature \
+    --exclude-features default \
+    --all-targets
+
+echo "All feature combinations compiled successfully!"


### PR DESCRIPTION
This introduces a script, make command and CI job that tests all feature combinations to prevent incorrect dependency feature definitions which are obscured by cargo's default feature unification.

Follows the pattern established in miden-vm and miden-base.

Closes #501