### PR TITLE
fix: Return empty witnesses when vault root not present in `InnerForest`

### DIFF
--- a/crates/store/src/inner_forest/mod.rs
+++ b/crates/store/src/inner_forest/mod.rs
@@ -200,7 +200,9 @@ impl InnerForest {
         block_num: BlockNumber,
         asset_keys: BTreeSet<AssetVaultKey>,
     ) -> Result<Vec<AssetWitness>, WitnessError> {
-        let root = self.get_vault_root(account_id, block_num).ok_or(WitnessError::RootNotFound)?;
+        let Some(root) = self.get_vault_root(account_id, block_num) else {
+            return Ok(Vec::new());
+        };
         let witnessees = asset_keys
             .into_iter()
             .map(|key| {


### PR DESCRIPTION
Closes #1581.

AFAICT the occurrences of account updates with empty vault deltas is expected behaviour. Which means the `InnerForest::get_vault_asset_witnesses()` fn should not error out when the corresponding vault root is not available in the `InnerForest`.