### PR TITLE
ci: remove cache from publish dry run

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -29,7 +29,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Update Rust toolchain
         run: rustup update --no-self-update
-      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-binstall@1.16.6


### PR DESCRIPTION
This is currently eating 2.2 GB of precious github cache but since this only runs _on merge_ into `next`/`main` we don't need it be fast.