### PR TITLE
fix: inner forest storage map entry proofs

### DIFF
--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -134,12 +134,6 @@ pub enum DatabaseError {
     SqlValueConversion(#[from] DatabaseTypeConversionError),
     #[error("Not implemented: {0}")]
     NotImplemented(String),
-    #[error("storage root not found for account {account_id}, slot {slot_name}, block {block_num}")]
-    StorageRootNotFound {
-        account_id: AccountId,
-        slot_name: String,
-        block_num: BlockNumber,
-    },
 }
 
 impl DatabaseError {

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -1114,19 +1114,9 @@ impl State {
             let details = match &slot_data {
                 SlotData::MapKeys(keys) => forest_guard
                     .open_storage_map(account_id, slot_name.clone(), block_num, keys)
-                    .ok_or_else(|| DatabaseError::StorageRootNotFound {
-                        account_id,
-                        slot_name: slot_name.to_string(),
-                        block_num,
-                    })?
                     .map_err(DatabaseError::MerkleError)?,
                 SlotData::All => forest_guard
-                    .storage_map_entries(account_id, slot_name.clone(), block_num)
-                    .ok_or_else(|| DatabaseError::StorageRootNotFound {
-                        account_id,
-                        slot_name: slot_name.to_string(),
-                        block_num,
-                    })?,
+                    .storage_map_entries(account_id, slot_name.clone(), block_num),
             };
 
             storage_map_details.push(details);


### PR DESCRIPTION
Follow up to storage maps, align with vault queries to return non-existence proofs.