### PR TITLE
fix: faucet metadata response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.13.3 (2026-01-29)
+
+### Fixes
+
+- Fixed network monitor faucet test failing to parse `/get_metadata` response due to field type mismatches ([#1612](https://github.com/0xMiden/miden-node/pull/1612)).
+
 ## v0.13.2 (2026-01-27)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "fs-err",
  "miette",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "clap 4.5.54",
  "fs-err",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "fs-err",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.90"
-version      = "0.13.2"
+version      = "0.13.3"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/bin/network-monitor/src/faucet.rs
+++ b/bin/network-monitor/src/faucet.rs
@@ -61,14 +61,14 @@ struct GetTokensResponse {
 /// Response from the faucet's `/get_metadata` endpoint.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetMetadataResponse {
+    version: String,
     id: String,
     issuance: u64,
     max_supply: u64,
     decimals: u8,
-    explorer_url: String,
-    pow_load_difficulty: u32,
+    explorer_url: Option<String>,
+    pow_load_difficulty: u64,
     base_amount: u64,
-    version: Option<String>,
 }
 
 // FAUCET TEST TASK


### PR DESCRIPTION
Fixed `GetMetadataResponse` struct field types to match faucet v0.13.0 API:
    - explorer_url: `String` -> `Option<String>`
    - pow_load_difficulty: u32 -> u64
    - version: Option<String> -> String