### PR TITLE
fix: hide explorer URL row when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.13.4 (TBD)
+
+### Fixes
+
+- Fixed network monitor displaying explorer URL as a "null" hyperlink when unset ([#1617](https://github.com/0xMiden/miden-node/pull/1617)).
+
 ## v0.13.3 (2026-01-29)
 
 ### Fixes

--- a/bin/network-monitor/assets/index.js
+++ b/bin/network-monitor/assets/index.js
@@ -550,6 +550,7 @@ function updateDisplay() {
                                         <span class="metric-label">PoW Difficulty:</span>
                                         <span class="metric-value">${details.FaucetTest.faucet_metadata.pow_load_difficulty}</span>
                                     </div>
+                                    ${details.FaucetTest.faucet_metadata.explorer_url ? `
                                     <div class="metric-row">
                                         <span class="metric-label">Explorer URL:</span>
                                         <span class="metric-value">
@@ -558,6 +559,7 @@ function updateDisplay() {
                                             </a>
                                         </span>
                                     </div>
+                                    ` : ''}
                                 </div>
                             </div>
                           ` : ''}


### PR DESCRIPTION
closes #1613
