### PR TITLE
chore: Remove one level of nesting in remote prover client modules

### DIFF
--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -9,7 +9,7 @@ use miden_node_proto::domain::batch::BatchInputs;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{BatchId, ProposedBatch, ProvenBatch};
-use miden_remote_prover_client::remote_prover::RemoteBatchProver;
+use miden_remote_prover_client::RemoteBatchProver;
 use miden_tx_batch_prover::LocalBatchProver;
 use rand::Rng;
 use tokio::task::JoinSet;

--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -31,7 +31,7 @@ use miden_protocol::transaction::{
     TransactionInputs,
 };
 use miden_protocol::vm::FutureMaybeSend;
-use miden_remote_prover_client::remote_prover::RemoteTransactionProver;
+use miden_remote_prover_client::RemoteTransactionProver;
 use miden_tx::auth::UnreachableAuth;
 use miden_tx::utils::Serializable;
 use miden_tx::{

--- a/crates/ntx-builder/src/actor/mod.rs
+++ b/crates/ntx-builder/src/actor/mod.rs
@@ -18,7 +18,7 @@ use miden_protocol::account::{Account, AccountDelta};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::NoteScript;
 use miden_protocol::transaction::TransactionId;
-use miden_remote_prover_client::remote_prover::RemoteTransactionProver;
+use miden_remote_prover_client::RemoteTransactionProver;
 use tokio::sync::{AcquireError, RwLock, Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 use url::Url;

--- a/crates/remote-prover-client/src/lib.rs
+++ b/crates/remote-prover-client/src/lib.rs
@@ -15,7 +15,14 @@ extern crate std;
 
 use thiserror::Error;
 
-pub mod remote_prover;
+mod remote_prover;
+
+#[cfg(feature = "batch-prover")]
+pub use remote_prover::batch_prover::RemoteBatchProver;
+#[cfg(feature = "block-prover")]
+pub use remote_prover::block_prover::RemoteBlockProver;
+#[cfg(feature = "tx-prover")]
+pub use remote_prover::tx_prover::RemoteTransactionProver;
 
 /// ERRORS
 /// ===============================================================================================

--- a/crates/remote-prover-client/src/remote_prover/mod.rs
+++ b/crates/remote-prover-client/src/remote_prover/mod.rs
@@ -3,16 +3,10 @@ pub mod generated;
 use crate::RemoteProverClientError;
 
 #[cfg(feature = "tx-prover")]
-mod tx_prover;
-#[cfg(feature = "tx-prover")]
-pub use tx_prover::RemoteTransactionProver;
+pub mod tx_prover;
 
 #[cfg(feature = "batch-prover")]
-mod batch_prover;
-#[cfg(feature = "batch-prover")]
-pub use batch_prover::RemoteBatchProver;
+pub mod batch_prover;
 
 #[cfg(feature = "block-prover")]
-mod block_prover;
-#[cfg(feature = "block-prover")]
-pub use block_prover::RemoteBlockProver;
+pub mod block_prover;

--- a/crates/store/src/server/block_prover_client.rs
+++ b/crates/store/src/server/block_prover_client.rs
@@ -1,8 +1,7 @@
 use miden_block_prover::{BlockProverError, LocalBlockProver};
 use miden_protocol::batch::OrderedBatches;
 use miden_protocol::block::{BlockHeader, BlockInputs, BlockProof};
-use miden_remote_prover_client::RemoteProverClientError;
-use miden_remote_prover_client::remote_prover::RemoteBlockProver;
+use miden_remote_prover_client::{RemoteBlockProver, RemoteProverClientError};
 use tracing::instrument;
 
 use crate::COMPONENT;


### PR DESCRIPTION
As per [comment](https://github.com/0xMiden/miden-node/pull/1579#discussion_r2730704971).
>the namespacing here feels a bit "too nested" - e.g., could this not be just miden_remote_prover_client::block_prover::RemoteBlockProver?