### PR TITLE
chore: Split Validator binary crate and update Debian workflows

### DIFF
--- a/.github/actions/debian/action.yml
+++ b/.github/actions/debian/action.yml
@@ -34,6 +34,7 @@ inputs:
     type: choice
     options:
       - miden-node
+      - miden-validator
       - miden-prover
       - miden-prover-proxy
   package:
@@ -42,6 +43,7 @@ inputs:
     type: choice
     options:
       - node
+      - validator
       - prover
       - prover-proxy
 

--- a/.github/workflows/publish-debian-all.yml
+++ b/.github/workflows/publish-debian-all.yml
@@ -44,6 +44,31 @@ jobs:
           crate: miden-node
           arch: ${{ matrix.arch }}
 
+  publish-validator:
+    name: Publish Validator ${{ matrix.arch }} Debian
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on:
+      labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Install RocksDB
+        uses: ./.github/actions/install-rocksdb
+      - name: Build and Publish Node
+        uses: ./.github/actions/debian
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          gitref: ${{ env.version }}
+          crate_dir: validator
+          service: miden-validator
+          package: validator
+          crate: miden-validator
+          arch: ${{ matrix.arch }}
+
   publish-prover:
     name: Publish Prover ${{ matrix.arch }} Debian
     strategy:

--- a/.github/workflows/publish-debian.yml
+++ b/.github/workflows/publish-debian.yml
@@ -10,6 +10,7 @@ on:
         options:
           - miden-network-monitor
           - miden-node
+          - miden-validator
           - miden-prover
           - miden-prover-proxy
       crate_dir:
@@ -19,6 +20,7 @@ on:
         options:
           - network-monitor
           - node
+          - validator
           - remote-prover
       package:
         required: true
@@ -27,6 +29,7 @@ on:
         options:
           - network-monitor
           - node
+          - validator
           - prover
           - prover-proxy
       crate:
@@ -36,6 +39,7 @@ on:
         options:
           - miden-network-monitor
           - miden-node
+          - miden-validator
           - miden-remote-prover
       version:
         description: "Version to release (E.G. v0.10.0-rc.1, v0.10.0). Corresponding git tag must already exist."

--- a/packaging/validator/miden-validator.service
+++ b/packaging/validator/miden-validator.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Miden validator
+Wants=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=exec
+Environment="OTEL_SERVICE_NAME=miden-validator"
+EnvironmentFile=/lib/systemd/system/miden-validator.env
+ExecStart=/usr/bin/miden-node validator start
+WorkingDirectory=/opt/miden-validator
+User=miden-validator
+RestartSec=5
+Restart=always

--- a/packaging/validator/postinst
+++ b/packaging/validator/postinst
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# This is a postinstallation script so the service can be configured and started when requested.
+
+# user is expected by the systemd service file and `/opt/<user>` is its working directory,
+sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent miden-validator
+
+# Working folder.
+if [ -d "/opt/miden-validator" ]
+then
+    echo "Directory /opt/miden-validator exists."
+else
+    mkdir -p /opt/miden-validator
+fi
+sudo chown -R miden-validator /opt/miden-validator
+
+# Configuration folder
+if [ -d "/etc/opt/miden-validator" ]
+then
+    echo "Directory /etc/opt/miden-validator exists."
+else
+    mkdir -p /etc/opt/miden-validator
+fi
+sudo chown -R miden-validator /etc/opt/miden-validator
+
+sudo systemctl daemon-reload

--- a/packaging/validator/postrm
+++ b/packaging/validator/postrm
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+###############
+# Remove miden-validator installs
+##############
+sudo rm -rf /lib/systemd/system/miden-validator.service
+sudo rm -rf /etc/opt/miden-validator
+sudo deluser miden-validator
+sudo systemctl daemon-reload


### PR DESCRIPTION
## Context

We want to be able to deploy Validator as a separate instance to the node. The cleanest thing to do is package it separately to the node (as its own Debian package).

## Changes
- Crate Validator binary crate.
- Add Validator debian packaging files.
- Update Debian package publishing workflows.