### PR TITLE
fix: rocksdb missing `build.rs`

### DIFF
--- a/crates/utils/build.rs
+++ b/crates/utils/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    miden_node_rocksdb_cxx_linkage_fix::configure();
+}


### PR DESCRIPTION
Interestingly `machete` doesn't pick up on unused `[build-dependencies]`

Adds a missing `build.rs` for `miden-node-util` in https://github.com/0xMiden/miden-node/pull/1633