### PR TITLE
fix: flush OTel traces on panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.13.5 (TBD)
+
+- OpenTelemetry traces are now flushed before program termination on panic ([#1643](https://github.com/0xMiden/miden-node/pull/1643)).
+
 ## v0.13.4 (2026-02-04)
 
 - Fixed network monitor displaying explorer URL as a "null" hyperlink when unset ([#1617](https://github.com/0xMiden/miden-node/pull/1617)).


### PR DESCRIPTION
  The panic hook adds the panic span to the batch queue, but the program terminates immediately after. The OtelGuard in `main()` is never dropped. Now the flush happens synchronously before the program terminates on panics.

This PR is aiming to `main` since it might be a good addition to have for devnet/testnet as soon as possible.