### PR TITLE
chore: bump `time` and `bytes` for dependabot security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,9 +471,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2-sys"


### PR DESCRIPTION
Bump these deps in our lockfile to address minor security alerts from `dependabot`.

This leaves three unresolved alerts which are unfortunately bound to `pingora`. One small reason to get of it :) Of course we can just mentally ignore these.