### PR TITLE
fix: add ca-certificates to node Docker image for TLS support

### DIFF
--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -31,7 +31,9 @@ RUN cargo build --release --locked --bin miden-node
 FROM debian:bullseye-slim AS runtime-base
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends sqlite3 \
+    apt-get install -y --no-install-recommends \
+        sqlite3 \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 FROM runtime-base AS runtime


### PR DESCRIPTION
Fixes #1661

Adds `ca-certificates` to the node Docker runtime image to enable TLS/HTTPS connections. Required for OpenTelemetry telemetry export and remote prover HTTPS connections.