### PR TITLE
Fix broken OpenTelemetry link

### DIFF
--- a/docs/external/src/operator/monitoring.md
+++ b/docs/external/src/operator/monitoring.md
@@ -136,7 +136,7 @@ miden-node bundled start --enable-otel
 ```
 
 The exporter can be configured using environment variables as specified in the official
-[documents](httpthes://opentelemetry.io/docs/specs/otel/protocol/exporter/).
+[documents](https://opentelemetry.io/docs/specs/otel/protocol/exporter/).
 
 <div class="warning">
 Not all options are fully supported. We are limited to what the Rust OpenTelemetry implementation supports. If you have any problems please open an issue and we'll do our best to resolve it.


### PR DESCRIPTION
Fixed an incorrect URL in the documents: changed `httpthes://` to `https://` for the OpenTelemetry Protocol Exporter specification. The corrected link now properly points to `https://opentelemetry.io/docs/specs/otel/protocol/exporter/`
