### PR TITLE
fix: make build.rs example compile by adding anyhow imports and Resul…

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -13,8 +13,9 @@ generates the RPC component bindings and writes them into the `src/generated` di
 ```rust
 use std::{fs, path::PathBuf, env};
 use miden_node_proto_build::rpc_api_descriptor;
+use anyhow::{Context, Result};
 
-fn main() {
+fn main() -> Result<()> {
     let crate_root: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
     let dst_dir = crate_root.join("src").join("generated");
 
@@ -31,6 +32,8 @@ fn main() {
         .build_server(false) // this setting generates only the client side of the rpc api
         .compile_fds_with_config(prost_config, file_descriptors)
         .context("compiling protobufs")?;
+
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
### Summary
The `build.rs` example in `proto/README.md` was not compiling:

- `?` was used in `main()` without `main()` returning a `Result`.
- `.context(...)` was used, but `anyhow::Context` was not imported.

### Changes
- Added `use anyhow::{Context, Result};` to imports.
- Changed `fn main()` to `fn main() -> Result<()>`.
- Added `Ok(())` at the end of `main()` to satisfy the Result return type.

### Reason
This makes the example compile correctly and demonstrates modern, idiomatic Rust error handling using `anyhow`.

### Notes
- Only README/example code is affected.
- Works with users’ projects using `anyhow` and `?` for concise error propagation.