### PR TITLE
ci: add workflow cleanup

### DIFF
--- a/.github/workflows/cleanup-workflows.yml
+++ b/.github/workflows/cleanup-workflows.yml
@@ -1,0 +1,142 @@
+# Manual workflow to cleanup deleted workflows runs.
+#
+# Github keeps workflows runs around even if the workflow is deleted.
+# This has the side effect that these still display in the UI which gets cluttered.
+# Once the runs of a workflow are deleted, they also get removed from the UI.
+name: Cleanup Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Choose 'dry run' to preview or 'execute' to delete runs"
+        required: true
+        default: "dry run"
+        type: choice
+        options:
+          - "dry run"
+          - "execute"
+
+jobs:
+  cleanup:
+    name: Cleanup deleted workflows
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # required for deleting workflow runs
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Workflows on main
+        id: main
+        run: |
+          git fetch origin main
+          WORKFLOWS=$(git ls-tree -r origin/main --name-only | grep '^.github/workflows/')
+          echo $WORKFLOWS
+          echo "workflows=$WORKFLOWS" >> "$GITHUB_OUTPUT"
+
+      - name: Workflows on next
+        id: next
+        run: |
+          git fetch origin next
+          WORKFLOWS=$(git ls-tree -r origin/next --name-only | grep '^.github/workflows/')
+          echo $WORKFLOWS
+          echo "workflows=$WORKFLOWS" >> "$GITHUB_OUTPUT"
+
+      - name: Workflows on github
+        id: github
+        run: |
+          # Note that we filter by `.github` path prefix to ensure we only get locally defined workflows.
+          #
+          # Examples of non-local workflows are `dependabot` and `copilot` which have paths:
+          # - dynamic/dependabot/dependabot-updates
+          # - dynamic/copilot-pull-request-reviewer/copilot-pull-request-reviewer
+          WORKFLOWS=$(gh workflow list \
+            --all \
+            --json path \
+            --jq '.[] | select(.path | startswith(".github")) | .path' \
+          )
+          echo $WORKFLOWS
+          echo "workflows=$WORKFLOWS" >> "$GITHUB_OUTPUT"
+
+      - name: Filter for deleted workflows
+        id: deleted
+        run: |
+          # Union of `main` and `next` workflows.
+          EXISTING_FILES=$(                       \
+            printf "%s\n%s\n"                     \
+            "${{ steps.main.outputs.workflows }}" \
+            "${{ steps.next.outputs.workflows }}" \
+          )
+          EXISTING_FILES=$(echo "$EXISTING_FILES" | sort -u)
+          echo $EXISTING_FILES
+
+          # Find deleted workflows as the items in `WORKFLOWS` but not in the union of main and next.
+          # This assumes that _all_ items in main and next are present in `WORKFLOWS`.
+          DELETED_FILES=$(                          \
+            printf "%s\n%s\n"                       \
+            "$EXISTING_FILES"                       \
+            "${{ steps.github.outputs.workflows }}" \
+          )
+          DELETED_FILES=$(echo "$DELETED_FILES" | sort | uniq -u)
+          echo $DELETED_FILES
+          echo "workflows=$DELETED_FILES" >> "$GITHUB_OUTPUT"
+
+      - name: Delete runs from deleted workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: ${{ inputs.mode }}
+          DELETED_WORKFLOWS: ${{ steps.deleted.outputs.workflows }}
+        run: |
+          set -euo pipefail
+
+          TOTAL_AFFECTED=0
+
+          echo ""
+          echo "=== Workflow Cleanup Summary ==="
+          echo ""
+
+          while IFS= read -r workflow; do
+            [ -z "$workflow" ] && continue
+
+            WF_COUNT=0
+
+            while true; do
+              RUN_IDS=$(gh run list \
+                --workflow "$workflow" \
+                --limit 100 \
+                --json databaseId \
+                --jq '.[].databaseId')
+
+              if [ -z "$RUN_IDS" ]; then
+                break
+              fi
+
+              BATCH_COUNT=$(echo "$RUN_IDS" | wc -l | tr -d ' ')
+              WF_COUNT=$((WF_COUNT + BATCH_COUNT))
+
+              if [ "$MODE" = "execute" ]; then
+                for RUN_ID in $RUN_IDS; do
+                  gh run delete "$RUN_ID" --yes >/dev/null
+                done
+              fi
+            done
+
+            echo "$workflow → $WF_COUNT runs"
+            TOTAL_AFFECTED=$((TOTAL_AFFECTED + WF_COUNT))
+
+          done <<< "$DELETED_WORKFLOWS"
+
+          echo ""
+          echo "--------------------------------------"
+          echo "Total runs affected: $TOTAL_AFFECTED"
+
+          if [ "$MODE" = "dry run" ]; then
+            echo "Dry run complete. No runs were deleted."
+          else
+            echo "Cleanup complete."
+          fi


### PR DESCRIPTION
Github has this unfortunate UI design where deleted workflows continue to exist until _all_ their runs are deleted from history. Common sense would indicate that they have some retention policy and that they'll eventually fade away, but it seems like its much longer than the 90 days I've seen mentioned online.

This is annoying if you want to find or manually run a workflow. Refactoring or renaming is especially punishing because you end up with multiple of very similar entries.

This PR adds a **manual workflow** which deletes all runs of deleted workflows. Deletion is detected as those which don't exist on either `main` or `next`. This could technically be automated but this is a somewhat rare occurrence and its nice to know something won't just yank CI runs out from under you.

There is an argument to also delete existing workflow runs more deliberately i.e. only keep one weeks worth, but I don't see why we should complicate matters just to work around github being annoying. 

Here is a [discussion](https://github.com/orgs/community/discussions/26256) on this topic if you're interested in further frustration.