### PR TITLE
fix: hash storage map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for the note transport layer in the network monitor ([#1660](https://github.com/0xMiden/miden-node/pull/1660)).
 - Debian packages now include debug symbols ([#1666](https://github.com/0xMiden/miden-node/pull/1666)).
 - Debian packages now have coredumps enabled ([#1666](https://github.com/0xMiden/miden-node/pull/1666)).
+- Fixed storage map keys not being hashed before insertion into the store's SMT forest ([#1681](https://github.com/0xMiden/miden-node/pull/1681)).
 
 ## v0.13.4 (2026-02-04)
 

--- a/crates/store/src/inner_forest/mod.rs
+++ b/crates/store/src/inner_forest/mod.rs
@@ -489,7 +489,7 @@ impl InnerForest {
             // build a vector of raw entries and filter out any empty values; such values
             // shouldn't be present in full-state deltas, but it is good to exclude them
             // explicitly
-            let raw_entries: Vec<(Word, Word)> = map_delta
+            let raw_map_entries: Vec<(Word, Word)> = map_delta
                 .entries()
                 .iter()
                 .filter_map(|(&key, &value)| {
@@ -503,7 +503,7 @@ impl InnerForest {
 
             // if the delta is empty, make sure we create an entry in the storage map roots map
             // and storage entries map (so storage_map_entries() queries work)
-            if raw_entries.is_empty() {
+            if raw_map_entries.is_empty() {
                 self.storage_map_roots
                     .insert((account_id, slot_name.clone(), block_num), prev_root);
                 self.storage_entries
@@ -514,7 +514,7 @@ impl InnerForest {
 
             // hash the keys before inserting into the forest, matching how `StorageMap`
             // hashes keys before inserting into the SMT.
-            let hashed_entries: Vec<(Word, Word)> = raw_entries
+            let hashed_entries: Vec<(Word, Word)> = raw_map_entries
                 .iter()
                 .map(|(key, value)| (StorageMap::hash_key(*key), *value))
                 .collect();
@@ -528,13 +528,13 @@ impl InnerForest {
             self.storage_map_roots
                 .insert((account_id, slot_name.clone(), block_num), new_root);
 
-            assert!(!raw_entries.is_empty(), "a non-empty delta should have entries");
-            let num_entries = raw_entries.len();
+            assert!(!raw_map_entries.is_empty(), "a non-empty delta should have entries");
+            let num_entries = raw_map_entries.len();
 
             // keep track of the state of storage map entries (using raw keys for delta merging)
             // TODO: this is a temporary solution until the LargeSmtForest is implemented as
             // tracking multiple versions of all storage maps will be prohibitively expensive
-            let map_entries = BTreeMap::from_iter(raw_entries);
+            let map_entries = BTreeMap::from_iter(raw_map_entries);
             self.storage_entries
                 .insert((account_id, slot_name.clone(), block_num), map_entries);
 


### PR DESCRIPTION
This PR fixes an issue where the account storage map keys were not being hashed before being inserted in the `InnerForest`. It was discovered by @Fumuran 's work on a [client integration test](https://github.com/0xMiden/miden-client/blob/andrew-ntx-integration-test-fpi/bin/integration-tests/src/tests/network_fpi.rs) which should be unblocked once this PR gets merged.

Notable follow ups:

- Bring this to `next`
- Look into adding self-contained integration tests
- Look into logging network transaction builder errors more (this specifically happens on the `DataStore` impl for a merkle root not being correct and only an opaque "notes failed to be executed" was being logged). A dev flag could be a good start here.