### PR TITLE
chore: v0.13.5 release bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.13.5 (TBD)
+## v0.13.5 (2026-02-19)
 
 - OpenTelemetry traces are now flushed before program termination on panic ([#1643](https://github.com/0xMiden/miden-node/pull/1643)).
 - Added support for the note transport layer in the network monitor ([#1660](https://github.com/0xMiden/miden-node/pull/1660)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "fs-err",
  "miette",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "clap 4.5.54",
  "fs-err",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "fs-err",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.90"
-version      = "0.13.4"
+version      = "0.13.5"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]


### PR DESCRIPTION
Doing a `cargo publish --dry-run` locally, will merge once it passes.