### PR TITLE
chore: use `build-rs` in build scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -753,6 +753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "build-rs"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc87f52297187fb5d25bde3d368f0480f88ac1d8f3cf4c80ac5575435511114"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2268,15 +2277,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2972,6 +2972,7 @@ name = "miden-node-ntx-builder"
 version = "0.14.0"
 dependencies = [
  "anyhow",
+ "build-rs",
  "diesel",
  "diesel_migrations",
  "futures",
@@ -3003,6 +3004,7 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "build-rs",
  "fs-err",
  "hex",
  "http 1.4.0",
@@ -3026,6 +3028,7 @@ dependencies = [
 name = "miden-node-proto-build"
 version = "0.14.0"
 dependencies = [
+ "build-rs",
  "fs-err",
  "miette",
  "protox",
@@ -3074,6 +3077,7 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "build-rs",
  "criterion",
  "deadpool",
  "deadpool-diesel",
@@ -3178,6 +3182,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-kms",
+ "build-rs",
  "diesel",
  "diesel_migrations",
  "k256",
@@ -3277,6 +3282,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "build-rs",
  "clap",
  "fs-err",
  "http 1.4.0",
@@ -3310,6 +3316,7 @@ dependencies = [
 name = "miden-remote-prover-client"
 version = "0.14.0"
 dependencies = [
+ "build-rs",
  "fs-err",
  "getrandom 0.4.1",
  "miden-node-proto-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ miden-crypto = { default-features = false, version = "0.19" }
 anyhow            = { version = "1.0" }
 assert_matches    = { version = "1.5" }
 async-trait       = { version = "0.1" }
+build-rs          = { version = "0.3" }
 clap              = { features = ["derive"], version = "4.5" }
 deadpool          = { default-features = false, version = "0.12" }
 deadpool-diesel   = { version = "0.6" }

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -47,6 +47,7 @@ miden-testing   = { workspace = true }
 miden-tx        = { features = ["testing"], workspace = true }
 
 [build-dependencies]
+build-rs                           = { workspace = true }
 fs-err                             = { workspace = true }
 miden-node-proto-build             = { features = ["internal"], workspace = true }
 miden-node-rocksdb-cxx-linkage-fix = { workspace = true }

--- a/bin/remote-prover/build.rs
+++ b/bin/remote-prover/build.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use fs_err as fs;
 use miden_node_proto_build::remote_prover_api_descriptor;
@@ -9,8 +9,7 @@ use tonic_prost_build::FileDescriptorSet;
 fn main() -> miette::Result<()> {
     miden_node_rocksdb_cxx_linkage_fix::configure();
 
-    let dst_dir =
-        PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR should be set")).join("generated");
+    let dst_dir = build_rs::input::out_dir().join("generated");
 
     // Remove all existing files.
     let _ = fs::remove_dir_all(&dst_dir);

--- a/crates/ntx-builder/Cargo.toml
+++ b/crates/ntx-builder/Cargo.toml
@@ -34,6 +34,9 @@ tonic                      = { workspace = true }
 tracing                    = { workspace = true }
 url                        = { workspace = true }
 
+[build-dependencies]
+build-rs = { workspace = true }
+
 [dev-dependencies]
 miden-node-test-macro = { path = "../test-macro" }
 miden-node-utils      = { features = ["testing"], workspace = true }

--- a/crates/ntx-builder/build.rs
+++ b/crates/ntx-builder/build.rs
@@ -3,9 +3,9 @@
 // <https://docs.rs/diesel_migrations/latest/diesel_migrations/macro.embed_migrations.html#automatic-rebuilds>.
 
 fn main() {
-    println!("cargo:rerun-if-changed=./src/db/migrations");
+    build_rs::output::rerun_if_changed("src/db/migrations");
     // If we do one re-write, the default rules are disabled,
     // hence we need to trigger explicitly on `Cargo.toml`.
     // <https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed>
-    println!("cargo:rerun-if-changed=Cargo.toml");
+    build_rs::output::rerun_if_changed("Cargo.toml");
 }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -33,6 +33,7 @@ assert_matches = { workspace = true }
 proptest       = { version = "1.7" }
 
 [build-dependencies]
+build-rs                           = { workspace = true }
 fs-err                             = { workspace = true }
 miden-node-proto-build             = { features = ["internal"], workspace = true }
 miden-node-rocksdb-cxx-linkage-fix = { workspace = true }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use fs_err as fs;
 use miden_node_proto_build::{
@@ -16,12 +15,9 @@ use tonic_prost_build::FileDescriptorSet;
 
 /// Generates Rust protobuf bindings using `miden-node-proto-build`.
 fn main() -> miette::Result<()> {
-    println!("cargo::rerun-if-changed=../../proto/proto");
-
     miden_node_rocksdb_cxx_linkage_fix::configure();
 
-    let dst_dir =
-        PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR should be set")).join("generated");
+    let dst_dir = build_rs::input::out_dir().join("generated");
 
     // Remove all existing files.
     let _ = fs::remove_dir_all(&dst_dir);

--- a/crates/remote-prover-client/Cargo.toml
+++ b/crates/remote-prover-client/Cargo.toml
@@ -41,6 +41,7 @@ tokio          = { default-features = false, features = ["sync"], optional = tru
 tonic-prost    = { workspace = true }
 
 [build-dependencies]
+build-rs               = { workspace = true }
 fs-err                 = { workspace = true }
 miden-node-proto-build = { workspace = true }
 miette                 = { features = ["fancy"], version = "7.5" }

--- a/crates/remote-prover-client/build.rs
+++ b/crates/remote-prover-client/build.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use fs_err as fs;
 use miden_node_proto_build::remote_prover_api_descriptor;
@@ -8,9 +8,7 @@ use tonic_prost_build::FileDescriptorSet;
 
 /// Generates Rust protobuf bindings.
 fn main() -> miette::Result<()> {
-    let dst_dir =
-        PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is always set for build.rs"))
-            .join("generated");
+    let dst_dir = build_rs::input::out_dir().join("generated");
 
     // Remove all existing files.
     let _ = fs::remove_dir_all(&dst_dir);

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -50,6 +50,7 @@ tracing           = { workspace = true }
 url               = { workspace = true }
 
 [build-dependencies]
+build-rs                           = { workspace = true }
 fs-err                             = { workspace = true }
 miden-agglayer                     = { branch = "next", features = ["testing"], git = "https://github.com/0xMiden/miden-base" }
 miden-node-rocksdb-cxx-linkage-fix = { workspace = true }

--- a/crates/store/build.rs
+++ b/crates/store/build.rs
@@ -9,11 +9,11 @@ use miden_protocol::account::{Account, AccountCode, AccountFile};
 use miden_protocol::{Felt, Word};
 
 fn main() {
-    println!("cargo:rerun-if-changed=./src/db/migrations");
+    build_rs::output::rerun_if_changed("src/db/migrations");
     // If we do one re-write, the default rules are disabled,
     // hence we need to trigger explicitly on `Cargo.toml`.
     // <https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed>
-    println!("cargo:rerun-if-changed=Cargo.toml");
+    build_rs::output::rerun_if_changed("Cargo.toml");
 
     // Generate sample agglayer account files for genesis config samples.
     generate_agglayer_sample_accounts();
@@ -28,11 +28,9 @@ fn main() {
 /// - `02-with-account-files/agglayer_faucet_usdc.mac` - agglayer faucet for wrapped USDC
 fn generate_agglayer_sample_accounts() {
     // Use CARGO_MANIFEST_DIR to get the absolute path to the crate root
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let manifest_dir = build_rs::input::cargo_manifest_dir();
     let samples_dir: PathBuf =
-        [&manifest_dir, "src", "genesis", "config", "samples", "02-with-account-files"]
-            .iter()
-            .collect();
+        manifest_dir.join("src/genesis/config/samples/02-with-account-files");
 
     // Create the directory if it doesn't exist
     fs_err::create_dir_all(&samples_dir).expect("Failed to create samples directory");

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -37,4 +37,7 @@ tonic-reflection       = { workspace = true }
 tower-http             = { features = ["util"], workspace = true }
 tracing                = { workspace = true }
 
+[build-dependencies]
+build-rs = { workspace = true }
+
 [dev-dependencies]

--- a/crates/validator/build.rs
+++ b/crates/validator/build.rs
@@ -1,9 +1,10 @@
 // This build.rs is required to trigger the `diesel_migrations::embed_migrations!` proc-macro in
-// `validator/src/db/migrations.rs` to include the latest version of the migrations into the binary, see <https://docs.rs/diesel_migrations/latest/diesel_migrations/macro.embed_migrations.html#automatic-rebuilds>.
+// `validator/src/db/migrations.rs` to include the latest version of the migrations into the binary,
+// see <https://docs.rs/diesel_migrations/latest/diesel_migrations/macro.embed_migrations.html#automatic-rebuilds>.
 fn main() {
-    println!("cargo:rerun-if-changed=./src/db/migrations");
+    build_rs::output::rerun_if_changed("./src/db/migrations");
     // If we do one re-write, the default rules are disabled,
     // hence we need to trigger explicitly on `Cargo.toml`.
     // <https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed>
-    println!("cargo:rerun-if-changed=Cargo.toml");
+    build_rs::output::rerun_if_changed("Cargo.toml");
 }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -24,6 +24,7 @@ protox            = { workspace = true }
 tonic-prost-build = { workspace = true }
 
 [build-dependencies]
-fs-err = { workspace = true }
-miette = { version = "7.6" }
-protox = { workspace = true }
+build-rs = { workspace = true }
+fs-err   = { workspace = true }
+miette   = { version = "7.6" }
+protox   = { workspace = true }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,3 @@
-use std::env;
-use std::path::PathBuf;
-
 use fs_err as fs;
 use miette::{Context, IntoDiagnostic};
 use protox::prost::Message;
@@ -28,14 +25,10 @@ const VALIDATOR_DESCRIPTOR: &str = "validator_file_descriptor.bin";
 /// This is done only if `BUILD_PROTO` environment variable is set to `1` to avoid running the
 /// script on crates.io where repo-level .proto files are not available.
 fn main() -> miette::Result<()> {
-    println!("cargo::rerun-if-changed=./proto");
-    println!("cargo::rerun-if-env-changed=BUILD_PROTO");
+    build_rs::output::rerun_if_changed("./proto");
 
-    let out_dir = PathBuf::from(
-        env::var("OUT_DIR").expect("env::OUT_DIR is always set in build.rs when used with cargo"),
-    );
-
-    let crate_root: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+    let out_dir = build_rs::input::out_dir();
+    let crate_root = build_rs::input::cargo_manifest_dir();
     let proto_src_dir = crate_root.join("proto");
     let includes = &[proto_src_dir];
 


### PR DESCRIPTION
[`build-rs`](https://docs.rs/build-rs/latest/build_rs/) makes it harder to @#$%-up our build scripts. This is more a nice-to-have than anything else, ran across this while trying to add more complex codegen :)

> provides a strongly typed interface around the Cargo build script protocol. Cargo provides inputs to the build script by environment variable and accepts commands by printing to stdout.
>
>    This crate is maintained by the Cargo team for use by the wider ecosystem. This crate follows semver compatibility for its APIs.
