### PR TITLE
fix/ci: avoid race for port

### DIFF
--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -91,8 +91,7 @@ fn build_test_proven_tx(account: &Account, delta: &AccountDelta) -> ProvenTransa
 async fn rpc_server_accepts_requests_without_accept_header() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
 
     // Override the client so that the ACCEPT header is not set.
     let mut rpc_client = {
@@ -119,8 +118,7 @@ async fn rpc_server_accepts_requests_without_accept_header() {
 async fn rpc_server_accepts_requests_with_accept_header() {
     // Start the RPC.
     let (mut rpc_client, _, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
 
     // Send any request to the RPC.
     let response = send_request(&mut rpc_client).await;
@@ -180,8 +178,7 @@ async fn rpc_startup_is_robust_to_network_failures() {
     assert!(response.is_err());
 
     // Start the store.
-    let (store_runtime, data_directory, _genesis, store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, data_directory, _genesis, store_addr) = start_store(store_listener).await;
 
     // Test: send request against RPC api and should succeed
     let response = send_request(&mut rpc_client).await;
@@ -205,8 +202,7 @@ async fn rpc_startup_is_robust_to_network_failures() {
 async fn rpc_server_has_web_support() {
     // Start server
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
 
     // Send a status request
     let client = reqwest::Client::new();
@@ -249,8 +245,7 @@ async fn rpc_server_has_web_support() {
 async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, genesis, _store_addr) = start_store(store_listener).await;
 
     // Wait for the store to be ready before sending requests.
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -304,8 +299,7 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
 async fn rpc_server_rejects_tx_submissions_without_genesis() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
 
     // Override the client so that the ACCEPT header is not set.
     let mut rpc_client =
@@ -357,8 +351,7 @@ async fn send_request(
 /// Binds a socket on an available port, runs the RPC server on it, and
 /// returns a client to talk to the server, along with the socket address.
 async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TcpListener) {
-    let store_listener =
-        TcpListener::bind("127.0.0.1:0").await.expect("store should bind a port");
+    let store_listener = TcpListener::bind("127.0.0.1:0").await.expect("store should bind a port");
     let store_addr = store_listener.local_addr().expect("store should get a local address");
     let block_producer_addr = {
         let block_producer_listener =
@@ -416,9 +409,8 @@ async fn start_store(store_listener: TcpListener) -> (Runtime, TempDir, Word, So
         .await
         .expect("store should bootstrap");
     let dir = data_directory.path().to_path_buf();
-    let store_addr = store_listener
-        .local_addr()
-        .expect("store listener should get a local address");
+    let store_addr =
+        store_listener.local_addr().expect("store listener should get a local address");
     let rpc_listener = store_listener;
     let ntx_builder_listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -492,8 +484,7 @@ async fn restart_store(store_addr: SocketAddr, data_directory: &std::path::Path)
 async fn get_limits_endpoint() {
     // Start the RPC and store
     let (mut rpc_client, _rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
 
     // Call the get_limits endpoint
     let response = rpc_client.get_limits(()).await.expect("get_limits should succeed");
@@ -552,8 +543,7 @@ async fn get_limits_endpoint() {
 #[tokio::test]
 async fn sync_chain_mmr_returns_delta() {
     let (mut rpc_client, _rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) =
-        start_store(store_listener).await;
+    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
 
     let request = proto::rpc::SyncChainMmrRequest {
         block_range: Some(proto::rpc::BlockRange { block_from: 0, block_to: None }),


### PR DESCRIPTION
We currently re-bind a port, but with our expanding test suite it becomes a race for free ports.

The change passes the listener instead of an address to bind the limited resource _once_.