### PR TITLE
chore: update repo references from 0xMiden/miden-node to 0xMiden/node

### DIFF
--- a/.github/actions/debian/action.yml
+++ b/.github/actions/debian/action.yml
@@ -121,8 +121,8 @@ runs:
         Maintainer: Miden <devops@miden.team>
         Description: $pkg binary package
         Homepage: https://miden.xyz
-        Vcs-Git: git@github.com:0xMiden/miden-node.git
-        Vcs-Browser: https://github.com/0xMiden/miden-node
+        Vcs-Git: git@github.com:0xMiden/node.git
+        Vcs-Browser: https://github.com/0xMiden/node
         EOF
 
     - name: Build binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,28 @@
 
 ### Enhancements
 
-- [BREAKING] Move block proving from Blocker Producer to the Store ([#1579](https://github.com/0xMiden/miden-node/pull/1579)).
-- [BREAKING] Updated miden-base dependencies to use `next` branch; renamed `NoteInputs` to `NoteStorage`, `.inputs()` to `.storage()`, and database `inputs` column to `storage` ([#1595](https://github.com/0xMiden/miden-node/pull/1595)).
-- Validator now persists validated transactions ([#1614](https://github.com/0xMiden/miden-node/pull/1614)).
-- [BREAKING] Remove `SynState` and introduce `SyncChainMmr` ([#1591](https://github.com/0xMiden/miden-node/issues/1591)).
-- Introduce `SyncChainMmr` RPC endpoint to sync chain MMR deltas within specified block ranges ([#1591](https://github.com/0xMiden/miden-node/issues/1591)).
-- Fixed `TransactionHeader` serialization for row insertion on database & fixed transaction cursor on retrievals ([#1701](https://github.com/0xMiden/miden-node/issues/1701)).
-- Added KMS signing support in validator ([#1677](https://github.com/0xMiden/miden-node/pull/1677)).
+- [BREAKING] Move block proving from Blocker Producer to the Store ([#1579](https://github.com/0xMiden/node/pull/1579)).
+- [BREAKING] Updated miden-base dependencies to use `next` branch; renamed `NoteInputs` to `NoteStorage`, `.inputs()` to `.storage()`, and database `inputs` column to `storage` ([#1595](https://github.com/0xMiden/node/pull/1595)).
+- Validator now persists validated transactions ([#1614](https://github.com/0xMiden/node/pull/1614)).
+- [BREAKING] Remove `SynState` and introduce `SyncChainMmr` ([#1591](https://github.com/0xMiden/node/issues/1591)).
+- Introduce `SyncChainMmr` RPC endpoint to sync chain MMR deltas within specified block ranges ([#1591](https://github.com/0xMiden/node/issues/1591)).
+- Fixed `TransactionHeader` serialization for row insertion on database & fixed transaction cursor on retrievals ([#1701](https://github.com/0xMiden/node/issues/1701)).
+- Added KMS signing support in validator ([#1677](https://github.com/0xMiden/node/pull/1677)).
 
 ### Changes
 
-- [BREAKING] Removed obsolete `SyncState` RPC endpoint; clients should use `SyncNotes`, `SyncNullifiers`, `SyncAccountVault`, `SyncAccountStorageMaps`, `SyncTransactions`, or `SyncChainMmr` instead ([#1636](https://github.com/0xMiden/miden-node/pull/1636)).
-- Added account ID limits for `SyncTransactions`, `SyncAccountVault`, and `SyncAccountStorageMaps` to `GetLimits` responses ([#1636](https://github.com/0xMiden/miden-node/pull/1636)).
-- [BREAKING] Added typed `GetAccountError` for `GetAccount` endpoint, splitting `BlockNotAvailable` into `UnknownBlock` and `BlockPruned`. `AccountNotFound` and `AccountNotPublic` now return `InvalidArgument` gRPC status instead of `NotFound`; clients should parse the error details discriminant rather than branching on status codes ([#1646](https://github.com/0xMiden/miden-node/pull/1646)).
-- Changed `note_type` field in proto `NoteMetadata` from `uint32` to a `NoteType` enum ([#1594](https://github.com/0xMiden/miden-node/pull/1594)).
-- Refactored NTX Builder startup and introduced `NtxBuilderConfig` with configurable parameters ([#1610](https://github.com/0xMiden/miden-node/pull/1610)).
-- Refactored NTX Builder actor state into `AccountDeltaTracker` and `NotePool` for clarity, and added tracing instrumentation to event broadcasting ([#1611](https://github.com/0xMiden/miden-node/pull/1611)).
-- Add #[track_caller] to tracing/logging helpers ([#1651](https://github.com/0xMiden/miden-node/pull/1651)).
-- Added support for generic account loading at genesis ([#1624](https://github.com/0xMiden/miden-node/pull/1624)).
-- Improved tracing span fields ([#1650](https://github.com/0xMiden/miden-node/pull/1650))
- - Replaced NTX Builder's in-memory state management with SQLite-backed persistence; account states, notes, and transaction effects are now stored in the database and inflight state is purged on startup ([#1662](https://github.com/0xMiden/miden-node/pull/1662)).
-- [BREAKING] Reworked `miden-remote-prover`, removing the `worker`/`proxy` distinction and simplifying to a `worker` with a request queue ([#1688](https://github.com/0xMiden/miden-node/pull/1688)).
-- [BREAKING] Renamed `NoteRoot` protobuf message used in `GetNoteScriptByRoot` gRPC endpoints into `NoteScriptRoot` ([#1722](https://github.com/0xMiden/miden-node/pull/1722)).
+- [BREAKING] Removed obsolete `SyncState` RPC endpoint; clients should use `SyncNotes`, `SyncNullifiers`, `SyncAccountVault`, `SyncAccountStorageMaps`, `SyncTransactions`, or `SyncChainMmr` instead ([#1636](https://github.com/0xMiden/node/pull/1636)).
+- Added account ID limits for `SyncTransactions`, `SyncAccountVault`, and `SyncAccountStorageMaps` to `GetLimits` responses ([#1636](https://github.com/0xMiden/node/pull/1636)).
+- [BREAKING] Added typed `GetAccountError` for `GetAccount` endpoint, splitting `BlockNotAvailable` into `UnknownBlock` and `BlockPruned`. `AccountNotFound` and `AccountNotPublic` now return `InvalidArgument` gRPC status instead of `NotFound`; clients should parse the error details discriminant rather than branching on status codes ([#1646](https://github.com/0xMiden/node/pull/1646)).
+- Changed `note_type` field in proto `NoteMetadata` from `uint32` to a `NoteType` enum ([#1594](https://github.com/0xMiden/node/pull/1594)).
+- Refactored NTX Builder startup and introduced `NtxBuilderConfig` with configurable parameters ([#1610](https://github.com/0xMiden/node/pull/1610)).
+- Refactored NTX Builder actor state into `AccountDeltaTracker` and `NotePool` for clarity, and added tracing instrumentation to event broadcasting ([#1611](https://github.com/0xMiden/node/pull/1611)).
+- Add #[track_caller] to tracing/logging helpers ([#1651](https://github.com/0xMiden/node/pull/1651)).
+- Added support for generic account loading at genesis ([#1624](https://github.com/0xMiden/node/pull/1624)).
+- Improved tracing span fields ([#1650](https://github.com/0xMiden/node/pull/1650))
+ - Replaced NTX Builder's in-memory state management with SQLite-backed persistence; account states, notes, and transaction effects are now stored in the database and inflight state is purged on startup ([#1662](https://github.com/0xMiden/node/pull/1662)).
+- [BREAKING] Reworked `miden-remote-prover`, removing the `worker`/`proxy` distinction and simplifying to a `worker` with a request queue ([#1688](https://github.com/0xMiden/node/pull/1688)).
+- [BREAKING] Renamed `NoteRoot` protobuf message used in `GetNoteScriptByRoot` gRPC endpoints into `NoteScriptRoot` ([#1722](https://github.com/0xMiden/node/pull/1722)).
 
 ### Fixes
 
@@ -42,267 +42,267 @@
 
 ## v0.13.5 (2026-02-19)
 
-- OpenTelemetry traces are now flushed before program termination on panic ([#1643](https://github.com/0xMiden/miden-node/pull/1643)).
-- Added support for the note transport layer in the network monitor ([#1660](https://github.com/0xMiden/miden-node/pull/1660)).
-- Debian packages now include debug symbols ([#1666](https://github.com/0xMiden/miden-node/pull/1666)).
-- Debian packages now have coredumps enabled ([#1666](https://github.com/0xMiden/miden-node/pull/1666)).
-- Fixed storage map keys not being hashed before insertion into the store's SMT forest ([#1681](https://github.com/0xMiden/miden-node/pull/1681)).
+- OpenTelemetry traces are now flushed before program termination on panic ([#1643](https://github.com/0xMiden/node/pull/1643)).
+- Added support for the note transport layer in the network monitor ([#1660](https://github.com/0xMiden/node/pull/1660)).
+- Debian packages now include debug symbols ([#1666](https://github.com/0xMiden/node/pull/1666)).
+- Debian packages now have coredumps enabled ([#1666](https://github.com/0xMiden/node/pull/1666)).
+- Fixed storage map keys not being hashed before insertion into the store's SMT forest ([#1681](https://github.com/0xMiden/node/pull/1681)).
 
 ## v0.13.4 (2026-02-04)
 
-- Fixed network monitor displaying explorer URL as a "null" hyperlink when unset ([#1617](https://github.com/0xMiden/miden-node/pull/1617)).
-- Fixed empty storage maps not being inserted into `storage_entries` table when inserting storage delta ([#1642](https://github.com/0xMiden/miden-node/pull/1642)).
+- Fixed network monitor displaying explorer URL as a "null" hyperlink when unset ([#1617](https://github.com/0xMiden/node/pull/1617)).
+- Fixed empty storage maps not being inserted into `storage_entries` table when inserting storage delta ([#1642](https://github.com/0xMiden/node/pull/1642)).
 
 ## v0.13.3 (2026-01-29)
 
-- Fixed network monitor faucet test failing to parse `/get_metadata` response due to field type mismatches ([#1612](https://github.com/0xMiden/miden-node/pull/1612)).
+- Fixed network monitor faucet test failing to parse `/get_metadata` response due to field type mismatches ([#1612](https://github.com/0xMiden/node/pull/1612)).
 
 ## v0.13.2 (2026-01-27)
 
-- Network transaction builder no longer creates conflicting transactions by consuming the same notes twice ([#1597](https://github.com/0xMiden/miden-node/issues/1597)).
+- Network transaction builder no longer creates conflicting transactions by consuming the same notes twice ([#1597](https://github.com/0xMiden/node/issues/1597)).
 
 ## v0.13.1 (2026-01-27)
 
 ### Enhancements
 
-- Bootstrap's genesis configuration file now allows eliding `wallet` and `fungible_faucet` fields ([#1590](https://github.com/0xMiden/miden-node/pull/1590)).
-- Updated miden-base dependencies to version 0.13.3 ([#1601](https://github.com/0xMiden/miden-node/pull/1601)).
+- Bootstrap's genesis configuration file now allows eliding `wallet` and `fungible_faucet` fields ([#1590](https://github.com/0xMiden/node/pull/1590)).
+- Updated miden-base dependencies to version 0.13.3 ([#1601](https://github.com/0xMiden/node/pull/1601)).
 
 ### Fixes
 
-- Bootstrap's genesis configuration file is now optional again ([#1590](https://github.com/0xMiden/miden-node/pull/1590)).
-- Network transaction builder fails if output notes are created ([#1599](https://github.com/0xMiden/miden-node/pull/1599)).
-- Fixed the copy button in the network monitor ([#1600](https://github.com/0xMiden/miden-node/pull/1600)).
-- Network transaction builder now loads foreign account code into the MAST store when consuming network notes ([#1598](https://github.com/0xMiden/miden-node/pull/1598)).
+- Bootstrap's genesis configuration file is now optional again ([#1590](https://github.com/0xMiden/node/pull/1590)).
+- Network transaction builder fails if output notes are created ([#1599](https://github.com/0xMiden/node/pull/1599)).
+- Fixed the copy button in the network monitor ([#1600](https://github.com/0xMiden/node/pull/1600)).
+- Network transaction builder now loads foreign account code into the MAST store when consuming network notes ([#1598](https://github.com/0xMiden/node/pull/1598)).
 
 ## v0.13.0 (2026-01-23)
 
 ### Enhancements
 
-- Cleanup old account data from the database on apply block ([#1304](https://github.com/0xMiden/miden-node/issues/1304)).
-- Added block validation endpoint to validator and integrated with block producer ([#1382](https://github.com/0xMiden/miden-node/pull/1381)).
-- Added support for timeouts in the WASM remote prover clients ([#1383](https://github.com/0xMiden/miden-node/pull/1383)).
-- Added mempool statistics to the block producer status in the `miden-network-monitor` binary ([#1392](https://github.com/0xMiden/miden-node/pull/1392)).
-- Added `GetLimits` endpoint to the RPC server ([#1410](https://github.com/0xMiden/miden-node/pull/1410)).
-- Added chain tip to the block producer status ([#1419](https://github.com/0xMiden/miden-node/pull/1419)).
-- Added success rate to the `miden-network-monitor` binary ([#1420](https://github.com/0xMiden/miden-node/pull/1420)).
-- The mempool's transaction capacity is now configurable ([#1433](https://github.com/0xMiden/miden-node/pull/1433)).
-- Added pagination to `GetNetworkAccountIds` store endpoint ([#1452](https://github.com/0xMiden/miden-node/pull/1452)).
-- Integrated NTX Builder with validator via `SubmitProvenTransaction` RPC ([#1453](https://github.com/0xMiden/miden-node/pull/1453)).
-- Integrated RPC stack with Validator component for transaction validation ([#1457](https://github.com/0xMiden/miden-node/pull/1457)).
-- Added partial storage map queries to RPC ([#1428](https://github.com/0xMiden/miden-node/pull/1428)).
-- Added explorer status to the `miden-network-monitor` binary ([#1450](https://github.com/0xMiden/miden-node/pull/1450)).
-- Added validated transactions check to block validation logic in Validator ([#1460](https://github.com/0xMiden/miden-node/pull/1460)).
-- Added gRPC-Web probe support to the `miden-network-monitor` binary ([#1484](https://github.com/0xMiden/miden-node/pull/1484)).
-- Added DB schema change check ([#1268](https://github.com/0xMiden/miden-node/pull/1485)).
-- Added foreign account support to validator ([#1493](https://github.com/0xMiden/miden-node/pull/1493)).
-- Decoupled ntx-builder from block-producer startup by loading network accounts asynchronously via a background task ([#1495](https://github.com/0xMiden/miden-node/pull/1495)).
-- Improved DB query performance for account queries ([#1496](https://github.com/0xMiden/miden-node/pull/1496)).
-- The network monitor now marks the chain as unhealthy if it fails to create new blocks ([#1512](https://github.com/0xMiden/miden-node/pull/1512)).
-- Limited number of storage map keys in `GetAccount` requests ([#1517](https://github.com/0xMiden/miden-node/pull/1517)).
-- Block producer now detects if it is desync'd from the store's chain tip and aborts ([#1520](https://github.com/0xMiden/miden-node/pull/1520)).
-- Pin tool versions in CI ([#1523](https://github.com/0xMiden/miden-node/pull/1523)).
-- Add `GetVaultAssetWitnesses` and `GetStorageMapWitness` RPC endpoints to store ([#1529](https://github.com/0xMiden/miden-node/pull/1529)).
-- Add check to ensure tree store state is in sync with database storage ([#1532](https://github.com/0xMiden/miden-node/issues/1534)).
-- Ensure store terminates on nullifier tree or account tree root vs header mismatch (#[#1569](https://github.com/0xMiden/miden-node/pull/1569)).
-- Added support for foreign accounts to `NtxDataStore` and add `GetAccount` endpoint to NTX Builder gRPC store client ([#1521](https://github.com/0xMiden/miden-node/pull/1521)).
-- Use paged queries for tree rebuilding to reduce memory usage during startup ([#1536](https://github.com/0xMiden/miden-node/pull/1536)).
+- Cleanup old account data from the database on apply block ([#1304](https://github.com/0xMiden/node/issues/1304)).
+- Added block validation endpoint to validator and integrated with block producer ([#1382](https://github.com/0xMiden/node/pull/1381)).
+- Added support for timeouts in the WASM remote prover clients ([#1383](https://github.com/0xMiden/node/pull/1383)).
+- Added mempool statistics to the block producer status in the `miden-network-monitor` binary ([#1392](https://github.com/0xMiden/node/pull/1392)).
+- Added `GetLimits` endpoint to the RPC server ([#1410](https://github.com/0xMiden/node/pull/1410)).
+- Added chain tip to the block producer status ([#1419](https://github.com/0xMiden/node/pull/1419)).
+- Added success rate to the `miden-network-monitor` binary ([#1420](https://github.com/0xMiden/node/pull/1420)).
+- The mempool's transaction capacity is now configurable ([#1433](https://github.com/0xMiden/node/pull/1433)).
+- Added pagination to `GetNetworkAccountIds` store endpoint ([#1452](https://github.com/0xMiden/node/pull/1452)).
+- Integrated NTX Builder with validator via `SubmitProvenTransaction` RPC ([#1453](https://github.com/0xMiden/node/pull/1453)).
+- Integrated RPC stack with Validator component for transaction validation ([#1457](https://github.com/0xMiden/node/pull/1457)).
+- Added partial storage map queries to RPC ([#1428](https://github.com/0xMiden/node/pull/1428)).
+- Added explorer status to the `miden-network-monitor` binary ([#1450](https://github.com/0xMiden/node/pull/1450)).
+- Added validated transactions check to block validation logic in Validator ([#1460](https://github.com/0xMiden/node/pull/1460)).
+- Added gRPC-Web probe support to the `miden-network-monitor` binary ([#1484](https://github.com/0xMiden/node/pull/1484)).
+- Added DB schema change check ([#1268](https://github.com/0xMiden/node/pull/1485)).
+- Added foreign account support to validator ([#1493](https://github.com/0xMiden/node/pull/1493)).
+- Decoupled ntx-builder from block-producer startup by loading network accounts asynchronously via a background task ([#1495](https://github.com/0xMiden/node/pull/1495)).
+- Improved DB query performance for account queries ([#1496](https://github.com/0xMiden/node/pull/1496)).
+- The network monitor now marks the chain as unhealthy if it fails to create new blocks ([#1512](https://github.com/0xMiden/node/pull/1512)).
+- Limited number of storage map keys in `GetAccount` requests ([#1517](https://github.com/0xMiden/node/pull/1517)).
+- Block producer now detects if it is desync'd from the store's chain tip and aborts ([#1520](https://github.com/0xMiden/node/pull/1520)).
+- Pin tool versions in CI ([#1523](https://github.com/0xMiden/node/pull/1523)).
+- Add `GetVaultAssetWitnesses` and `GetStorageMapWitness` RPC endpoints to store ([#1529](https://github.com/0xMiden/node/pull/1529)).
+- Add check to ensure tree store state is in sync with database storage ([#1532](https://github.com/0xMiden/node/issues/1534)).
+- Ensure store terminates on nullifier tree or account tree root vs header mismatch (#[#1569](https://github.com/0xMiden/node/pull/1569)).
+- Added support for foreign accounts to `NtxDataStore` and add `GetAccount` endpoint to NTX Builder gRPC store client ([#1521](https://github.com/0xMiden/node/pull/1521)).
+- Use paged queries for tree rebuilding to reduce memory usage during startup ([#1536](https://github.com/0xMiden/node/pull/1536)).
 
 ### Changes
 
-- Improved tracing in `miden-network-monitor` binary ([#1366](https://github.com/0xMiden/miden-node/pull/1366)).
-- Added support for caching mempool statistics in the block producer server ([#1388](https://github.com/0xMiden/miden-node/pull/1388)).
-- Renamed card's names in the `miden-network-monitor` binary ([#1441](https://github.com/0xMiden/miden-node/pull/1441)).
-- [BREAKING] Removed `GetAccountDetails` RPC endpoint. Use `GetAccount` instead ([#1185](https://github.com/0xMiden/miden-node/issues/1185)).
-- [BREAKING] Renamed `SyncTransactions` response fields ([#1357](https://github.com/0xMiden/miden-node/pull/1357)).
-- Normalized response size in endpoints to 4 MB ([#1357](https://github.com/0xMiden/miden-node/pull/1357)).
-- [BREAKING] Renamed `ProxyWorkerStatus::address` to `ProxyWorkerStatus::name` ([#1348](https://github.com/0xMiden/miden-node/pull/1348)).
-- Added `SyncTransactions` stress test to `miden-node-stress-test` binary ([#1294](https://github.com/0xMiden/miden-node/pull/1294)).
-- Removed `trait AccountTreeStorage` ([#1352](https://github.com/0xMiden/miden-node/issues/1352)).
-- [BREAKING] `SubmitProvenTransaction` now **requires** that the network's genesis commitment is set in the request's `ACCEPT` header ([#1298](https://github.com/0xMiden/miden-node/pull/1298), [#1436](https://github.com/0xMiden/miden-node/pull/1436)).
-- Added `S` generic to `NullifierTree` to allow usage with `LargeSmt`s ([#1353](https://github.com/0xMiden/miden-node/issues/1353)).
-- Refactored account table and introduce tracking forest ([#1394](https://github.com/0xMiden/miden-node/pull/1394)).
-- [BREAKING] Re-organized RPC protobuf schema to be independent of internal schema ([#1401](https://github.com/0xMiden/miden-node/pull/1401)).
-- Removed internal errors from the `miden-network-monitor` ([#1424](https://github.com/0xMiden/miden-node/pull/1424)).
-- [BREAKING] Added block signing capabilities to Validator component and updated gensis bootstrap to sign blocks with configured signer ([#1426](https://github.com/0xMiden/miden-node/pull/1426)).
-- Track network transactions latency in `miden-network-monitor` ([#1430](https://github.com/0xMiden/miden-node/pull/1430)).
-- Reduced default block interval from `5s` to `2s` ([#1438](https://github.com/0xMiden/miden-node/pull/1438)).
-- Increased retained account tree history from 33 to 100 blocks to account for the reduced block interval ([#1438](https://github.com/0xMiden/miden-node/pull/1438)).
-- Increased the maximum query limit for the store ([#1443](https://github.com/0xMiden/miden-node/pull/1443)).
-- [BREAKING] Migrated to version `v0.20` of the VM ([#1476](https://github.com/0xMiden/miden-node/pull/1476)).
-- [BREAKING] Change account in database representation ([#1481](https://github.com/0xMiden/miden-node/pull/1481)).
-- Remove the cyclic database optimization ([#1497](https://github.com/0xMiden/miden-node/pull/1497)).
-- Fix race condition at DB shutdown in tests ([#1503](https://github.com/0xMiden/miden-node/pull/1503)).
-- [BREAKING] Updated to new miden-base protocol: removed `aux` and `execution_hint` from `NoteMetadata`, removed `NoteExecutionMode`, and `NoteMetadata::new()` is now infallible ([#1526](https://github.com/0xMiden/miden-node/pull/1526)).
-- [BREAKING] Network note queries now use full account ID instead of 30-bit prefix ([#1572](https://github.com/0xMiden/miden-node/pull/1572)).
-- [BREAKING] Renamed `SyncStorageMaps` RPC endpoint to `SyncAccountStorageMaps` for consistency ([#1581](https://github.com/0xMiden/miden-node/pull/1581)).
-- Removed git information from node's `--version` CLI as it was often incorrect ([#1576](https://github.com/0xMiden/miden-node/pull/1576)).
-- [BREAKING] Renamed `GetNetworkAccountDetailsByPrefix` endpoint to `GetNetworkAccountDetailsById` which now accepts full account ID instead of 30-bit prefix ([#1580](https://github.com/0xMiden/miden-node/pull/1580)).
-- Ensure store terminates on nullifier tree or account tree root vs header mismatch (#[#1569](https://github.com/0xMiden/miden-node/pull/1569)).
+- Improved tracing in `miden-network-monitor` binary ([#1366](https://github.com/0xMiden/node/pull/1366)).
+- Added support for caching mempool statistics in the block producer server ([#1388](https://github.com/0xMiden/node/pull/1388)).
+- Renamed card's names in the `miden-network-monitor` binary ([#1441](https://github.com/0xMiden/node/pull/1441)).
+- [BREAKING] Removed `GetAccountDetails` RPC endpoint. Use `GetAccount` instead ([#1185](https://github.com/0xMiden/node/issues/1185)).
+- [BREAKING] Renamed `SyncTransactions` response fields ([#1357](https://github.com/0xMiden/node/pull/1357)).
+- Normalized response size in endpoints to 4 MB ([#1357](https://github.com/0xMiden/node/pull/1357)).
+- [BREAKING] Renamed `ProxyWorkerStatus::address` to `ProxyWorkerStatus::name` ([#1348](https://github.com/0xMiden/node/pull/1348)).
+- Added `SyncTransactions` stress test to `miden-node-stress-test` binary ([#1294](https://github.com/0xMiden/node/pull/1294)).
+- Removed `trait AccountTreeStorage` ([#1352](https://github.com/0xMiden/node/issues/1352)).
+- [BREAKING] `SubmitProvenTransaction` now **requires** that the network's genesis commitment is set in the request's `ACCEPT` header ([#1298](https://github.com/0xMiden/node/pull/1298), [#1436](https://github.com/0xMiden/node/pull/1436)).
+- Added `S` generic to `NullifierTree` to allow usage with `LargeSmt`s ([#1353](https://github.com/0xMiden/node/issues/1353)).
+- Refactored account table and introduce tracking forest ([#1394](https://github.com/0xMiden/node/pull/1394)).
+- [BREAKING] Re-organized RPC protobuf schema to be independent of internal schema ([#1401](https://github.com/0xMiden/node/pull/1401)).
+- Removed internal errors from the `miden-network-monitor` ([#1424](https://github.com/0xMiden/node/pull/1424)).
+- [BREAKING] Added block signing capabilities to Validator component and updated gensis bootstrap to sign blocks with configured signer ([#1426](https://github.com/0xMiden/node/pull/1426)).
+- Track network transactions latency in `miden-network-monitor` ([#1430](https://github.com/0xMiden/node/pull/1430)).
+- Reduced default block interval from `5s` to `2s` ([#1438](https://github.com/0xMiden/node/pull/1438)).
+- Increased retained account tree history from 33 to 100 blocks to account for the reduced block interval ([#1438](https://github.com/0xMiden/node/pull/1438)).
+- Increased the maximum query limit for the store ([#1443](https://github.com/0xMiden/node/pull/1443)).
+- [BREAKING] Migrated to version `v0.20` of the VM ([#1476](https://github.com/0xMiden/node/pull/1476)).
+- [BREAKING] Change account in database representation ([#1481](https://github.com/0xMiden/node/pull/1481)).
+- Remove the cyclic database optimization ([#1497](https://github.com/0xMiden/node/pull/1497)).
+- Fix race condition at DB shutdown in tests ([#1503](https://github.com/0xMiden/node/pull/1503)).
+- [BREAKING] Updated to new miden-base protocol: removed `aux` and `execution_hint` from `NoteMetadata`, removed `NoteExecutionMode`, and `NoteMetadata::new()` is now infallible ([#1526](https://github.com/0xMiden/node/pull/1526)).
+- [BREAKING] Network note queries now use full account ID instead of 30-bit prefix ([#1572](https://github.com/0xMiden/node/pull/1572)).
+- [BREAKING] Renamed `SyncStorageMaps` RPC endpoint to `SyncAccountStorageMaps` for consistency ([#1581](https://github.com/0xMiden/node/pull/1581)).
+- Removed git information from node's `--version` CLI as it was often incorrect ([#1576](https://github.com/0xMiden/node/pull/1576)).
+- [BREAKING] Renamed `GetNetworkAccountDetailsByPrefix` endpoint to `GetNetworkAccountDetailsById` which now accepts full account ID instead of 30-bit prefix ([#1580](https://github.com/0xMiden/node/pull/1580)).
+- Ensure store terminates on nullifier tree or account tree root vs header mismatch (#[#1569](https://github.com/0xMiden/node/pull/1569)).
 
 ### Fixes
 
-- RPC client now correctly sets `genesis` value in `ACCEPT` header if `version` is unspecified ([#1370](https://github.com/0xMiden/miden-node/pull/1370)).
-- Pin protobuf (`protox`) dependencies to avoid breaking changes in transitive dependency ([#1403](https://github.com/0xMiden/miden-node/pull/1403)).
-- Fixed no-std compatibility for remote prover clients ([#1407](https://github.com/0xMiden/miden-node/pull/1407)).
-- Fixed `AccountProofRequest` to retrieve the latest known state in case specified block number (or chain tip) does not contain account updates ([#1422](https://github.com/0xMiden/miden-node/issues/1422)).
-- Fixed missing asset setup for full account initialization ([#1461](https://github.com/0xMiden/miden-node/pull/1461)).
-- Fixed `GetNetworkAccountIds` pagination to return the chain tip ([#1489](https://github.com/0xMiden/miden-node/pull/1489)).
-- Fixed the network monitor counter account to use the storage slot name ([#1501](https://github.com/0xMiden/miden-node/pull/1501)).
-- gRPC traces now correctly connect to the method implementation ([1553](https://github.com/0xMiden/miden-node/pull/1553)).
-- Fixed ntx-builder crash on node restart after network transaction by adding missing `is_latest` filter to network account query ([#1578](https://github.com/0xMiden/miden-node/pull/1578)).
+- RPC client now correctly sets `genesis` value in `ACCEPT` header if `version` is unspecified ([#1370](https://github.com/0xMiden/node/pull/1370)).
+- Pin protobuf (`protox`) dependencies to avoid breaking changes in transitive dependency ([#1403](https://github.com/0xMiden/node/pull/1403)).
+- Fixed no-std compatibility for remote prover clients ([#1407](https://github.com/0xMiden/node/pull/1407)).
+- Fixed `AccountProofRequest` to retrieve the latest known state in case specified block number (or chain tip) does not contain account updates ([#1422](https://github.com/0xMiden/node/issues/1422)).
+- Fixed missing asset setup for full account initialization ([#1461](https://github.com/0xMiden/node/pull/1461)).
+- Fixed `GetNetworkAccountIds` pagination to return the chain tip ([#1489](https://github.com/0xMiden/node/pull/1489)).
+- Fixed the network monitor counter account to use the storage slot name ([#1501](https://github.com/0xMiden/node/pull/1501)).
+- gRPC traces now correctly connect to the method implementation ([1553](https://github.com/0xMiden/node/pull/1553)).
+- Fixed ntx-builder crash on node restart after network transaction by adding missing `is_latest` filter to network account query ([#1578](https://github.com/0xMiden/node/pull/1578)).
 
 ## v0.12.8 (2026-01-15)
 
 ### Enhancements
 
-- Enable traces within database closures ([#1511](https://github.com/0xMiden/miden-node/pull/1511)).
+- Enable traces within database closures ([#1511](https://github.com/0xMiden/node/pull/1511)).
 
 ## v0.12.7 (2026-01-15)
 
 ### Enhancements
 
-- Emit database table size metrics ([#1511](https://github.com/0xMiden/miden-node/pull/1511)).
-- Improved telemetry in the network transaction builder ([#1508](https://github.com/0xMiden/miden-node/pull/1508)).
-- Improved telemetry in the store's `apply_block` ([#1508](https://github.com/0xMiden/miden-node/pull/1508)).
+- Emit database table size metrics ([#1511](https://github.com/0xMiden/node/pull/1511)).
+- Improved telemetry in the network transaction builder ([#1508](https://github.com/0xMiden/node/pull/1508)).
+- Improved telemetry in the store's `apply_block` ([#1508](https://github.com/0xMiden/node/pull/1508)).
 
 ### Fixes
 
-- Network transaction builder now marks notes from any error as failed ([#1508](https://github.com/0xMiden/miden-node/pull/1508)).
-- Network transaction builder now adheres to note limit set by protocol ([#1508](https://github.com/0xMiden/miden-node/pull/1508)).
-- Race condition resolved in the store's `apply_block` ([#1508](https://github.com/0xMiden/miden-node/pull/1508)).
+- Network transaction builder now marks notes from any error as failed ([#1508](https://github.com/0xMiden/node/pull/1508)).
+- Network transaction builder now adheres to note limit set by protocol ([#1508](https://github.com/0xMiden/node/pull/1508)).
+- Race condition resolved in the store's `apply_block` ([#1508](https://github.com/0xMiden/node/pull/1508)).
   - This presented as a database locked error and in rare cases a desync between the mempool and store.
 
 ## v0.12.6 (2026-01-12)
 
 ### Enhancements
 
-- Added Faucet metadata to the `miden-network-monitor` binary ([#1373](https://github.com/0xMiden/miden-node/pull/1373)).
-- Improve telemetry in the store ([#1504](https://github.com/0xMiden/miden-node/pull/1504)).
+- Added Faucet metadata to the `miden-network-monitor` binary ([#1373](https://github.com/0xMiden/node/pull/1373)).
+- Improve telemetry in the store ([#1504](https://github.com/0xMiden/node/pull/1504)).
 
 ### Fixes
 
-- Block producer crash caused by pass through transactions ([#1396](https://github.com/0xMiden/miden-node/pull/1396)).
+- Block producer crash caused by pass through transactions ([#1396](https://github.com/0xMiden/node/pull/1396)).
 
 ## v0.12.5 (2025-11-27)
 
-- Actually update `miden-base` dependencies ([#1384](https://github.com/0xMiden/miden-node/pull/1384)).
+- Actually update `miden-base` dependencies ([#1384](https://github.com/0xMiden/node/pull/1384)).
 
 ## v0.12.4 (2025-11-27)
 
-- Split counter increment and tracking services in `miden-network-monitor` binary ([#1362](https://github.com/0xMiden/miden-node/pull/1362)).
-- Updated the counter account from the `miden-network-monitor` to start at 0 ([#1367](https://github.com/0xMiden/miden-node/pull/1367)).
-- Updated  `miden-base` dependencies to fix ECDSA issues ([#1382](https://github.com/0xMiden/miden-node/pull/1382)).
+- Split counter increment and tracking services in `miden-network-monitor` binary ([#1362](https://github.com/0xMiden/node/pull/1362)).
+- Updated the counter account from the `miden-network-monitor` to start at 0 ([#1367](https://github.com/0xMiden/node/pull/1367)).
+- Updated  `miden-base` dependencies to fix ECDSA issues ([#1382](https://github.com/0xMiden/node/pull/1382)).
 
 ## v0.12.3 (2025-11-15)
 
-- Added configurable timeout support to `RemoteBatchProver`, `RemoteBlockProver`, and `RemoteTransactionProver` clients ([#1365](https://github.com/0xMiden/miden-node/pull/1365)).
-- Added configurable timeout support to `miden-network-monitor` binary ([#1365](https://github.com/0xMiden/miden-node/pull/1365)).
+- Added configurable timeout support to `RemoteBatchProver`, `RemoteBlockProver`, and `RemoteTransactionProver` clients ([#1365](https://github.com/0xMiden/node/pull/1365)).
+- Added configurable timeout support to `miden-network-monitor` binary ([#1365](https://github.com/0xMiden/node/pull/1365)).
 
 ## v0.12.2 (2025-11-12)
 
-- Fixed `PoW` challenge solving in `miden-network-monitor` binary ([#1363](https://github.com/0xMiden/miden-node/pull/1363)).
+- Fixed `PoW` challenge solving in `miden-network-monitor` binary ([#1363](https://github.com/0xMiden/node/pull/1363)).
 
 ## v0.12.1 (2025-11-08)
 
-- Added support for network transaction service in `miden-network-monitor` binary ([#1295](https://github.com/0xMiden/miden-node/pull/1295)).
-- Improves `.env` file example in for the `miden-network-monitor` binary ([#1345](https://github.com/0xMiden/miden-node/pull/1345)).
+- Added support for network transaction service in `miden-network-monitor` binary ([#1295](https://github.com/0xMiden/node/pull/1295)).
+- Improves `.env` file example in for the `miden-network-monitor` binary ([#1345](https://github.com/0xMiden/node/pull/1345)).
 
 ## v0.12.0 (2025-11-06)
 
 ### Changes
 
 - [BREAKING] Updated MSRV to 1.90.
-- [BREAKING] Refactored `CheckNullifiersByPrefix` endpoint adding pagination ([#1191](https://github.com/0xMiden/miden-node/pull/1191)).
-- [BREAKING] Renamed `CheckNullifiersByPrefix` endpoint to `SyncNullifiers` ([#1191](https://github.com/0xMiden/miden-node/pull/1191)).
-- Added `GetNoteScriptByRoot` gRPC endpoint for retrieving a note script by its root ([#1196](https://github.com/0xMiden/miden-node/pull/1196)).
-- [BREAKING] Added `block_range` and `pagination_info` fields to paginated gRPC endpoints ([#1205](https://github.com/0xMiden/miden-node/pull/1205)).
-- Implemented usage of `tonic` error codes for gRPC errors ([#1208](https://github.com/0xMiden/miden-node/pull/1208)).
-- [BREAKING] Replaced `GetAccountProofs` with `GetAccountProof` in the public store API (#[1211](https://github.com/0xMiden/miden-node/pull/1211)).
-- Implemented storage map `DataStore` function ([#1226](https://github.com/0xMiden/miden-node/pull/1226)).
-- [BREAKING] Refactored the mempool to use a single DAG across transactions and batches ([#1234](https://github.com/0xMiden/miden-node/pull/1234)).
-- [BREAKING] Renamed `RemoteProverProxy` to `RemoteProverClient` ([#1236](https://github.com/0xMiden/miden-node/pull/1236)).
-- Added pagination to `SyncNotes` endpoint ([#1257](https://github.com/0xMiden/miden-node/pull/1257)).
-- Added application level error in gRPC endpoints ([#1266](https://github.com/0xMiden/miden-node/pull/1266)).
-- Added `deploy-account` command to `miden-network-monitor` binary ([#1276](https://github.com/0xMiden/miden-node/pull/1276)).
-- [BREAKING] Response type nuances of `GetAccountProof` in the public store API (#[1277](https://github.com/0xMiden/miden-node/pull/1277)).
-- Add optional `TransactionInputs` field to `SubmitProvenTransaction` endpoint for transaction re-execution (#[1278](https://github.com/0xMiden/miden-node/pull/1278)).
-- Added `validator` crate with initial protobuf, gRPC server, and sub-command (#[1293](https://github.com/0xMiden/miden-node/pull/1293)).
-- [BREAKING] Added `AccountTreeWithHistory` and integrate historical queries into `GetAccountProof` ([#1292](https://github.com/0xMiden/miden-node/pull/1292)).
-- [BREAKING] Added `rocksdb` feature to enable rocksdb backends of `LargeSmt` ([#1326](https://github.com/0xMiden/miden-node/pull/1326)).
-- [BREAKING] Handle past/historical `AccountProof` requests ([#1333](https://github.com/0xMiden/miden-node/pull/1333)).
-- Implement `DataStore::get_note_script()` for `NtxDataStore` (#[1332](https://github.com/0xMiden/miden-node/pull/1332)).
-- Started validating notes by their commitment instead of ID before entering the mempool ([#1338](https://github.com/0xMiden/miden-node/pull/1338)).
+- [BREAKING] Refactored `CheckNullifiersByPrefix` endpoint adding pagination ([#1191](https://github.com/0xMiden/node/pull/1191)).
+- [BREAKING] Renamed `CheckNullifiersByPrefix` endpoint to `SyncNullifiers` ([#1191](https://github.com/0xMiden/node/pull/1191)).
+- Added `GetNoteScriptByRoot` gRPC endpoint for retrieving a note script by its root ([#1196](https://github.com/0xMiden/node/pull/1196)).
+- [BREAKING] Added `block_range` and `pagination_info` fields to paginated gRPC endpoints ([#1205](https://github.com/0xMiden/node/pull/1205)).
+- Implemented usage of `tonic` error codes for gRPC errors ([#1208](https://github.com/0xMiden/node/pull/1208)).
+- [BREAKING] Replaced `GetAccountProofs` with `GetAccountProof` in the public store API (#[1211](https://github.com/0xMiden/node/pull/1211)).
+- Implemented storage map `DataStore` function ([#1226](https://github.com/0xMiden/node/pull/1226)).
+- [BREAKING] Refactored the mempool to use a single DAG across transactions and batches ([#1234](https://github.com/0xMiden/node/pull/1234)).
+- [BREAKING] Renamed `RemoteProverProxy` to `RemoteProverClient` ([#1236](https://github.com/0xMiden/node/pull/1236)).
+- Added pagination to `SyncNotes` endpoint ([#1257](https://github.com/0xMiden/node/pull/1257)).
+- Added application level error in gRPC endpoints ([#1266](https://github.com/0xMiden/node/pull/1266)).
+- Added `deploy-account` command to `miden-network-monitor` binary ([#1276](https://github.com/0xMiden/node/pull/1276)).
+- [BREAKING] Response type nuances of `GetAccountProof` in the public store API (#[1277](https://github.com/0xMiden/node/pull/1277)).
+- Add optional `TransactionInputs` field to `SubmitProvenTransaction` endpoint for transaction re-execution (#[1278](https://github.com/0xMiden/node/pull/1278)).
+- Added `validator` crate with initial protobuf, gRPC server, and sub-command (#[1293](https://github.com/0xMiden/node/pull/1293)).
+- [BREAKING] Added `AccountTreeWithHistory` and integrate historical queries into `GetAccountProof` ([#1292](https://github.com/0xMiden/node/pull/1292)).
+- [BREAKING] Added `rocksdb` feature to enable rocksdb backends of `LargeSmt` ([#1326](https://github.com/0xMiden/node/pull/1326)).
+- [BREAKING] Handle past/historical `AccountProof` requests ([#1333](https://github.com/0xMiden/node/pull/1333)).
+- Implement `DataStore::get_note_script()` for `NtxDataStore` (#[1332](https://github.com/0xMiden/node/pull/1332)).
+- Started validating notes by their commitment instead of ID before entering the mempool ([#1338](https://github.com/0xMiden/node/pull/1338)).
 
 ## v0.11.3 (2025-11-04)
 
-- Reduced note retries to 1 ([#1308](https://github.com/0xMiden/miden-node/pull/1308)).
-- Address network transaction builder (NTX) invariant breaking for unavailable accounts ([#1312](https://github.com/0xMiden/miden-node/pull/1312)).
-- Tweaked HTTP configurations on the pingora proxy server ([#1281](https://github.com/0xMiden/miden-node/pull/1281)).
-- Added the counter increment task to `miden-network-monitor` binary ([#1295](https://github.com/0xMiden/miden-node/pull/1295)).
+- Reduced note retries to 1 ([#1308](https://github.com/0xMiden/node/pull/1308)).
+- Address network transaction builder (NTX) invariant breaking for unavailable accounts ([#1312](https://github.com/0xMiden/node/pull/1312)).
+- Tweaked HTTP configurations on the pingora proxy server ([#1281](https://github.com/0xMiden/node/pull/1281)).
+- Added the counter increment task to `miden-network-monitor` binary ([#1295](https://github.com/0xMiden/node/pull/1295)).
 
 ## v0.11.2 (2025-09-10)
 
-- Added support for keepalive requests against base path `/` of RPC server ([#1212](https://github.com/0xMiden/miden-node/pull/1212)).
-- [BREAKING] Replace `GetAccountProofs` with `GetAccountProof` in the public store API ([#1211](https://github.com/0xMiden/miden-node/pull/1211)).
-- [BREAKING] Optimize `GetAccountProof` for small accounts ([#1185](https://github.com/0xMiden/miden-node/pull/1185)).
+- Added support for keepalive requests against base path `/` of RPC server ([#1212](https://github.com/0xMiden/node/pull/1212)).
+- [BREAKING] Replace `GetAccountProofs` with `GetAccountProof` in the public store API ([#1211](https://github.com/0xMiden/node/pull/1211)).
+- [BREAKING] Optimize `GetAccountProof` for small accounts ([#1185](https://github.com/0xMiden/node/pull/1185)).
 
 ## v0.11.1 (2025-09-08)
 
 - Removed decorators from scripts when submitting transactions and batches, and inserting notes into the DB ([#1194](https://github.com/
-0xMiden/miden-node/pull/1194)).
+0xMiden/node/pull/1194)).
 - Refresh `miden-base` dependencies.
-- Added `SyncTransactions` gRPC endpoint for retrieving transactions for specific accounts within a block range ([#1224](https://github.com/0xMiden/miden-node/pull/1224)).
-- Added `miden-network-monitor` binary for monitoring the Miden network ([#1217](https://github.com/0xMiden/miden-node/pull/1217)).
+- Added `SyncTransactions` gRPC endpoint for retrieving transactions for specific accounts within a block range ([#1224](https://github.com/0xMiden/node/pull/1224)).
+- Added `miden-network-monitor` binary for monitoring the Miden network ([#1217](https://github.com/0xMiden/node/pull/1217)).
 
 ## v0.11.0 (2025-08-28)
 
 ### Enhancements
 
-- Added environment variable support for batch and block size CLI arguments ([#1081](https://github.com/0xMiden/miden-node/pull/1081)).
-- RPC accept header now supports specifying the genesis commitment in addition to the RPC version. This lets clients ensure they are on the right network ([#1084](https://github.com/0xMiden/miden-node/pull/1084)).
-- A transaction's account delta is now checked against its commitments in `SubmitProvenTransaction` endpoint ([#1093](https://github.com/0xMiden/miden-node/pull/1093)).
-- Added check for Account Id prefix uniqueness when transactions to create accounts are submitted to the mempool ([#1094](https://github.com/0xMiden/miden-node/pull/1094)).
-- Added benchmark CLI sub-command for the `miden-store` component to measure the state load time ([#1154](https://github.com/0xMiden/miden-node/pull/1154)).
-- Retry failed network notes with exponential backoff instead of immediately ([#1116](https://github.com/0xMiden/miden-node/pull/1116))
-- Network notes are now dropped after failing 30 times ([#1116](https://github.com/0xMiden/miden-node/pull/1116))
-- gRPC server timeout is now configurable (defaults to `10s`) ([#1133](https://github.com/0xMiden/miden-node/pull/1133))
-- [BREAKING] Refactored protobuf messages ([#1045](https://github.com/0xMiden/miden-node/pull/#1045)).
-- Added `SyncStorageMaps` gRPC endpoint for retrieving account storage maps ([#1140](https://github.com/0xMiden/miden-node/pull/1140), [#1132](https://github.com/0xMiden/miden-node/pull/1132)).
-- Added `SyncAccountVault` gRPC endpoints for retrieving account assets ([#1176](https://github.com/0xMiden/miden-node/pull/1176)).
-- Refactored Network Transaction Builder to manage dedicated tasks for every network account in the chain ([#1219](https://github.com/0xMiden/miden-node/pull/1219)).
+- Added environment variable support for batch and block size CLI arguments ([#1081](https://github.com/0xMiden/node/pull/1081)).
+- RPC accept header now supports specifying the genesis commitment in addition to the RPC version. This lets clients ensure they are on the right network ([#1084](https://github.com/0xMiden/node/pull/1084)).
+- A transaction's account delta is now checked against its commitments in `SubmitProvenTransaction` endpoint ([#1093](https://github.com/0xMiden/node/pull/1093)).
+- Added check for Account Id prefix uniqueness when transactions to create accounts are submitted to the mempool ([#1094](https://github.com/0xMiden/node/pull/1094)).
+- Added benchmark CLI sub-command for the `miden-store` component to measure the state load time ([#1154](https://github.com/0xMiden/node/pull/1154)).
+- Retry failed network notes with exponential backoff instead of immediately ([#1116](https://github.com/0xMiden/node/pull/1116))
+- Network notes are now dropped after failing 30 times ([#1116](https://github.com/0xMiden/node/pull/1116))
+- gRPC server timeout is now configurable (defaults to `10s`) ([#1133](https://github.com/0xMiden/node/pull/1133))
+- [BREAKING] Refactored protobuf messages ([#1045](https://github.com/0xMiden/node/pull/#1045)).
+- Added `SyncStorageMaps` gRPC endpoint for retrieving account storage maps ([#1140](https://github.com/0xMiden/node/pull/1140), [#1132](https://github.com/0xMiden/node/pull/1132)).
+- Added `SyncAccountVault` gRPC endpoints for retrieving account assets ([#1176](https://github.com/0xMiden/node/pull/1176)).
+- Refactored Network Transaction Builder to manage dedicated tasks for every network account in the chain ([#1219](https://github.com/0xMiden/node/pull/1219)).
 
 ### Changes
 
 - [BREAKING] Updated MSRV to 1.88.
-- [BREAKING] De-duplicate storage of code in DB (no-migration) ([#1083](https://github.com/0xMiden/miden-node/issue/#1083)).
-- [BREAKING] RPC accept header format changed from `application/miden.vnd+grpc.<version>` to `application/vnd.miden; version=<version>` ([#1084](https://github.com/0xMiden/miden-node/pull/1084)).
-- [BREAKING] Integrated `FeeParameters` into block headers. ([#1122](https://github.com/0xMiden/miden-node/pull/1122)).
-- [BREAKING] Genesis configuration now supports fees ([#1157](https://github.com/0xMiden/miden-node/pull/1157)).
+- [BREAKING] De-duplicate storage of code in DB (no-migration) ([#1083](https://github.com/0xMiden/node/issue/#1083)).
+- [BREAKING] RPC accept header format changed from `application/miden.vnd+grpc.<version>` to `application/vnd.miden; version=<version>` ([#1084](https://github.com/0xMiden/node/pull/1084)).
+- [BREAKING] Integrated `FeeParameters` into block headers. ([#1122](https://github.com/0xMiden/node/pull/1122)).
+- [BREAKING] Genesis configuration now supports fees ([#1157](https://github.com/0xMiden/node/pull/1157)).
   - Configure `NativeFaucet`, which determines the native asset used to pay fees
   - Configure the base verification fee
   - Note: fees are not yet activated, and this has no impact beyond setting these values in the block headers
-- [BREAKING] Remove public store API `GetAccountStateDelta` ([#1162](https://github.com/0xMiden/miden-node/pull/1162)).
-- Removed `faucet` binary ([#1172](https://github.com/0xMiden/miden-node/pull/1172)).
-- Add `genesis_commitment` in `Status` response ([#1181](https://github.com/0xMiden/miden-node/pull/1181)).
+- [BREAKING] Remove public store API `GetAccountStateDelta` ([#1162](https://github.com/0xMiden/node/pull/1162)).
+- Removed `faucet` binary ([#1172](https://github.com/0xMiden/node/pull/1172)).
+- Add `genesis_commitment` in `Status` response ([#1181](https://github.com/0xMiden/node/pull/1181)).
 
 ### Fixes
 
 - [BREAKING] Integrated proxy status endpoint into main proxy service, removing separate status port.
-- RPC requests with wildcard (`*/*`) media-type are not longer rejected ([#1084](https://github.com/0xMiden/miden-node/pull/1084)).
-- Stress-test CLI account now properly sets the storage mode and increment nonce in transactions ([#1113](https://github.com/0xMiden/miden-node/pull/1113)).
-- [BREAKING] Update `notes` table schema to have a nullable `consumed_block_num` ([#1100](https://github.com/0xMiden/miden-node/pull/1100)).
-- Network Transaction Builder now correctly discards non-single-target network notes instead of panicking ([#1166](https://github.com/0xMiden/miden-node/pull/1166)).
+- RPC requests with wildcard (`*/*`) media-type are not longer rejected ([#1084](https://github.com/0xMiden/node/pull/1084)).
+- Stress-test CLI account now properly sets the storage mode and increment nonce in transactions ([#1113](https://github.com/0xMiden/node/pull/1113)).
+- [BREAKING] Update `notes` table schema to have a nullable `consumed_block_num` ([#1100](https://github.com/0xMiden/node/pull/1100)).
+- Network Transaction Builder now correctly discards non-single-target network notes instead of panicking ([#1166](https://github.com/0xMiden/node/pull/1166)).
 
 ### Removed
 
-- Moved the `miden-faucet` binary to the [`miden-faucet` repository](https://github.com/0xmiden/miden-faucet) ([#1179](https://github.com/0xMiden/miden-node/pull/1179)).
+- Moved the `miden-faucet` binary to the [`miden-faucet` repository](https://github.com/0xmiden/miden-faucet) ([#1179](https://github.com/0xMiden/node/pull/1179)).
 
 ## v0.10.1 (2025-07-14)
 
 ### Fixes
 
-- Network accounts are no longer disabled after one transaction ([#1086](https://github.com/0xMiden/miden-node/pull/1086)).
+- Network accounts are no longer disabled after one transaction ([#1086](https://github.com/0xMiden/node/pull/1086)).
 
 ## v0.10.0 (2025-07-10)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude      = [".github/"]
 homepage     = "https://miden.xyz"
 license      = "MIT"
 readme       = "README.md"
-repository   = "https://github.com/0xMiden/miden-node"
+repository   = "https://github.com/0xMiden/node"
 rust-version = "1.91"
 version      = "0.14.0"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miden node
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-node/blob/main/LICENSE)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/node/blob/main/LICENSE)
 [![CI](https://github.com/0xMiden/node/actions/workflows/ci.yml/badge.svg)](https://github.com/0xMiden/node/actions/workflows/ci.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.90+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-node)](https://crates.io/crates/miden-node)

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -38,8 +38,8 @@ FROM runtime-base AS runtime
 COPY --from=builder /app/target/release/miden-node /usr/local/bin/miden-node
 LABEL org.opencontainers.image.authors=devops@miden.team \
     org.opencontainers.image.url=https://0xMiden.github.io/ \
-    org.opencontainers.image.documentation=https://github.com/0xMiden/miden-node \
-    org.opencontainers.image.source=https://github.com/0xMiden/miden-node \
+    org.opencontainers.image.documentation=https://github.com/0xMiden/node \
+    org.opencontainers.image.source=https://github.com/0xMiden/node \
     org.opencontainers.image.vendor=Miden \
     org.opencontainers.image.licenses=MIT
 ARG CREATED

--- a/bin/remote-prover/README.md
+++ b/bin/remote-prover/README.md
@@ -7,7 +7,7 @@ This enables weaker devices to offload the proof generation to a beefy remote se
 The implementation provides a configurable request queue and proves one request at a time in FIFO order. This is not intended to cover
 complex proxy setups nor load-balancing, but can instead be used as a starting point for more advanced setups.
 
-The gRPC specification can be found in the [Miden repository](https://github.com/0xMiden/miden-node/blob/main/proto/proto/remote_prover.proto).
+The gRPC specification can be found in the [Miden repository](https://github.com/0xMiden/node/blob/main/proto/proto/remote_prover.proto).
 Ensure you are viewing the appropriate version tag or commit.
 
 ## Quick start
@@ -43,8 +43,8 @@ Install the Debian package:
 ```bash
 set -e
 
-sudo wget https://github.com/0xMiden/miden-node/releases/download/v0.8/miden-prover-v0.8-arm64.deb -O prover.deb
-sudo wget -q -O - https://github.com/0xMiden/miden-node/releases/download/v0.8/miden-prover-v0.8-arm64.deb.checksum | awk '{print $1}' | sudo tee prover.checksum
+sudo wget https://github.com/0xMiden/node/releases/download/v0.8/miden-prover-v0.8-arm64.deb -O prover.deb
+sudo wget -q -O - https://github.com/0xMiden/node/releases/download/v0.8/miden-prover-v0.8-arm64.deb.checksum | awk '{print $1}' | sudo tee prover.checksum
 sudo sha256sum prover.deb | awk '{print $1}' > prover.sha256
 sudo diff prover.sha256 prover.checksum
 sudo dpkg -i prover.deb
@@ -125,7 +125,7 @@ The server implements the following health and status related gRPC services:
 
 - [gRPC Health Check](https://grpc.io/docs/guides/health-checking/)
 - [gRPC Reflection](https://grpc.io/docs/guides/reflection/) 
-- [WorkerStatusApi](https://github.com/0xMiden/miden-node/blob/main/proto/proto/remote_prover.proto)
+- [WorkerStatusApi](https://github.com/0xMiden/node/blob/main/proto/proto/remote_prover.proto)
 
 The server supports OpenTelemetry traces which can be configured using the environment variables specified in the OpenTelemetry documentation.
 

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -365,7 +365,7 @@ pub async fn load_smt_forest(
         // Process each account in this page
         for account_id in page.account_ids {
             // TODO: Loading the full account from the database is inefficient and will need to
-            // go away. <https://github.com/0xMiden/miden-node/issues/1556>
+            // go away. <https://github.com/0xMiden/node/issues/1556>
             let account_info = db.select_account(account_id).await?;
             let account = account_info
                 .details

--- a/docs/external/src/index.md
+++ b/docs/external/src/index.md
@@ -20,6 +20,6 @@ interface for users, dApps, wallets and other clients to submit transactions and
 ## Feedback
 
 Please report any issues, ask questions or leave feedback in the node repository
-[here](https://github.com/0xMiden/miden-node/issues/new/choose).
+[here](https://github.com/0xMiden/node/issues/new/choose).
 
 This includes outdated, misleading, incorrect or just plain confusing information :)

--- a/docs/external/src/operator/index.md
+++ b/docs/external/src/operator/index.md
@@ -4,4 +4,4 @@ Welcome to the `Miden` node operator guide which should cover everything you nee
 Miden node.
 
 You can report any issues, ask questions or leave feedback at our project repo
-[here](https://github.com/0xMiden/miden-node/issues/new/choose).
+[here](https://github.com/0xMiden/node/issues/new/choose).

--- a/docs/external/src/operator/installation.md
+++ b/docs/external/src/operator/installation.md
@@ -8,7 +8,7 @@ We provide Debian packages for official releases for the node software. Alternat
 
 ## Debian package
 
-Official Debian packages are available under our [releases](https://github.com/0xMiden/miden-node/releases) page.
+Official Debian packages are available under our [releases](https://github.com/0xMiden/node/releases) page.
 Both `amd64` and `arm64` packages are available.
 
 Note that the packages include a `systemd` service which is disabled by default.
@@ -69,13 +69,13 @@ this for advanced use only. The incantation is a little different as you'll be t
 
 ```sh
 # Install from a specific branch
-cargo install --locked --git https://github.com/0xMiden/miden-node miden-node --branch <branch>
+cargo install --locked --git https://github.com/0xMiden/node miden-node --branch <branch>
 
 # Install a specific tag
-cargo install --locked --git https://github.com/0xMiden/miden-node miden-node --tag <tag>
+cargo install --locked --git https://github.com/0xMiden/node miden-node --tag <tag>
 
 # Install a specific git revision
-cargo install --locked --git https://github.com/0xMiden/miden-node miden-node --rev <git-sha>
+cargo install --locked --git https://github.com/0xMiden/node miden-node --rev <git-sha>
 ```
 
 More information on the various `cargo install` options can be found

--- a/docs/external/src/operator/usage.md
+++ b/docs/external/src/operator/usage.md
@@ -142,4 +142,4 @@ source profile.env && miden-node <...>
 
 This works well on Linux and MacOS, but Windows requires some additional scripting unfortunately.
 
-See the `.env` files in each of the binary crates' [directories](https://github.com/0xMiden/miden-node/tree/next/bin) for a list of all available environment variables.
+See the `.env` files in each of the binary crates' [directories](https://github.com/0xMiden/node/tree/next/bin) for a list of all available environment variables.

--- a/docs/external/src/rpc.md
+++ b/docs/external/src/rpc.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 This is a reference of the Node's public RPC interface. It consists of a gRPC API which may be used to submit transactions and query the state of the blockchain.
 
-The gRPC service definition can be found in the Miden node's `proto` [directory](https://github.com/0xMiden/miden-node/tree/main/proto) in the `rpc.proto` file.
+The gRPC service definition can be found in the Miden node's `proto` [directory](https://github.com/0xMiden/node/tree/main/proto) in the `rpc.proto` file.
 
 <!--toc:start-->
 

--- a/docs/internal/book.toml
+++ b/docs/internal/book.toml
@@ -6,7 +6,7 @@ multilingual = false
 title        = "The Miden Node Developer Guide"
 
 [output.html]
-git-repository-url = "https://github.com/0xMiden/miden-node"
+git-repository-url = "https://github.com/0xMiden/node"
 
 [preprocessor.katex]
 after = ["links"]

--- a/docs/internal/src/index.md
+++ b/docs/internal/src/index.md
@@ -14,6 +14,6 @@ It is also a good idea to familiarise yourself with the [operator manual](https:
 Living documents go stale - the code is the final arbitrator of truth.
 
 If you encounter any outdated, incorrect or misleading information, please
-[open an issue](https://github.com/0xMiden/miden-node/issues/new/choose).
+[open an issue](https://github.com/0xMiden/node/issues/new/choose).
 
 </div>


### PR DESCRIPTION
## Summary
- Replaces all `0xMiden/miden-node` GitHub URL references with `0xMiden/node` across docs, CI, Dockerfile, Cargo.toml, and source code comments
- 14 files updated (docs, README, Dockerfile, Cargo.toml, CI actions, source comment)

## Test plan
- [ ] CI passes (pure reference/URL change, no logic affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)