### PR TITLE
fix: set RUSTUP_TOOLCHAIN=stable for MSRV check in publish workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Install cargo-msrv
         run: cargo binstall --no-confirm --force cargo-msrv
       - name: Check MSRV for each workspace member
+        # Use stable toolchain instead of rust-toolchain.toml version to avoid
+        # issues where cargo-msrv requires a newer Rust than the pinned version.
+        env:
+          RUSTUP_TOOLCHAIN: stable
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
           ./scripts/check-msrv.sh


### PR DESCRIPTION
## Summary

- The publish workflow's MSRV check (`check-msrv.sh`) fails for every workspace member because `rust-toolchain.toml` pins the channel to `1.91`, which interferes with `cargo-msrv`'s toolchain resolution
- The nightly workflow already avoids this by setting `RUSTUP_TOOLCHAIN: stable` (with an explicit comment explaining why)
- This applies the same fix to the publish workflow's MSRV check step

## Context

Failed run: https://github.com/0xMiden/node/actions/runs/23306258363/job/67781096134

The nightly workflow's MSRV checks all pass because it sets `env: RUSTUP_TOOLCHAIN: stable`. The publish workflow was missing this override, causing `cargo msrv verify` to fail when `rust-toolchain.toml` is present.

## Test plan

- Re-run the release workflow after merging; the MSRV check step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)