### PR TITLE
fix(rpc): stop classifying expected gRPC responses as trace errors

### DIFF
--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -11,6 +11,7 @@ use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic_reflection::server;
 use tonic_web::GrpcWebLayer;
+use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 use url::Url;
@@ -74,7 +75,17 @@ impl Rpc {
             .timeout(self.grpc_options.request_timeout)
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
             .layer(grpc::connect_info_layer())
-            .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
+            .layer(
+                TraceLayer::new(SharedClassifier::new(
+                    GrpcErrorsAsFailures::new()
+                        .with_success(GrpcCode::InvalidArgument)
+                        .with_success(GrpcCode::NotFound)
+                        .with_success(GrpcCode::ResourceExhausted)
+                        .with_success(GrpcCode::Unimplemented)
+                        .with_success(GrpcCode::Unknown),
+                ))
+                .make_span_with(grpc_trace_fn),
+            )
             .layer(HealthCheckLayer)
             .layer(grpc::rate_limit_concurrent_connections(self.grpc_options))
             .layer(grpc::rate_limit_per_ip(self.grpc_options)?)


### PR DESCRIPTION
## Problem

On devnet we regularly observe a spike of errors in our traces, all originating from `tower_http::trace::on_failure`. `TraceLayer::new_for_grpc()` classifier treats every non-`Ok` gRPC status code as a failure, which emits `ERROR`-level trace events. The errors include:

- **`RESOURCE_EXHAUSTED` (code 8)** — rate limiting working as intended
- **`UNIMPLEMENTED` (code 12)** — security scanners probing non-existent RPC methods
- **`UNKNOWN` (code 2)** — scanners probing paths like `.env`, `.git/config`, `.aws/credentials`

None of these are actual server errors — they're either expected operational behavior (rate limiting) or client/scanner misbehavior.

## Solution

Replace `TraceLayer::new_for_grpc()` with a customized `GrpcErrorsAsFailures` classifier that treats client-fault and expected-operational codes as successes:

| Code | Name | Rationale |
|------|------|-----------|
| 2 | `Unknown` | Scanner probing garbage paths |
| 3 | `InvalidArgument` | Client validation errors |
| 5 | `NotFound` | Scanner probing non-existent resources |
| 8 | `ResourceExhausted` | Rate limiting (expected behavior) |
| 12 | `Unimplemented` | Scanner hitting non-existent RPC methods |

These responses are still returned to clients with the same gRPC status codes — the only change is that they no longer trigger `on_failure` (ERROR-level) in traces, and instead flow through `on_response` (DEBUG-level).

Codes that remain classified as failures: `Internal`, `Unavailable`, `DataLoss`, `DeadlineExceeded`, `Cancelled`, `PermissionDenied`, `Unauthenticated`.