### PR TITLE
fix(proto): make build.rs example compile correctly

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -30,7 +30,7 @@ fn main() {
         .out_dir(dst_dir)
         .build_server(false) // this setting generates only the client side of the rpc api
         .compile_fds_with_config(prost_config, file_descriptors)
-        .context("compiling protobufs")?;
+        .expect("compiling protobufs");
 }
 ```
 


### PR DESCRIPTION
Update proto/README.md build.rs example for correct error handling

The previous build.rs example used:

- `?` in main() without returning a Result type.
- `.context(...)` without importing the Context trait.

These would cause compilation errors in a standard Rust project. 

This PR replaces `.context(...)?` with `.expect("compiling protobufs")` so that main() can remain `fn main()`. 
It makes the example consistent with typical build.rs usage and avoids compilation issues related to error handling.