### PR TITLE
fix: network transaction executor + network monitor

### DIFF
--- a/bin/network-monitor/src/assets/counter_program.masm
+++ b/bin/network-monitor/src/assets/counter_program.masm
@@ -1,6 +1,6 @@
 # Counter program for network monitoring with note authentication
 # Storage layout:
-# - OWNER_SLOT: authorized wallet account id as [prefix, suffix, 0, 0]
+# - OWNER_SLOT: authorized wallet account id as [suffix, prefix, 0, 0]
 # - COUNTER_SLOT: counter value (u64)
 
 use miden::core::sys
@@ -19,10 +19,10 @@ const OWNER_SLOT = word("miden::monitor::counter_contract::owner")
 pub proc increment
     # Ensure the note sender matches the authorized wallet.
     push.OWNER_SLOT[0..2] exec.active_account::get_item
-    # => [owner_prefix, owner_suffix, 0, 0]
+    # => [owner_suffix, owner_prefix, 0, 0]
 
     exec.active_note::get_sender
-    # => [sender_prefix, sender_suffix, owner_prefix, owner_suffix, 0, 0]
+    # => [sender_suffix, sender_prefix, owner_suffix, owner_prefix, 0, 0]
 
     exec.account_id::is_equal
     # => [are_equal, 0, 0]

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -122,7 +122,7 @@ async fn fetch_counter_value(
         .find(|slot| slot.slot_name == COUNTER_SLOT_NAME.as_str())
         .context(format!("counter slot '{}' not found", COUNTER_SLOT_NAME.as_str()))?;
 
-    // The counter value is stored as a Word, with the actual u64 value in the last element
+    // The counter value is stored as a Word, with the actual u64 value in the first element
     let slot_value: Word = counter_slot
         .commitment
         .as_ref()
@@ -130,7 +130,11 @@ async fn fetch_counter_value(
         .try_into()
         .context("failed to convert slot value to word")?;
 
-    let value = slot_value.as_elements().last().expect("Word has 4 elements").as_canonical_u64();
+    let value = slot_value
+        .as_elements()
+        .first()
+        .expect("Word has 4 elements")
+        .as_canonical_u64();
 
     Ok(Some(value))
 }

--- a/bin/network-monitor/src/deploy/counter.rs
+++ b/bin/network-monitor/src/deploy/counter.rs
@@ -46,7 +46,7 @@ pub fn create_counter_account(owner_account_id: AccountId) -> Result<Account> {
 
     let owner_id_slot = StorageSlot::with_value(
         OWNER_SLOT_NAME.clone(),
-        Word::from([Felt::ZERO, Felt::ZERO, owner_account_id_suffix, owner_account_id_prefix]),
+        Word::from([owner_account_id_suffix, owner_account_id_prefix, Felt::ZERO, Felt::ZERO]),
     );
 
     let counter_slot = StorageSlot::with_value(COUNTER_SLOT_NAME.clone(), Word::empty());

--- a/bin/network-monitor/src/deploy/mod.rs
+++ b/bin/network-monitor/src/deploy/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use miden_node_proto::clients::{Builder, RpcClient};
 use miden_node_proto::generated::rpc::BlockHeaderByNumberRequest;
 use miden_node_proto::generated::transaction::ProvenTransaction;
-use miden_protocol::account::{Account, AccountId, PartialAccount, PartialStorage, StorageMapKey};
+use miden_protocol::account::{Account, AccountId, PartialAccount, StorageMapKey};
 use miden_protocol::assembly::{
     DefaultSourceManager,
     Library,
@@ -19,7 +19,7 @@ use miden_protocol::assembly::{
     ModuleKind,
     Path as MidenPath,
 };
-use miden_protocol::asset::{AssetVaultKey, AssetWitness, PartialVault};
+use miden_protocol::asset::{AssetVaultKey, AssetWitness};
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::crypto::merkle::mmr::{MmrPeaks, PartialMmr};
 use miden_protocol::note::NoteScript;
@@ -288,18 +288,8 @@ impl DataStore for MonitorDataStore {
         account_id: AccountId,
         mut _block_refs: BTreeSet<BlockNumber>,
     ) -> Result<(PartialAccount, BlockHeader, PartialBlockchain), DataStoreError> {
-        let account = self.get_account(account_id)?.clone();
-        let partial_storage = PartialStorage::new_full(account.storage().clone());
-        let assert_vault = PartialVault::new_full(account.vault().clone());
-        let partial_account = PartialAccount::new(
-            account_id,
-            account.nonce(),
-            account.code().clone(),
-            partial_storage,
-            assert_vault,
-            account.seed(),
-        )
-        .expect("Partial account be valid");
+        let account = self.get_account(account_id)?;
+        let partial_account = PartialAccount::from(account);
 
         Ok((partial_account, self.block_header.clone(), self.partial_block_chain.clone()))
     }

--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -138,9 +138,14 @@ impl NtxContext {
         &self,
         data_store: &'a NtxDataStore,
     ) -> TransactionExecutor<'a, 'b, NtxDataStore, UnreachableAuth> {
-        let exec_options =
-            ExecutionOptions::new(Some(self.max_cycles), self.max_cycles, 0, false, false)
-                .expect("max_cycles should be within valid range");
+        let exec_options = ExecutionOptions::new(
+            Some(self.max_cycles),
+            self.max_cycles,
+            ExecutionOptions::DEFAULT_CORE_TRACE_FRAGMENT_SIZE,
+            false,
+            false,
+        )
+        .expect("max_cycles should be within valid range");
 
         TransactionExecutor::new(data_store)
             .with_options(exec_options)


### PR DESCRIPTION
This PR contains 2 fixes:

- on the NTX builder, creates the executor with a valid core trace fragment size
- updates the monitor code for the new Word stack orientation changes in the new VM revision

Found while running client integration tests:
```
thread 'tokio-rt-worker' (15182569) panicked at .cargo/git/checkouts/miden-node-98c06b5d084e5405/b59b408/crates/ntx-builder/src/actor/execute.rs:143:18:
max_cycles should be within valid range: CoreTraceFragmentSizeTooSmall
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```