### PR TITLE
revert: remove stress-test seeding offset changes

### DIFF
--- a/bin/stress-test/src/seeding/mod.rs
+++ b/bin/stress-test/src/seeding/mod.rs
@@ -54,8 +54,7 @@ use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::faucets::BasicFungibleFaucet;
 use miden_standards::account::wallets::BasicWallet;
 use miden_standards::note::P2idNote;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::prelude::ParallelSlice;
 use tokio::io::AsyncWriteExt;
@@ -177,27 +176,23 @@ async fn generate_blocks(
         let mut block_txs = Vec::with_capacity(BATCHES_PER_BLOCK * TRANSACTIONS_PER_BATCH);
 
         // create public accounts and notes that mint assets for these accounts
-        // Use separate index offsets for public and private accounts to avoid ID prefix
-        // collisions (different storage modes can produce the same prefix in v0.14).
-        let pub_offset = i * (num_public_accounts + num_private_accounts);
         let (pub_accounts, pub_notes) = create_accounts_and_notes(
             num_public_accounts,
             AccountStorageMode::Public,
             &key_pair,
             &rng,
             faucet.id(),
-            pub_offset,
+            i,
         );
 
         // create private accounts and notes that mint assets for these accounts
-        let priv_offset = pub_offset + num_public_accounts;
         let (priv_accounts, priv_notes) = create_accounts_and_notes(
             num_private_accounts,
             AccountStorageMode::Private,
             &key_pair,
             &rng,
             faucet.id(),
-            priv_offset,
+            i,
         );
 
         let notes = [pub_notes, priv_notes].concat();
@@ -296,14 +291,14 @@ fn create_accounts_and_notes(
     key_pair: &SecretKey,
     rng: &Arc<Mutex<RandomCoin>>,
     faucet_id: AccountId,
-    index_offset: usize,
+    block_num: usize,
 ) -> (Vec<Account>, Vec<Note>) {
     (0..num_accounts)
         .into_par_iter()
         .map(|account_index| {
             let account = create_account(
                 key_pair.public_key(),
-                (index_offset + account_index) as u64,
+                ((block_num * num_accounts) + account_index) as u64,
                 storage_mode,
             );
             let note = {
@@ -330,13 +325,11 @@ fn create_note(faucet_id: AccountId, target_id: AccountId, rng: &mut RandomCoin)
     .expect("note creation failed")
 }
 
-/// Creates a new account with a given public key. Uses a seeded PRNG derived from the index to
-/// generate a high-entropy init seed, avoiding `AccountId` prefix collisions that can occur with
-/// low-entropy seeds.
+/// Creates a new private account with a given public key and anchor block. Generates the seed from
+/// the given index.
 fn create_account(public_key: PublicKey, index: u64, storage_mode: AccountStorageMode) -> Account {
-    let mut rng = StdRng::seed_from_u64(index);
-    let init_seed: [u8; 32] = rng.random();
-    AccountBuilder::new(init_seed)
+    let init_seed: Vec<_> = index.to_be_bytes().into_iter().chain([0u8; 24]).collect();
+    AccountBuilder::new(init_seed.try_into().unwrap())
         .account_type(AccountType::RegularAccountImmutableCode)
         .storage_mode(storage_mode)
         .with_auth_component(AuthSingleSig::new(public_key.into(), AuthScheme::Falcon512Poseidon2))


### PR DESCRIPTION
## Summary

- Reverts the index offset separation (`pub_offset`/`priv_offset`) and high-entropy `StdRng`-based seed generation in the stress test seeding
- Returns to the original simpler `block_num * num_accounts + account_index` indexing and `index.to_be_bytes()` seed generation

These changes were introduced to avoid account ID prefix collisions, but the stress test passes without them (verified locally with `seed-store --num-accounts 500 --public-accounts-percentage 50`).

## Test plan

- [x] Stress test `seed-store` passes locally without these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)