### PR TITLE
feat: display monitor information in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added KMS signing support in validator ([#1677](https://github.com/0xMiden/node/pull/1677)).
 - Added per-IP gRPC rate limiting across services as well as global concurrent connection limit ([#1746](https://github.com/0xMiden/node/issues/1746)).
 - Added limit to execution cycles for a transaction network, configurable through CLI args (`--ntx-builder.max-tx-cycles`) ([#1801](https://github.com/0xMiden/node/issues/1801)).
+- Added monitor version and network name to the network monitor dashboard, network name is configurable via `--network-name` / `MIDEN_MONITOR_NETWORK_NAME` ([#1838](https://github.com/0xMiden/node/pull/1838)).
 
 ### Changes
 

--- a/bin/network-monitor/.env
+++ b/bin/network-monitor/.env
@@ -1,3 +1,5 @@
+# network identity
+MIDEN_MONITOR_NETWORK_NAME=Devnet
 # service configs
 MIDEN_MONITOR_PORT=3001
 MIDEN_MONITOR_ENABLE_OTEL=true

--- a/bin/network-monitor/README.md
+++ b/bin/network-monitor/README.md
@@ -27,6 +27,7 @@ miden-network-monitor start --faucet-url http://localhost:8080 --enable-otel
 ```
 
 **Available Options:**
+- `--network-name`: Display name of the network shown on the dashboard (default: `Localhost`)
 - `--rpc-url`: RPC service URL (default: `http://localhost:50051`)
 - `--remote-prover-urls`: Comma-separated list of remote prover URLs. If omitted or empty, prover tasks are disabled.
 - `--faucet-url`: Faucet service URL for testing. If omitted, faucet testing is disabled.
@@ -51,6 +52,7 @@ miden-network-monitor start --faucet-url http://localhost:8080 --enable-otel
 
 If command-line arguments are not provided, the application falls back to environment variables:
 
+- `MIDEN_MONITOR_NETWORK_NAME`: Display name of the network shown on the dashboard (default: `Localhost`)
 - `MIDEN_MONITOR_RPC_URL`: RPC service URL
 - `MIDEN_MONITOR_REMOTE_PROVER_URLS`: Comma-separated list of remote prover URLs. If unset or empty, prover tasks are disabled.
 - `MIDEN_MONITOR_FAUCET_URL`: Faucet service URL for testing. If unset, faucet testing is disabled.
@@ -218,6 +220,7 @@ The monitor application provides real-time status monitoring for the following M
 
 The web dashboard provides a clean, responsive interface with the following features:
 
+- **Network Identity**: Displays the configured network name (e.g., "Testnet", "Devnet") above the dashboard title and the monitor version in the footer
 - **Real-time Updates**: Automatically refreshes service status every 10 seconds
 - **Unified Service Cards**: Each service is displayed in a dedicated card that auto-sizes to show all information
 - **Combined Prover Information**: Remote prover cards integrate both connectivity status and proof generation test results

--- a/bin/network-monitor/assets/index.css
+++ b/bin/network-monitor/assets/index.css
@@ -52,6 +52,7 @@ body {
     color: #ff5500;
 }
 
+
 .main-content {
     width: 100%;
     max-width: 1200px;
@@ -167,6 +168,10 @@ body {
     color: rgba(0, 0, 0, 0.4);
     font-weight: 400;
     font-size: 12px;
+}
+
+.footer-center {
+    text-align: center;
 }
 
 .tokens-section {

--- a/bin/network-monitor/assets/index.html
+++ b/bin/network-monitor/assets/index.html
@@ -12,7 +12,7 @@
         <div class="header">
             <div class="logo">
                 <div class="logo-icon"></div>
-                <div class="logo-text">Miden <span class="highlight">Network</span></div>
+                <div class="logo-text">Miden <span class="highlight" id="network-name">Localhost</span></div>
             </div>
         </div>
 
@@ -36,6 +36,9 @@
             <div class="footer-section">
                 <div class="footer-label">Network Status</div>
                 <div class="footer-value" id="overall-status">Checking...</div>
+            </div>
+            <div class="footer-section footer-center">
+                <div class="footer-value" id="monitor-version"></div>
             </div>
             <div class="footer-section tokens-section">
                 <div class="footer-label">Services</div>

--- a/bin/network-monitor/assets/index.js
+++ b/bin/network-monitor/assets/index.js
@@ -377,6 +377,15 @@ function updateDisplay() {
     overallStatus.style.color = allHealthy ? '#22C55D' : '#ff5500';
     servicesCount.textContent = `${totalServices} Services`;
 
+    // Update network name in logo
+    document.getElementById('network-name').textContent = statusData.network_name;
+
+    // Update monitor version
+    const versionEl = document.getElementById('monitor-version');
+    if (statusData.monitor_version) {
+        versionEl.textContent = 'Monitor v' + statusData.monitor_version;
+    }
+
     // Generate status cards
     const serviceCardsHtml = processedServices.map(service => {
         const isHealthy = service.status === 'Healthy';

--- a/bin/network-monitor/src/commands/start.rs
+++ b/bin/network-monitor/src/commands/start.rs
@@ -93,6 +93,8 @@ pub async fn start_monitor(config: MonitorConfig) -> Result<()> {
         ntx_tracking: ntx_tracking_rx,
         explorer: explorer_rx,
         note_transport: note_transport_rx,
+        monitor_version: env!("CARGO_PKG_VERSION").to_string(),
+        network_name: config.network_name.clone(),
     };
     tasks.spawn_http_server(server_state, &config);
 

--- a/bin/network-monitor/src/config.rs
+++ b/bin/network-monitor/src/config.rs
@@ -29,6 +29,15 @@ pub struct MonitorConfig {
     )]
     pub rpc_url: Url,
 
+    /// The display name of the network (e.g., "Testnet", "Devnet").
+    #[arg(
+        long = "network-name",
+        env = "MIDEN_MONITOR_NETWORK_NAME",
+        default_value = "Localhost",
+        help = "The display name of the network (e.g., Testnet, Devnet)"
+    )]
+    pub network_name: String,
+
     /// The URLs of the remote provers for status checking (comma-separated).
     #[arg(
         long = "remote-prover-urls",

--- a/bin/network-monitor/src/frontend.rs
+++ b/bin/network-monitor/src/frontend.rs
@@ -27,6 +27,8 @@ pub struct ServerState {
     pub ntx_tracking: Option<watch::Receiver<ServiceStatus>>,
     pub explorer: Option<watch::Receiver<ServiceStatus>>,
     pub note_transport: Option<watch::Receiver<ServiceStatus>>,
+    pub monitor_version: String,
+    pub network_name: String,
 }
 
 /// Runs the frontend server.
@@ -109,7 +111,12 @@ async fn get_status(
         services.push(note_transport_rx.borrow().clone());
     }
 
-    let network_status = NetworkStatus { services, last_updated: current_time };
+    let network_status = NetworkStatus {
+        services,
+        last_updated: current_time,
+        monitor_version: server_state.monitor_version.clone(),
+        network_name: server_state.network_name.clone(),
+    };
 
     axum::response::Json(network_status)
 }

--- a/bin/network-monitor/src/status.rs
+++ b/bin/network-monitor/src/status.rs
@@ -271,6 +271,8 @@ pub struct WorkerStatusDetails {
 pub struct NetworkStatus {
     pub services: Vec<ServiceStatus>,
     pub last_updated: u64,
+    pub monitor_version: String,
+    pub network_name: String,
 }
 
 // FROM IMPLEMENTATIONS


### PR DESCRIPTION
closes https://github.com/0xMiden/node/issues/1813

- Displays the monitor version in the footer.
- Add a network name to be displayed in the title.

<img width="1624" height="1006" alt="Image" src="https://github.com/user-attachments/assets/56669556-9354-4d42-b4d3-f94f6d89c421" />