### PR TITLE
chore: v0.13.9 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
+## v0.13.9 (2026-03-26)
+
+- Network transaction actors now share the same gRPC clients, limiting the number of file descriptors being used ([#1808](https://github.com/0xMiden/node/issues/1808)).
+
 ## v0.13.8 (2026-03-12)
 
 - Private notes with the network note attachment are no longer incorrectly considered as network notes (#[#1736](https://github.com/0xMiden/node/pull/1736)).
 - Fixed network monitor looping on stale wallet nonce after node restarts by re-syncing wallet state from RPC after repeated failures ([#1748](https://github.com/0xMiden/node/pull/1748)).
 - Added verbose `info!`-level logging to the network transaction builder for transaction execution, note filtering failures, and transaction outcomes ([#1770](https://github.com/0xMiden/node/pull/1770)).
-- Network transaction actors now share the same gRPC clients, limiting the number of file descriptors being used ([#1808](https://github.com/0xMiden/node/issues/1808)).
 
 ## v0.13.7 (2026-02-25)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "futures",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "fs-err",
  "miette",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "futures",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "clap 4.5.54",
  "fs-err",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "fs-err",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.90"
-version      = "0.13.8"
+version      = "0.13.9"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/crates/ntx-builder/src/actor/account_state.rs
+++ b/crates/ntx-builder/src/actor/account_state.rs
@@ -158,7 +158,7 @@ impl NetworkAccountState {
     }
 
     /// Updates state with the mempool event.
-    #[instrument(target = COMPONENT, name = "ntx.state.mempool_update", skip_all)]
+    #[instrument(target = COMPONENT, name = "ntx.state.mempool_update", skip_all, level = "debug")]
     pub fn mempool_update(&mut self, update: &MempoolEvent) -> Option<ActorShutdownReason> {
         let span = tracing::Span::current();
         span.set_attribute("mempool_event.kind", update.kind());

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -18,12 +18,20 @@ pub fn grpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
 
     // Create a span with a generic, static name. Fields to be recorded after needs to be
     // initialized as empty since otherwise the assignment will have no effect.
-    let span = tracing::info_span!(
-        "rpc",
-        otel.name = field::Empty,
-        rpc.service = service,
-        rpc.method = method
-    );
+    let span = match method {
+        "SyncState" | "SyncNullifiers" => tracing::debug_span!(
+            "rpc",
+            otel.name = field::Empty,
+            rpc.service = service,
+            rpc.method = method
+        ),
+        _ => tracing::info_span!(
+            "rpc",
+            otel.name = field::Empty,
+            rpc.service = service,
+            rpc.method = method
+        ),
+    };
 
     // Set the span name via otel.name
     let otel_name = format!("{service}/{method}");


### PR DESCRIPTION
Version v0.13.9 release for the gRPC client re-use bug fix.

This _also_ includes dropping noisy traces down to `debug`:

- mempool event handler
- `SyncState`
- `SyncNullifiers`

The last two we would ideally keep, but we're really over budget at the moment. We can come up with something more ideal in v0.14.