### PR TITLE
fix: explorer field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.14.6 (2026-04-10)
+
+- Fixed network monitor explorer health check failing to parse string-encoded numeric fields from the Explorer GraphQL API ([#1922](https://github.com/0xMiden/node/pull/1922)).
+
 ## v0.14.5 (2026-04-10)
 
 - Removed `issuance` field from the network monitor's faucet `GetMetadataResponse` ([#1918](https://github.com/0xMiden/node/pull/1918)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "miden-genesis"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "deadpool",
  "deadpool-diesel",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3311,11 +3311,11 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.14.5"
+version = "0.14.6"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "futures",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "clap",
  "fs-err",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "build-rs",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.93"
-version      = "0.14.5"
+version      = "0.14.6"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/bin/network-monitor/src/explorer.rs
+++ b/bin/network-monitor/src/explorer.rs
@@ -131,15 +131,23 @@ pub(crate) async fn check_explorer_status(
         .send()
         .await;
 
-    let value = match resp {
-        Ok(resp) => resp.json::<serde_json::Value>().await,
+    let body = match resp {
+        Ok(resp) => match resp.text().await {
+            Ok(body) => body,
+            Err(e) => return unhealthy(&name, current_time, &e),
+        },
         Err(e) => return unhealthy(&name, current_time, &e),
     };
 
-    let details = match value {
-        Ok(value) => ExplorerStatusDetails::try_from(value),
-        Err(e) => return unhealthy(&name, current_time, &e),
+    let value: serde_json::Value = match serde_json::from_str(&body) {
+        Ok(value) => value,
+        Err(e) => {
+            let msg = format!("{e}: {body}");
+            return unhealthy(&name, current_time, &msg);
+        },
     };
+
+    let details = ExplorerStatusDetails::try_from(value);
 
     match details {
         Ok(details) => ServiceStatus {
@@ -177,6 +185,12 @@ impl Display for ExplorerStatusError {
     }
 }
 
+/// Extracts a u64 from a JSON value that may be either a number or a
+/// string-encoded number (as returned by the Explorer's GraphQL API).
+fn value_as_u64(value: &serde_json::Value) -> Option<u64> {
+    value.as_u64().or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+}
+
 impl TryFrom<serde_json::Value> for ExplorerStatusDetails {
     type Error = ExplorerStatusError;
 
@@ -187,31 +201,27 @@ impl TryFrom<serde_json::Value> for ExplorerStatusDetails {
 
         let block_number = node
             .get("block_number")
-            .and_then(serde_json::Value::as_u64)
+            .and_then(value_as_u64)
             .ok_or_else(|| ExplorerStatusError::MissingField("block_number".to_string()))?;
         let timestamp = node
             .get("timestamp")
-            .and_then(serde_json::Value::as_u64)
+            .and_then(value_as_u64)
             .ok_or_else(|| ExplorerStatusError::MissingField("timestamp".to_string()))?;
 
-        let number_of_transactions = node
-            .get("number_of_transactions")
-            .and_then(serde_json::Value::as_u64)
-            .ok_or_else(|| {
+        let number_of_transactions =
+            node.get("number_of_transactions").and_then(value_as_u64).ok_or_else(|| {
                 ExplorerStatusError::MissingField("number_of_transactions".to_string())
             })?;
         let number_of_nullifiers = node
             .get("number_of_nullifiers")
-            .and_then(serde_json::Value::as_u64)
+            .and_then(value_as_u64)
             .ok_or_else(|| ExplorerStatusError::MissingField("number_of_nullifiers".to_string()))?;
         let number_of_notes = node
             .get("number_of_notes")
-            .and_then(serde_json::Value::as_u64)
+            .and_then(value_as_u64)
             .ok_or_else(|| ExplorerStatusError::MissingField("number_of_notes".to_string()))?;
-        let number_of_account_updates = node
-            .get("number_of_account_updates")
-            .and_then(serde_json::Value::as_u64)
-            .ok_or_else(|| {
+        let number_of_account_updates =
+            node.get("number_of_account_updates").and_then(value_as_u64).ok_or_else(|| {
                 ExplorerStatusError::MissingField("number_of_account_updates".to_string())
             })?;
 


### PR DESCRIPTION
Looks like the Explorer's GraphQL API changed and now returns some numeric fields as JSON strings instead of numbers:

{"block_number": "30629", "timestamp": "1775830836", "number_of_transactions": "1", ...}

The monitor code used `serde_json::Value::as_u64()` to extract these, which only works for actual JSON numbers. So it returned None for every block, and the health check always failed.

<img width="1624" height="1006" alt="Screenshot 2026-04-10 at 11 35 12" src="https://github.com/user-attachments/assets/d82afc3f-f5d6-4831-a568-e19fa441cfdf" />
