### PR TITLE
fix(store): bump SQLite connection pool size to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.13.13 (2026-04-13)
+
+- Increase SQLite connection pool size to 128.
+
 ## v0.13.12 (2026-04-10)
 
 - Improved `GetAccount` instrumentation ([#1916](https://github.com/0xMiden/node/issues/1916)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "clap 4.5.54",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "futures",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "fs-err",
  "miette",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "futures",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "clap 4.5.54",
  "fs-err",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "fs-err",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.90"
-version      = "0.13.12"
+version      = "0.13.13"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -318,7 +318,7 @@ impl Db {
     #[instrument(target = COMPONENT, skip_all)]
     pub async fn load(database_filepath: PathBuf) -> Result<Self, DatabaseSetupError> {
         let manager = ConnectionManager::new(database_filepath.to_str().unwrap());
-        let pool = deadpool_diesel::Pool::builder(manager).max_size(16).build()?;
+        let pool = deadpool_diesel::Pool::builder(manager).max_size(128).build()?;
 
         info!(
             target: COMPONENT,


### PR DESCRIPTION
We allow up to 1k concurrent RPC requests, and each request may require a connection to the database. The default SQLite connection pool size is 16, which is too small for our use case and can lead to timeouts when the pool is exhausted. By increasing the pool size to 128, we can better accommodate concurrent requests and reduce the likelihood of timeouts.